### PR TITLE
Fix: Hidden tooltip in collapsed sidebar

### DIFF
--- a/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
@@ -1,13 +1,15 @@
 <template>
   <li class="oc-sidebar-nav-item oc-pb-xs oc-px-s" :aria-current="active ? 'page' : null">
     <oc-button
-      v-oc-tooltip="toolTip"
       :type="handler ? 'button' : 'router-link'"
       appearance="raw"
       :variation="active ? 'primary' : 'passive'"
       :class="['oc-sidebar-nav-item-link', 'oc-oc-width-1-1', { active: active }]"
       :data-nav-id="index"
       :data-nav-name="navName"
+      :aria-label="
+        collapsed ? $gettext('Navigate to %{ pageName } page', { pageName: name }) : undefined
+      "
       v-bind="attrs"
     >
       <span class="oc-flex">
@@ -18,7 +20,8 @@
   </li>
 </template>
 <script lang="ts">
-import { computed, defineComponent, PropType } from 'vue'
+import { useRouter } from '@opencloud-eu/web-pkg'
+import { computed, defineComponent, PropType, unref } from 'vue'
 import { RouteLocationRaw } from 'vue-router'
 
 export default defineComponent({
@@ -62,6 +65,8 @@ export default defineComponent({
     }
   },
   setup(props) {
+    const router = useRouter()
+
     const attrs = computed(() => {
       return {
         ...(props.handler && { onClick: props.handler }),
@@ -69,27 +74,14 @@ export default defineComponent({
       }
     })
 
-    return { attrs }
-  },
-  computed: {
-    navName() {
-      if (this.target) {
-        return this.$router?.resolve(this.target, this.$route)?.name || 'route.name'
+    const navName = computed(() => {
+      if (props.target) {
+        return router?.resolve(props.target, unref(router.currentRoute))?.name || 'route.name'
       }
-      return this.name
-    },
-    toolTip() {
-      const value = this.collapsed
-        ? this.$gettext('Navigate to %{ pageName } page', {
-            pageName: this.name
-          })
-        : ''
-      return {
-        content: value,
-        placement: 'right',
-        arrow: false
-      }
-    }
+      return props.name
+    })
+
+    return { attrs, navName }
   }
 })
 </script>


### PR DESCRIPTION
Removes the tooltip in the collapsed sidebar as it was almost completely hidden, leading to a visual glitch on hover. Replaces it with a proper `aria-label` to make it a11y conform.

Before:

<img width="84" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/1eeea4e3-b8b9-4c6d-a5fa-7c34e5713296" />

After:

<img width="69" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/6e4dbb26-3be6-432a-a446-9ccf907f2672" />
