### PR TITLE
chore(design-system): initialize gettext for docs

### DIFF
--- a/packages/design-system/docs/.vitepress/theme/index.ts
+++ b/packages/design-system/docs/.vitepress/theme/index.ts
@@ -1,4 +1,5 @@
 import DefaultTheme from 'vitepress/theme-without-fonts'
+import { createGettext } from 'vue3-gettext'
 import * as components from './../../../src/components'
 import * as directives from './../../../src/directives'
 import './custom.scss'
@@ -6,7 +7,8 @@ import './custom.scss'
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
-    import('./../../../src/utils/webFontLoader')
+    const gettext = createGettext()
+    app.use(gettext)
 
     // TODO: remove `|| c.name` when all components follow the script setup syntax
     Object.values(components).forEach((c) => app.component(c.__name || c.name, c))


### PR DESCRIPTION
This is necessary to document all components that use `vue3-gettext`.