### PR TITLE
feat(runtime): rework app tokens

### DIFF
--- a/packages/web-runtime/src/components/Modals/AppTokenModal.vue
+++ b/packages/web-runtime/src/components/Modals/AppTokenModal.vue
@@ -1,0 +1,113 @@
+<template>
+  <div v-if="!createdToken">
+    <oc-datepicker
+      :label="$gettext('Expiration date')"
+      type="date"
+      :min-date="minDate"
+      @date-changed="onDateChanged"
+    />
+    <div class="link-modal-actions oc-flex oc-flex-right oc-flex-middle oc-mt-s">
+      <oc-button
+        class="oc-modal-body-actions-cancel oc-ml-s"
+        appearance="outline"
+        variation="passive"
+        @click="$emit('cancel')"
+        >{{ $gettext('Cancel') }}
+      </oc-button>
+      <oc-button
+        :disabled="confirmDisabled"
+        class="oc-modal-body-actions-confirm oc-ml-s"
+        appearance="filled"
+        variation="primary"
+        @click="createAppToken"
+        >{{ $gettext('Confirm') }}
+      </oc-button>
+    </div>
+  </div>
+  <div v-else>
+    <span
+      v-text="
+        $gettext(
+          'Your app token has been successfully created. This is the only time it will be displayed, so please make sure to copy it now.'
+        )
+      "
+    />
+    <div class="oc-mt-m oc-mb-s oc-flex oc-flex-middle oc-rounded">
+      <div class="created-token-container oc-pr-m">
+        <span class="created-token" v-text="createdToken" />
+        <div class="oc-text-small">
+          <span v-text="$gettext('Expires on:')" />
+          <span v-text="formatDateFromDateTime(expiryDate, currentLanguage)" />
+        </div>
+      </div>
+      <oc-button
+        v-oc-tooltip="$gettext('Copy app token to clipboard')"
+        appearance="raw"
+        class="copy-app-token-btn oc-pl-s"
+        :aria-label="$gettext('Copy app token to clipboard')"
+        @click="copy(createdToken)"
+      >
+        <oc-icon
+          :name="copied ? 'check' : 'file-copy'"
+          :variation="copied ? 'success' : 'passive'"
+          fill-type="line"
+        />
+      </oc-button>
+    </div>
+    <div class="link-modal-actions oc-flex oc-flex-right oc-flex-middle oc-mt-s">
+      <oc-button
+        class="oc-modal-body-actions-confirm oc-ml-s"
+        appearance="filled"
+        variation="secondary"
+        @click="$emit('confirm')"
+        >{{ $gettext('Close') }}
+      </oc-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, unref } from 'vue'
+import { DateTime } from 'luxon'
+import { formatDateFromDateTime, Modal, useClientService } from '@opencloud-eu/web-pkg'
+import { useGettext } from 'vue3-gettext'
+import { useClipboard } from '@vueuse/core'
+import { AppToken } from '../../helpers/appTokens'
+
+defineProps<{ modal: Modal }>()
+defineEmits(['confirm', 'cancel'])
+
+const { $gettext, current: currentLanguage } = useGettext()
+const { httpAuthenticated: client } = useClientService()
+const { copy, copied } = useClipboard({ legacy: true, copiedDuring: 2000 })
+
+const expiryDate = ref<DateTime>()
+const confirmDisabled = ref(true)
+const createdToken = ref('')
+
+const minDate = computed(() => DateTime.now())
+
+const onDateChanged = ({ date, error }: { date: DateTime; error: boolean }) => {
+  confirmDisabled.value = error || !date
+  expiryDate.value = date
+}
+
+const createAppToken = async () => {
+  try {
+    const expiry = `${unref(expiryDate).diff(DateTime.now(), 'hours').hours}h`
+    const { data } = await client.post<AppToken>('/auth-app/tokens', null, { params: { expiry } })
+    createdToken.value = data.token
+  } catch (error) {
+    console.error(error)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.created-token {
+  font-weight: bold;
+  &-container {
+    border-right: 1px solid var(--oc-color-border);
+  }
+}
+</style>

--- a/packages/web-runtime/src/helpers/appTokens.ts
+++ b/packages/web-runtime/src/helpers/appTokens.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+const AppTokenSchema = z.object({
+  token: z.string(),
+  expiration_date: z.string(),
+  created_date: z.string(),
+  label: z.string().optional()
+})
+
+export const AppTokenListSchema = z.array(AppTokenSchema)
+export type AppToken = z.infer<typeof AppTokenSchema>

--- a/packages/web-runtime/tests/unit/components/Account/AppTokens.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Account/AppTokens.spec.ts
@@ -8,7 +8,8 @@ import {
 import { ClientService, useModals } from '@opencloud-eu/web-pkg'
 import { flushPromises } from '@vue/test-utils'
 import { OcTable } from '@opencloud-eu/design-system/components'
-import AppTokens, { AppToken } from '../../../../src/components/Account/AppTokens.vue'
+import AppTokens from '../../../../src/components/Account/AppTokens.vue'
+import { AppToken } from '../../../../src/helpers/appTokens'
 
 const selectors = {
   createAppTokenBtn: '.create-app-token-btn',

--- a/packages/web-runtime/tests/unit/components/Modals/AppTokenModal.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Modals/AppTokenModal.spec.ts
@@ -1,0 +1,87 @@
+import AppTokenModal from '../../../../src/components/Modals/AppTokenModal.vue'
+import {
+  defaultComponentMocks,
+  defaultPlugins,
+  mockAxiosResolve,
+  shallowMount
+} from '@opencloud-eu/web-test-helpers'
+import { mockDeep } from 'vitest-mock-extended'
+import { ClientService } from '@opencloud-eu/web-pkg'
+import { OcButton, OcDatepicker } from '@opencloud-eu/design-system/components'
+import { DateTime } from 'luxon'
+
+const copyMock = vi.fn()
+vi.mock('@vueuse/core', () => ({
+  useClipboard: vi.fn(() => ({ copy: copyMock, copied: false }))
+}))
+
+describe('AppTokenModal component', () => {
+  it('should display an input for the expiration date', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.find('oc-datepicker-stub').exists()).toBeTruthy()
+  })
+  describe('confirm button', () => {
+    it('should be disabled when no date has been entered', () => {
+      const { wrapper } = getWrapper()
+      const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
+      expect(btn.props('disabled')).toBeTruthy()
+    })
+    it('should not be disabled when a date has been entered', async () => {
+      const { wrapper } = getWrapper()
+      wrapper
+        .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
+        .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+      const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
+      await wrapper.vm.$nextTick()
+      expect(btn.props('disabled')).toBeFalsy()
+    })
+    it('should create a token on submit', async () => {
+      const { wrapper, mocks } = getWrapper()
+      wrapper
+        .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
+        .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+      const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
+      await wrapper.vm.$nextTick()
+      await btn.trigger('click')
+      expect(mocks.$clientService.httpAuthenticated.post).toHaveBeenCalled()
+    })
+  })
+  it('should display the created token', async () => {
+    const { wrapper } = getWrapper()
+    wrapper
+      .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
+      .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+    const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
+    await wrapper.vm.$nextTick()
+    await btn.trigger('click')
+    expect(wrapper.find('.created-token').exists()).toBeTruthy()
+  })
+  it('the created token can be copied', async () => {
+    const { wrapper } = getWrapper()
+    wrapper
+      .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
+      .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+    const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
+    await wrapper.vm.$nextTick()
+    await btn.trigger('click')
+    await wrapper.find('.copy-app-token-btn').trigger('click')
+    expect(copyMock).toHaveBeenCalled()
+  })
+})
+
+const getWrapper = () => {
+  const clientService = mockDeep<ClientService>()
+  clientService.httpAuthenticated.post.mockResolvedValue(mockAxiosResolve({ token: 'token' }))
+  const mocks = { ...defaultComponentMocks(), $clientService: clientService }
+
+  return {
+    mocks,
+    wrapper: shallowMount(AppTokenModal, {
+      global: {
+        mocks,
+        provide: mocks,
+        plugins: [...defaultPlugins()]
+      }
+    })
+  }
+}


### PR DESCRIPTION
Reworks the app tokens so a newly created token gets only shown once to the user. The user then can copy the token.

Follow-up after https://github.com/opencloud-eu/web/pull/43

refs https://github.com/opencloud-eu/web/issues/42