### PR TITLE
chore: prepare publishing of 1.0.0 packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,5 @@
   ],
   "cucumberautocomplete.strictGherkinCompletion": true,
   "typescript.tsdk": "node_modules/typescript/lib",
-  "vue.server.includeLanguages": ["vue", "markdown"]
+  "vue.server.includeLanguages": ["vue"]
 }

--- a/dev/scripts/bump_versions.sh
+++ b/dev/scripts/bump_versions.sh
@@ -5,7 +5,7 @@
 #
 # NOTE: only run this if all packages are supposed to get the same version!
 
-apps=("design-system" "eslint-config" "extension-sdk" "web-pkg" "web-client" "web-test-helpers")
+apps=("design-system" "eslint-config" "extension-sdk" "prettier-config" "tsconfig" "web-pkg" "web-client" "web-test-helpers")
 
 NEW_VERSION="$1"
 

--- a/dev/scripts/create_and_push_tags.sh
+++ b/dev/scripts/create_and_push_tags.sh
@@ -2,13 +2,13 @@
 
 # This script creates and pushes tags for the main app and all published packages.
 
-APPS=("design-system" "eslint-config" "extension-sdk" "web-pkg" "web-client" "web-test-helpers")
+APPS=("design-system" "eslint-config" "extension-sdk" "prettier-config" "tsconfig" "web-pkg" "web-client" "web-test-helpers")
 
 cd "$(dirname "$0")/../.."
 VERSION=$(node -p "require('./package.json').version")
 TAG="v${VERSION}"
 
-git tag "$TAG"
+git tag -s -a "$TAG" -m "$TAG"
 git push origin "$TAG"
 echo "v$VERSION has been created and pushed"
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "homepage": "https://github.com/opencloud-eu/web",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "homepage": "https://github.com/opencloud-eu/web",
   "license": "AGPL-3.0",

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -1,14 +1,16 @@
 # OpenCloud Design System
 
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
 The **OpenCloud Design System** provides components and utilities for application and extension development within the
 OpenCloud Web ecosystem. It can be developed standalone via the design system documentation. The documentation is
 built with [VitePress](https://vitepress.dev/).
 
 Head over to the [hosted docs](https://design.opencloud.eu/) for more information!
 
-## Local setup
+## Running the docs locally
 
-Install all dependencies:
+To run the docs, you first need to install all dependencies:
 
 ```
 pnpm i
@@ -19,3 +21,17 @@ Start docs in dev mode:
 ```
 pnpm docs:dev
 ```
+
+## Usage as a package
+
+To use the components and utilities of the design-system in your application, you first need to install the package. Depending on your package manager, run one of the following commands:
+
+```
+$ npm install @opencloud-eu/design-system --save-dev
+
+$ pnpm add -D @opencloud-eu/design-system
+
+$ yarn add @opencloud-eu/design-system --dev
+```
+
+It's recommended to install this package as a dev dependency because it's only really needed for providing autocompletion in your IDE and unit tests. In a runtime context, the OpenCloud Web runtime provides the actual implementation.

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/design-system",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "OpenCloud Design System is used to design OpenCloud UI components",
   "keywords": [
     "vue design system",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/design-system",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenCloud Design System is used to design OpenCloud UI components",
   "keywords": [
     "vue design system",
@@ -49,23 +49,23 @@
     "linkDirectory": false,
     "exports": {
       ".": {
-        "default": "./dist/design-system.mjs",
-        "require": "./dist/design-system.js",
+        "default": "./dist/design-system.js",
+        "require": "./dist/design-system.cjs",
         "types": "./dist/src/index.d.ts"
       },
       "./components": {
-        "default": "./dist/design-system/components.mjs",
-        "require": "./dist/design-system/components.js",
+        "default": "./dist/design-system/components.js",
+        "require": "./dist/design-system/components.cjs",
         "types": "./dist/src/components/index.d.ts"
       },
       "./composables": {
-        "default": "./dist/design-system/composables.mjs",
-        "require": "./dist/design-system/composables.js",
+        "default": "./dist/design-system/composables.js",
+        "require": "./dist/design-system/composables.cjs",
         "types": "./dist/src/composables/index.d.ts"
       },
       "./helpers": {
-        "default": "./dist/design-system/helpers.mjs",
-        "require": "./dist/design-system/helpers.js",
+        "default": "./dist/design-system/helpers.js",
+        "require": "./dist/design-system/helpers.cjs",
         "types": "./dist/src/helpers/index.d.ts"
       }
     }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/design-system",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "OpenCloud Design System is used to design OpenCloud UI components",
   "keywords": [
     "vue design system",

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -2,7 +2,7 @@ import { resolve } from 'path'
 import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import dts from 'vite-plugin-dts'
 import vue from '@vitejs/plugin-vue'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json'
 
 const projectRootDir = searchForWorkspaceRoot(process.cwd())
 

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -15,3 +15,13 @@ $ pnpm add -D @opencloud-eu/eslint-config
 
 $ yarn add @opencloud-eu/eslint-config --dev
 ```
+
+## Usage
+
+To extend your eslint config with the OpenCloud eslint config, add the following to your `.eslint.config.js` file:
+
+```js
+import openCloudConfig from '@opencloud-eu/eslint-config'
+
+export default [...openCloudConfig]
+```

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,0 +1,17 @@
+# OpenCloud eslint-config
+
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
+This package provides a reusable eslint config for application and extension development within the OpenCloud Web ecosystem.
+
+## Installation
+
+Depending on your package manager, run one of the following commands:
+
+```
+$ npm install @opencloud-eu/eslint-config --save-dev
+
+$ pnpm add -D @opencloud-eu/eslint-config
+
+$ yarn add @opencloud-eu/eslint-config --dev
+```

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,7 +2,7 @@
   "name": "@opencloud-eu/eslint-config",
   "main": "index.js",
   "private": false,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "AGPL-3.0",
   "type": "module",
   "author": "OpenCloud GmbH <info@opencloud.eu>",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,7 +2,7 @@
   "name": "@opencloud-eu/eslint-config",
   "main": "index.js",
   "private": false,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "AGPL-3.0",
   "type": "module",
   "author": "OpenCloud GmbH <info@opencloud.eu>",

--- a/packages/extension-sdk/README.md
+++ b/packages/extension-sdk/README.md
@@ -1,0 +1,17 @@
+# OpenCloud extension-sdk
+
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
+This package provides a default vite config that can be used when developing applications and extensions for the OpenCloud Web ecosystem.
+
+## Installation
+
+Depending on your package manager, run one of the following commands:
+
+```
+$ npm install @opencloud-eu/extension-sdk --save-dev
+
+$ pnpm add -D @opencloud-eu/extension-sdk
+
+$ yarn add @opencloud-eu/extension-sdk --dev
+```

--- a/packages/extension-sdk/README.md
+++ b/packages/extension-sdk/README.md
@@ -15,3 +15,25 @@ $ pnpm add -D @opencloud-eu/extension-sdk
 
 $ yarn add @opencloud-eu/extension-sdk --dev
 ```
+
+## Usage
+
+You can use the OpenCloud vite config via the `defineConfig` method provided by this package. The following example showcases how your `vite.config.ts` file could look like:
+
+```ts
+import { defineConfig } from '@opencloud-eu/extension-sdk'
+
+export default defineConfig({
+  name: 'your-app',
+  server: {
+    port: 9700
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'your-app.js'
+      }
+    }
+  }
+})
+```

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/extension-sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "OpenCloud Web Extension SDK",
   "license": "AGPL-3.0",
   "main": "index.mjs",

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/extension-sdk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "OpenCloud Web Extension SDK",
   "license": "AGPL-3.0",
   "main": "index.mjs",

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -15,3 +15,11 @@ $ pnpm add -D @opencloud-eu/prettier-config
 
 $ yarn add @opencloud-eu/prettier-config --dev
 ```
+
+## Usage
+
+To extend your prettier config with the OpenCloud prettier config, add the following to your `.prettierrc.json` file:
+
+```json
+"@opencloud-eu/prettier-config"
+```

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,0 +1,17 @@
+# OpenCloud prettier-config
+
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
+This package provides a reusable prettier config for application and extension development within the OpenCloud Web ecosystem.
+
+## Installation
+
+Depending on your package manager, run one of the following commands:
+
+```
+$ npm install @opencloud-eu/prettier-config --save-dev
+
+$ pnpm add -D @opencloud-eu/prettier-config
+
+$ yarn add @opencloud-eu/prettier-config --dev
+```

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencloud-eu/prettier-config",
   "private": false,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "index.js",
   "license": "AGPL-3.0",
   "author": "OpenCloud GmbH <info@opencloud.eu>",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencloud-eu/prettier-config",
   "private": false,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "index.js",
   "license": "AGPL-3.0",
   "author": "OpenCloud GmbH <info@opencloud.eu>",

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -15,3 +15,13 @@ $ pnpm add -D @opencloud-eu/ts-config
 
 $ yarn add @opencloud-eu/ts-config --dev
 ```
+
+## Usage
+
+To extend your TypeScript config with the OpenCloud TypeScript config, add the following to your `tsconfig.json` file:
+
+```json
+{
+  "extends": "@opencloud-eu/tsconfig"
+}
+```

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,17 @@
+# OpenCloud ts-config
+
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
+This package provides a reusable TypeScript config for application and extension development within the OpenCloud Web ecosystem.
+
+## Installation
+
+Depending on your package manager, run one of the following commands:
+
+```
+$ npm install @opencloud-eu/ts-config --save-dev
+
+$ pnpm add -D @opencloud-eu/ts-config
+
+$ yarn add @opencloud-eu/ts-config --dev
+```

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencloud-eu/tsconfig",
   "private": false,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "AGPL-3.0",
   "author": "OpenCloud GmbH <info@opencloud.eu>",
   "homepage": "https://github.com/opencloud-eu/web/tree/main/packages/tsconfig",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencloud-eu/tsconfig",
   "private": false,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "AGPL-3.0",
   "author": "OpenCloud GmbH <info@opencloud.eu>",
   "homepage": "https://github.com/opencloud-eu/web/tree/main/packages/tsconfig",

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -1,5 +1,7 @@
 # web-client
 
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
 The `web-client` is a standalone package that allows you to interact with the [OpenCloud](https://github.com/opencloud-eu/opencloud/) APIs via TypeScript. It provides an abstraction layer between the server and a (web-) application that converts API data into objects with helpful types and utilities. This abstraction ensures that users of the APIs don't need in-depth knowledge about them, such as required methods or returned status codes.
 
 The supported APIs are:

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-client",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "OpenCloud web client",
   "license": "AGPL-3.0",
   "private": false,

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-client",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "OpenCloud web client",
   "license": "AGPL-3.0",
   "private": false,

--- a/packages/web-pkg/README.md
+++ b/packages/web-pkg/README.md
@@ -1,5 +1,7 @@
 # web-pkg
 
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
 `web-pkg` is a package that provides utilities, most importantly a variety of components and composables, that can be useful when developing apps and extensions for OpenCloud Web.
 
 ## Installation

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-pkg",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "OpenCloud web pkg",
   "license": "AGPL-3.0",
   "main": "src/index.ts",

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-pkg",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenCloud web pkg",
   "license": "AGPL-3.0",
   "main": "src/index.ts",

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-pkg",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "OpenCloud web pkg",
   "license": "AGPL-3.0",
   "main": "src/index.ts",

--- a/packages/web-pkg/src/components/TextEditor/TextEditor.vue
+++ b/packages/web-pkg/src/components/TextEditor/TextEditor.vue
@@ -64,7 +64,8 @@ import 'cropperjs/dist/cropper.css'
 
 export default defineComponent({
   name: 'TextEditor',
-  components: { MdEditor, MdPreview },
+  // type casts are needed to ensure type inference works correctly when building web-pkg
+  components: { MdEditor: MdEditor as any, MdPreview: MdPreview as any },
   props: {
     applicationConfig: { type: Object as PropType<AppConfigObject>, required: false },
     currentContent: {

--- a/packages/web-pkg/tsconfig.json
+++ b/packages/web-pkg/tsconfig.json
@@ -5,7 +5,13 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@vue/shared": ["node_modules/@vue/shared/"]
+      "@vue/shared": ["node_modules/@vue/shared/"],
+      "@codemirror/autocomplete": [
+        "./node_modules/@codemirror/autocomplete"
+      ],
+      "vue/jsx-runtime": [
+        "./node_modules/vue/jsx-runtime"
+      ]
     },
   }
 }

--- a/packages/web-pkg/vite.config.ts
+++ b/packages/web-pkg/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import dts from 'vite-plugin-dts'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import vue from '@vitejs/plugin-vue'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json'
 
 const projectRootDir = searchForWorkspaceRoot(process.cwd())
 const external = [...Object.keys(pkg.dependencies)]

--- a/packages/web-test-helpers/README.md
+++ b/packages/web-test-helpers/README.md
@@ -1,5 +1,7 @@
 # web-test-helpers
 
+[![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
+
 This packages provides utilities for unit testing within the OpenCloud app ecosystem.
 
 ## Installation

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-test-helpers",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "OpenCloud web test helpers",
   "license": "AGPL-3.0",
   "private": false,

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-test-helpers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenCloud web test helpers",
   "license": "AGPL-3.0",
   "private": false,

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/web-test-helpers",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "OpenCloud web test helpers",
   "license": "AGPL-3.0",
   "private": false,

--- a/packages/web-test-helpers/vite.config.ts
+++ b/packages/web-test-helpers/vite.config.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({


### PR DESCRIPTION
This doesn't include any CI pipelines since we don't have CI in place just yet. It just prepares all the packages to be published manually.

closes https://github.com/opencloud-eu/web/issues/209