### PR TITLE
split e2e app-provider suite

### DIFF
--- a/tests/e2e/cucumber/features/app-provider-onlyOffice/officeSuites.feature
+++ b/tests/e2e/cucumber/features/app-provider-onlyOffice/officeSuites.feature
@@ -1,0 +1,148 @@
+Feature: Integrate with online office suites using OnlyOffice online office
+  As a user
+  I want to work on different docs, sheets, slides etc.., using OnlyOffice online office
+  So that the collaboration is seamless
+  # To run this feature we need to run the external app-provider service along with wopi, OnlyOffice services
+  # This is a minimal test for the integration of OpenCloud with OnlyOffice online office
+
+  Background:
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+      | Brian |
+    And "Alice" logs in
+    And "Alice" opens the "files" app
+
+
+  Scenario: create a Microsoft Word file with OnlyOffice
+    When "Alice" creates the following resources
+      | resource           | type           | content                |
+      | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
+    And "Alice" creates a public link of following resource using the sidebar panel
+      | resource           | role     | password |
+      | MicrosoftWord.docx | Can edit | %public% |
+    And "Alice" opens the following file in OnlyOffice
+      | resource           |
+      | MicrosoftWord.docx |
+    And "Anonymous" opens the public link "Unnamed link"
+    And "Anonymous" unlocks the public link with password "%public%"
+    Then "Anonymous" should see the content "Microsoft Word Content" in editor "OnlyOffice"
+    When "Alice" edits the following resource
+      | resource           | type           | content                             |
+      | MicrosoftWord.docx | Microsoft Word | Alice Edited Microsoft Word Content |
+    Then "Anonymous" should see the content "Alice Edited Microsoft Word Content" in editor "OnlyOffice"
+    When "Anonymous" edits the following resource
+      | resource           | type           | content                       |
+      | MicrosoftWord.docx | Microsoft Word | Edited Microsoft Word Content |
+    Then "Alice" should see the content "Edited Microsoft Word Content" in editor "OnlyOffice"
+    And "Alice" closes the file viewer
+    When "Alice" edits the public link named "Unnamed link" of resource "MicrosoftWord.docx" changing role to "Can view"
+    And "Anonymous" opens the public link "Unnamed link"
+    And "Anonymous" unlocks the public link with password "%public%"
+    Then "Anonymous" should not be able to edit content of following resource
+      | resource           | type           | content                       |
+      | MicrosoftWord.docx | Microsoft Word | Edited Microsoft Word Content |
+
+    And for "Alice" file "MicrosoftWord.docx" should not be locked
+    When "Alice" shares the following resource using the sidebar panel
+      | resource           | recipient | type | role     | resourceType |
+      | MicrosoftWord.docx | Brian     | user | Can view | file         |
+    And "Brian" logs in
+    And "Brian" navigates to the shared with me page
+    And "Brian" opens the following file in OnlyOffice
+      | resource           |
+      | MicrosoftWord.docx |
+    Then "Brian" should not be able to edit content of following resource
+      | resource           | type           | content                       |
+      | MicrosoftWord.docx | Microsoft Word | Edited Microsoft Word Content |
+    And "Brian" closes the file viewer
+    When "Alice" updates following sharee role
+      | resource           | recipient | type | role     | resourceType |
+      | MicrosoftWord.docx | Brian     | user | Can edit | file         |
+    And "Alice" opens the following file in OnlyOffice
+      | resource           |
+      | MicrosoftWord.docx |
+    And "Brian" opens the following file in OnlyOffice
+      | resource           |
+      | MicrosoftWord.docx |
+    And "Alice" edits the following resource
+      | resource           | type           | content                             |
+      | MicrosoftWord.docx | Microsoft Word | Alice Edited Microsoft Word Content |
+    Then "Brian" should see the content "Alice Edited Microsoft Word Content" in editor "OnlyOffice"
+    When "Brian" edits the following resource
+      | resource           | type           | content                             |
+      | MicrosoftWord.docx | Microsoft Word | Brian Edited Microsoft Word Content |
+    Then "Alice" should see the content "Brian Edited Microsoft Word Content" in editor "OnlyOffice"
+    And "Alice" logs out
+    And "Brian" logs out
+
+
+  Scenario: public creates a Microsoft Word file with OnlyOffice
+    Given "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following project space using API
+      | name      | id          |
+      | Marketing | marketing.1 |
+    And "Alice" creates the following folder in space "Marketing" using API
+      | name     |
+      | myfolder |
+    When "Alice" navigates to the project space "marketing.1"
+    And "Alice" creates a public link for the space with password "%public%" using the sidebar panel
+    And "Alice" renames the most recently created public link of space to "spaceLink"
+    And "Alice" edits the public link named "spaceLink" of the space changing role to "Can edit"
+    And "Alice" creates a public link of following resource using the sidebar panel
+      | resource | role     | password |
+      | myfolder | Can edit | %public% |
+
+    # public create .docx file using spaceLink
+    When "Anonymous" opens the public link "spaceLink"
+    And "Anonymous" unlocks the public link with password "%public%"
+    And "Anonymous" creates the following resources
+      | resource            | type           | content                                                      |
+      | usingSpaceLink.docx | Microsoft Word | public can create files in the project space using spaceLink |
+
+    # public create .docx file using folderLink
+    When "Anonymous" opens the public link "Unnamed link"
+    And "Anonymous" unlocks the public link with password "%public%"
+    And "Anonymous" creates the following resources
+      | resource             | type           | content                |
+      | usingFolderLink.docx | Microsoft Word | Microsoft Word Content |
+
+    When "Alice" navigates to the project space "marketing.1"
+    And "Alice" opens the following file in OnlyOffice
+      | resource            |
+      | usingSpaceLink.docx |
+    Then "Alice" should see the content "public can create files in the project space using spaceLink" in editor "OnlyOffice"
+    And "Alice" closes the file viewer
+
+    When "Alice" opens folder "myfolder"
+    And "Alice" opens the following file in OnlyOffice
+      | resource             |
+      | usingFolderLink.docx |
+    Then "Alice" should see the content "Microsoft Word Content" in editor "OnlyOffice"
+    And "Alice" logs out
+
+
+  Scenario: create files from office templates
+    Given "Alice" uploads the following local file into personal space using API
+      | localFile     | to            |
+      | Template.dotx | Template.dotx |
+
+    When "Alice" creates a file from template file "Template.dotx" via "OnlyOffice" using the sidebar panel
+    Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "OnlyOffice"
+    And "Alice" closes the file viewer
+
+    And following resources should be displayed in the files list for user "Alice"
+      | resource      |
+      | Template.docx |
+
+    When "Alice" opens file "Template.dotx"
+    Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "OnlyOffice"
+
+    When "Alice" closes the file viewer
+    And following resources should be displayed in the files list for user "Alice"
+      | resource          |
+      | Template (1).docx |
+
+    And "Alice" logs out

--- a/tests/e2e/cucumber/features/app-provider-onlyOffice/urlJourneys.feature
+++ b/tests/e2e/cucumber/features/app-provider-onlyOffice/urlJourneys.feature
@@ -1,0 +1,28 @@
+Feature: url stability for mobile and desktop client
+  As a user
+  I want to work on different docs, sheets, slides etc.., using OnlyOffice online office
+  To make sure that the file can be opened from the mobile and desktop client
+  # To run this feature we need to run the external app-provider service along with wopi, OnlyOffice services
+  # This is a minimal test for the integration of OpenCloud with OnlyOffice online office
+  # Check that the file can be opened in the onlyoffice online office using the url.
+
+
+  Scenario: open office suite files with onlyOffice
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+    And "Alice" logs in
+    And "Alice" creates the following resources
+      | resource           | type           | content                |
+      | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
+    And for "Alice" file "MicrosoftWord.docx" should not be locked
+    And "Alice" opens the "files" app
+
+    # desktop feature
+    When "Alice" opens the file "MicrosoftWord.docx" of space "personal" in OnlyOffice through the URL for desktop client
+    Then "Alice" should see the content "Microsoft Word Content" in editor "OnlyOffice"
+
+    # mobile feature
+    When "Alice" opens the file "MicrosoftWord.docx" of space "personal" in OnlyOffice through the URL for mobile client
+    Then "Alice" should see the content "Microsoft Word Content" in editor "OnlyOffice"
+    And "Alice" logs out

--- a/tests/e2e/cucumber/features/app-provider/lock.feature
+++ b/tests/e2e/cucumber/features/app-provider/lock.feature
@@ -26,8 +26,8 @@ Feature: lock
     Then "Brian" should see the content "some content" in editor "Collabora"
 
     # file-locked
-    And "Alice" should get "file-locked" SSE event
-    And for "Alice" file "test.odt" should be locked
+    # And "Alice" should get "file-locked" SSE event
+    # And for "Alice" file "test.odt" should be locked
 
     # checking that user cannot 'move', 'rename', 'delete' locked file
     And "Alice" should not be able to edit file "test.odt"
@@ -45,8 +45,8 @@ Feature: lock
 
     # file-unlocked
     When "Brian" closes the file viewer
-    Then "Alice" should get "file-unlocked" SSE event
-    And for "Alice" file "test.odt" should not be locked
+    # Then "Alice" should get "file-unlocked" SSE event
+    # And for "Alice" file "test.odt" should not be locked
     And "Alice" should be able to manage share of a file "test.odt" for user "Brian"
 
     And "Brian" logs out

--- a/tests/e2e/cucumber/features/app-provider/officeSuites.feature
+++ b/tests/e2e/cucumber/features/app-provider/officeSuites.feature
@@ -1,9 +1,9 @@
-Feature: Integrate with online office suites like Collabora and OnlyOffice
+Feature: Integration with Collabora online office
   As a user
-  I want to work on different docs, sheets, slides etc.., using online office suites like Collabora or OnlyOffice
+  I want to work on different docs, sheets, slides etc.., using online office suites like Collabora
   So that the collaboration is seamless
-  # To run this feature we need to run the external app-provider service along with wopi, OnlyOffice, Collabora services
-  # This is a minimal test for the integration of OpenCloud with different online office suites like Collabora and OnlyOffice
+  # To run this feature we need to run the external app-provider service along with wopi, Collabora services
+  # This is a minimal test for the integration of OpenCloud with Collabora online office
 
   Background:
     Given "Admin" creates following users using API
@@ -76,116 +76,6 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     And "Alice" logs out
 
 
-  Scenario: create a Microsoft Word file with OnlyOffice
-    When "Alice" creates the following resources
-      | resource           | type           | content                |
-      | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
-    And "Alice" creates a public link of following resource using the sidebar panel
-      | resource           | role     | password |
-      | MicrosoftWord.docx | Can edit | %public% |
-    And "Alice" opens the following file in OnlyOffice
-      | resource           |
-      | MicrosoftWord.docx |
-    And "Anonymous" opens the public link "Unnamed link"
-    And "Anonymous" unlocks the public link with password "%public%"
-    Then "Anonymous" should see the content "Microsoft Word Content" in editor "OnlyOffice"
-    When "Alice" edits the following resource
-      | resource           | type           | content                             |
-      | MicrosoftWord.docx | Microsoft Word | Alice Edited Microsoft Word Content |
-    Then "Anonymous" should see the content "Alice Edited Microsoft Word Content" in editor "OnlyOffice"
-    When "Anonymous" edits the following resource
-      | resource           | type           | content                       |
-      | MicrosoftWord.docx | Microsoft Word | Edited Microsoft Word Content |
-    Then "Alice" should see the content "Edited Microsoft Word Content" in editor "OnlyOffice"
-    And "Alice" closes the file viewer
-    When "Alice" edits the public link named "Unnamed link" of resource "MicrosoftWord.docx" changing role to "Can view"
-    And "Anonymous" opens the public link "Unnamed link"
-    And "Anonymous" unlocks the public link with password "%public%"
-    Then "Anonymous" should not be able to edit content of following resource
-      | resource           | type           | content                       |
-      | MicrosoftWord.docx | Microsoft Word | Edited Microsoft Word Content |
-
-    And for "Alice" file "MicrosoftWord.docx" should not be locked
-    When "Alice" shares the following resource using the sidebar panel
-      | resource           | recipient | type | role     | resourceType |
-      | MicrosoftWord.docx | Brian     | user | Can view | file         |
-    And "Brian" logs in
-    And "Brian" navigates to the shared with me page
-    And "Brian" opens the following file in OnlyOffice
-      | resource           |
-      | MicrosoftWord.docx |
-    Then "Brian" should not be able to edit content of following resource
-      | resource           | type           | content                       |
-      | MicrosoftWord.docx | Microsoft Word | Edited Microsoft Word Content |
-    And "Brian" closes the file viewer
-    When "Alice" updates following sharee role
-      | resource           | recipient | type | role     | resourceType |
-      | MicrosoftWord.docx | Brian     | user | Can edit | file         |
-    And "Alice" opens the following file in OnlyOffice
-      | resource           |
-      | MicrosoftWord.docx |
-    And "Brian" opens the following file in OnlyOffice
-      | resource           |
-      | MicrosoftWord.docx |
-    And "Alice" edits the following resource
-      | resource           | type           | content                             |
-      | MicrosoftWord.docx | Microsoft Word | Alice Edited Microsoft Word Content |
-    Then "Brian" should see the content "Alice Edited Microsoft Word Content" in editor "OnlyOffice"
-    When "Brian" edits the following resource
-      | resource           | type           | content                             |
-      | MicrosoftWord.docx | Microsoft Word | Brian Edited Microsoft Word Content |
-    Then "Alice" should see the content "Brian Edited Microsoft Word Content" in editor "OnlyOffice"
-    And "Alice" logs out
-    And "Brian" logs out
-
-
-  Scenario: public creates a Microsoft Word file with OnlyOffice
-    Given "Admin" assigns following roles to the users using API
-      | id    | role        |
-      | Alice | Space Admin |
-    And "Alice" creates the following project space using API
-      | name      | id          |
-      | Marketing | marketing.1 |
-    And "Alice" creates the following folder in space "Marketing" using API
-      | name     |
-      | myfolder |
-    When "Alice" navigates to the project space "marketing.1"
-    And "Alice" creates a public link for the space with password "%public%" using the sidebar panel
-    And "Alice" renames the most recently created public link of space to "spaceLink"
-    And "Alice" edits the public link named "spaceLink" of the space changing role to "Can edit"
-    And "Alice" creates a public link of following resource using the sidebar panel
-      | resource | role     | password |
-      | myfolder | Can edit | %public% |
-
-    # public create .docx file using spaceLink
-    When "Anonymous" opens the public link "spaceLink"
-    And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" creates the following resources
-      | resource            | type           | content                                                      |
-      | usingSpaceLink.docx | Microsoft Word | public can create files in the project space using spaceLink |
-
-    # public create .docx file using folderLink
-    When "Anonymous" opens the public link "Unnamed link"
-    And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" creates the following resources
-      | resource             | type           | content                |
-      | usingFolderLink.docx | Microsoft Word | Microsoft Word Content |
-
-    When "Alice" navigates to the project space "marketing.1"
-    And "Alice" opens the following file in OnlyOffice
-      | resource            |
-      | usingSpaceLink.docx |
-    Then "Alice" should see the content "public can create files in the project space using spaceLink" in editor "OnlyOffice"
-    And "Alice" closes the file viewer
-
-    When "Alice" opens folder "myfolder"
-    And "Alice" opens the following file in OnlyOffice
-      | resource             |
-      | usingFolderLink.docx |
-    Then "Alice" should see the content "Microsoft Word Content" in editor "OnlyOffice"
-    And "Alice" logs out
-
-
   Scenario: public creates a Microsoft Word file with Collabora
     Given "Admin" assigns following roles to the users using API
       | id    | role        |
@@ -204,14 +94,14 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
       | resource | role     | password |
       | myfolder | Can edit | %public% |
 
-    # public create .docx file using spaceLink
+    # public create .odt file using spaceLink
     When "Anonymous" opens the public link "spaceLink"
     And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" creates the following resources
       | resource           | type         | content                                                      |
       | usingSpaceLink.odt | OpenDocument | public can create files in the project space using spaceLink |
 
-    # public create .docx file using folderLink
+    # public create .odt file using folderLink
     When "Anonymous" opens the public link "Unnamed link"
     And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" creates the following resources
@@ -236,12 +126,7 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
   Scenario: create files from office templates
     Given "Alice" uploads the following local file into personal space using API
       | localFile     | to            |
-      | Template.dotx | Template.dotx |
       | Template.ott  | Template.ott  |
-
-    When "Alice" creates a file from template file "Template.dotx" via "OnlyOffice" using the sidebar panel
-    Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "OnlyOffice"
-    And "Alice" closes the file viewer
 
     When "Alice" creates a file from template file "Template.ott" via "Collabora" using the context menu
     Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "Collabora"
@@ -250,15 +135,6 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     And following resources should be displayed in the files list for user "Alice"
       | resource      |
       | Template.odt  |
-      | Template.docx |
-
-    When "Alice" opens file "Template.dotx"
-    Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "OnlyOffice"
-
-    When "Alice" closes the file viewer
-    And following resources should be displayed in the files list for user "Alice"
-      | resource          |
-      | Template (1).docx |
 
     When "Alice" opens template file "Template.ott" via "Collabora" using the context menu
     Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "Collabora"
@@ -266,6 +142,5 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     When "Alice" closes the file viewer
     Then following resources should not be displayed in the files list for user "Alice"
       | resource          |
-      | Template (2).docx |
-
+      | Template (1).docx |
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/app-provider/secureView.feature
+++ b/tests/e2e/cucumber/features/app-provider/secureView.feature
@@ -3,7 +3,7 @@ Feature: Secure view
   I want to share different docs using secure view role
   So that the recipient can only open documents in Collabora with watermarks applied
   Any actions for the recipient, such as editing, downloading, copying the document, are prohibited
-  # To run this feature we need to run the external app-provider service along OnlyOffice, Collabora services
+  # To run this feature we need to run the external app-provider service along Collabora service
 
   Background:
     Given "Admin" creates following users using API

--- a/tests/e2e/cucumber/features/app-provider/urlJourneys.feature
+++ b/tests/e2e/cucumber/features/app-provider/urlJourneys.feature
@@ -1,13 +1,13 @@
 Feature: url stability for mobile and desktop client
   As a user
-  I want to work on different docs, sheets, slides etc.., using online office suites like Collabora or OnlyOffice
+  I want to work on different docs, sheets, slides etc.., using Collabora online office
   To make sure that the file can be opened from the mobile and desktop client
-  # To run this feature we need to run the external app-provider service along with wopi, OnlyOffice, Collabora services
-  # This is a minimal test for the integration of OpenCloud with different online office suites like Collabora and OnlyOffice
-  # Check that the file can be opened in collabora or onlyoffice using the url.
+  # To run this feature we need to run the external app-provider service along with wopi, Collabora services
+  # This is a minimal test for the integration of OpenCloud with Collabora online office
+  # Check that the file can be opened in collabora using the url.
 
 
-  Scenario: open office suite files with Collabora and onlyOffice
+  Scenario: open office suite files with Collabora
     Given "Admin" creates following users using API
       | id    |
       | Alice |
@@ -15,21 +15,12 @@ Feature: url stability for mobile and desktop client
     And "Alice" creates the following files into personal space using API
       | pathToFile       | content              |
       | OpenDocument.odt | OpenDocument Content |
-    And "Alice" creates the following resources
-      | resource           | type           | content                |
-      | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
-    And for "Alice" file "MicrosoftWord.docx" should not be locked
-    And "Alice" opens the "files" app
 
     # desktop feature
     When "Alice" opens the file "OpenDocument.odt" of space "personal" in Collabora through the URL for desktop client
     Then "Alice" should see the content "OpenDocument Content" in editor "Collabora"
-    When "Alice" opens the file "MicrosoftWord.docx" of space "personal" in OnlyOffice through the URL for desktop client
-    Then "Alice" should see the content "Microsoft Word Content" in editor "OnlyOffice"
-
+   
     # mobile feature
     When "Alice" opens the file "OpenDocument.odt" of space "personal" in Collabora through the URL for mobile client
     Then "Alice" should see the content "OpenDocument Content" in editor "Collabora"
-    When "Alice" opens the file "MicrosoftWord.docx" of space "personal" in OnlyOffice through the URL for mobile client
-    Then "Alice" should see the content "Microsoft Word Content" in editor "OnlyOffice"
     And "Alice" logs out


### PR DESCRIPTION
after https://github.com/opencloud-eu/web/pull/89 we can't run app-provider locally
I split the app provider into two parts: `app-provider` and `app-provider-onlyoffice`