### PR TITLE
feat: mobile sidebars

### DIFF
--- a/packages/web-app-admin-settings/src/components/AppTemplate.vue
+++ b/packages/web-app-admin-settings/src/components/AppTemplate.vue
@@ -1,67 +1,74 @@
 <template>
   <main class="oc-flex oc-height-1-1 app-content oc-width-1-1">
-    <app-loading-spinner v-if="loading" />
-    <template v-else>
-      <div id="admin-settings-wrapper" class="oc-width-expand oc-height-1-1 oc-position-relative">
+    <div
+      class="admin-settings-wrapper oc-flex oc-width-1-1 oc-width-expand oc-height-1-1 oc-flex-wrap"
+    >
+      <app-loading-spinner v-if="loading" />
+      <template v-else>
         <div
-          id="admin-settings-app-bar"
-          ref="appBarRef"
-          class="oc-app-bar oc-py-s"
-          :class="{ 'admin-settings-app-bar-sticky': isSticky }"
+          id="admin-settings-view-wrapper"
+          class="oc-width-expand oc-width-1-1 oc-height-1-1 oc-flex-wrap"
         >
-          <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
-            <oc-breadcrumb
-              v-if="!isMobileWidth"
-              id="admin-settings-breadcrumb"
-              :items="breadcrumbs"
-            />
-            <portal-target name="app.runtime.mobile.nav" />
-            <div class="oc-flex">
-              <view-options
-                v-if="showViewOptions"
-                :has-hidden-files="false"
-                :has-file-extensions="false"
-                :has-pagination="true"
-                :pagination-options="paginationOptions"
-                :per-page-default="perPageDefault"
-                per-page-storage-prefix="admin-settings"
+          <div
+            id="admin-settings-app-bar"
+            ref="appBarRef"
+            class="oc-app-bar oc-py-s"
+            :class="{ 'admin-settings-app-bar-sticky': isSticky }"
+          >
+            <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
+              <oc-breadcrumb
+                v-if="!isMobileWidth"
+                id="admin-settings-breadcrumb"
+                :items="breadcrumbs"
+              />
+              <portal-target name="app.runtime.mobile.nav" />
+              <div class="oc-flex">
+                <view-options
+                  v-if="showViewOptions"
+                  :has-hidden-files="false"
+                  :has-file-extensions="false"
+                  :has-pagination="true"
+                  :pagination-options="paginationOptions"
+                  :per-page-default="perPageDefault"
+                  per-page-storage-prefix="admin-settings"
+                />
+              </div>
+            </div>
+            <div
+              v-if="showAppBar"
+              class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs"
+            >
+              <slot
+                name="topbarActions"
+                :limited-screen-space="limitedScreenSpace"
+                class="oc-flex-1 oc-flex oc-flex-start"
+              />
+              <batch-actions
+                v-if="showBatchActions"
+                :actions="batchActions"
+                :action-options="{ resources: batchActionItems }"
+                :limited-screen-space="limitedScreenSpace"
               />
             </div>
           </div>
-          <div
-            v-if="showAppBar"
-            class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs"
-          >
-            <slot
-              name="topbarActions"
-              :limited-screen-space="limitedScreenSpace"
-              class="oc-flex-1 oc-flex oc-flex-start"
-            />
-            <batch-actions
-              v-if="showBatchActions"
-              :actions="batchActions"
-              :action-options="{ resources: batchActionItems }"
-              :limited-screen-space="limitedScreenSpace"
-            />
-          </div>
+          <slot name="mainContent" />
         </div>
-        <slot name="mainContent" />
-      </div>
-      <side-bar
-        v-if="isSideBarOpen"
-        :active-panel="sideBarActivePanel"
-        :available-panels="sideBarAvailablePanels"
-        :panel-context="sideBarPanelContext"
-        :loading="sideBarLoading"
-        :is-open="isSideBarOpen"
-        @select-panel="selectPanel"
-        @close="closeSideBar"
-      >
-        <template #header>
-          <slot name="sideBarHeader" />
-        </template>
-      </side-bar>
-    </template>
+        <side-bar
+          v-if="isSideBarOpen"
+          :active-panel="sideBarActivePanel"
+          :available-panels="sideBarAvailablePanels"
+          :panel-context="sideBarPanelContext"
+          :loading="sideBarLoading"
+          :is-open="isSideBarOpen"
+          @select-panel="selectPanel"
+          @close="closeSideBar"
+        >
+          <template #header>
+            <slot name="sideBarHeader" />
+          </template>
+        </side-bar>
+      </template>
+    </div>
   </main>
 </template>
 
@@ -214,7 +221,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-#admin-settings-wrapper {
+#admin-settings-view-wrapper {
   overflow-y: auto;
 }
 
@@ -246,7 +253,9 @@ export default defineComponent({
   min-height: 3rem;
 }
 
-#admin-settings-wrapper {
-  overflow-y: auto;
+@media only screen and (max-width: $oc-breakpoint-small-default) {
+  .admin-settings-wrapper {
+    flex-wrap: nowrap !important;
+  }
 }
 </style>

--- a/packages/web-app-admin-settings/tests/unit/components/AppTemplate.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/AppTemplate.spec.ts
@@ -19,7 +19,7 @@ const stubSelectors = {
 }
 
 const elSelectors = {
-  adminSettingsWrapper: '#admin-settings-wrapper'
+  adminSettingsWrapper: '#admin-settings-view-wrapper'
 }
 
 vi.mock('@opencloud-eu/web-pkg')

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
     <thead class="oc-thead">
       <tr class="oc-table-header-row">
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
-          <div><span class="oc-table-thead-content"><oc-checkbox-stub label="Select all spaces" disabled="false" id="oc-checkbox-1" labelhidden="true" outline="false" size="large" modelvalue="false" class="oc-ml-s"></oc-checkbox-stub></span></div>
+          <div><span class="oc-table-thead-content"><oc-checkbox-stub label="Select all spaces" disabled="false" id="oc-checkbox-1" labelhidden="true" size="large" modelvalue="false" class="oc-ml-s"></oc-checkbox-stub></span></div>
         </th>
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-th oc-table-header-cell oc-table-header-cell-icon" style="top: 0px;">
           <div><span class="oc-table-thead-content header-text"></span></div>
@@ -60,7 +60,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
     <tbody class="has-item-context-menu">
       <tr class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s">
-          <oc-checkbox-stub option="undefined" label="Select 1 Some space" disabled="false" id="oc-checkbox-2" labelhidden="true" outline="false" size="large" modelvalue="false" class="oc-ml-s"></oc-checkbox-stub>
+          <oc-checkbox-stub option="undefined" label="Select 1 Some space" disabled="false" id="oc-checkbox-2" labelhidden="true" size="large" modelvalue="false" class="oc-ml-s"></oc-checkbox-stub>
         </td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name mark-element"><span class="spaces-table-space-name" data-test-space-name="1 Some space">1 Some space</span></td>
@@ -86,7 +86,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
       </tr>
       <tr class="oc-tbody-tr oc-tbody-tr-2" data-item-id="2" draggable="false">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s">
-          <oc-checkbox-stub option="undefined" label="Select 2 Another space" disabled="false" id="oc-checkbox-3" labelhidden="true" outline="false" size="large" modelvalue="false" class="oc-ml-s"></oc-checkbox-stub>
+          <oc-checkbox-stub option="undefined" label="Select 2 Another space" disabled="false" id="oc-checkbox-3" labelhidden="true" size="large" modelvalue="false" class="oc-ml-s"></oc-checkbox-stub>
         </td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name mark-element"><span class="spaces-table-space-name" data-test-space-name="2 Another space">2 Another space</span></td>

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
@@ -3,24 +3,26 @@
 exports[`Spaces view > loading states > should render spaces list after loading has been finished 1`] = `
 "<div>
   <main class="oc-flex oc-height-1-1 app-content oc-width-1-1">
-    <div id="admin-settings-wrapper" class="oc-width-expand oc-height-1-1 oc-position-relative">
-      <div id="admin-settings-app-bar" class="oc-app-bar oc-py-s admin-settings-app-bar-sticky">
-        <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
-          <oc-breadcrumb-stub items="[object Object],[object Object]" contextmenupadding="medium" id="admin-settings-breadcrumb" maxwidth="-1" showcontextactions="false" truncationoffset="2" variation="default"></oc-breadcrumb-stub>
-          <portal-target name="app.runtime.mobile.nav"></portal-target>
-          <div class="oc-flex">
-            <view-options-stub perpagestorageprefix="admin-settings" hashiddenfiles="false" hasfileextensions="false" haspagination="true" paginationoptions="20,50,100,250" perpagequeryname="items-per-page" perpagedefault="50" viewmodedefault="resource-table" viewmodes=""></view-options-stub>
+    <div class="admin-settings-wrapper oc-flex oc-width-1-1 oc-width-expand oc-height-1-1 oc-flex-wrap">
+      <div id="admin-settings-view-wrapper" class="oc-width-expand oc-width-1-1 oc-height-1-1 oc-flex-wrap">
+        <div id="admin-settings-app-bar" class="oc-app-bar oc-py-s admin-settings-app-bar-sticky">
+          <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
+            <oc-breadcrumb-stub items="[object Object],[object Object]" contextmenupadding="medium" id="admin-settings-breadcrumb" maxwidth="-1" showcontextactions="false" truncationoffset="2" variation="default"></oc-breadcrumb-stub>
+            <portal-target name="app.runtime.mobile.nav"></portal-target>
+            <div class="oc-flex">
+              <view-options-stub perpagestorageprefix="admin-settings" hashiddenfiles="false" hasfileextensions="false" haspagination="true" paginationoptions="20,50,100,250" perpagequeryname="items-per-page" perpagedefault="50" viewmodedefault="resource-table" viewmodes=""></view-options-stub>
+            </div>
+          </div>
+          <div class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs">
+            <!--v-if-->
           </div>
         </div>
-        <div class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs">
-          <!--v-if-->
+        <div>
+          <spaces-list-stub class=""></spaces-list-stub>
         </div>
       </div>
-      <div>
-        <spaces-list-stub class=""></spaces-list-stub>
-      </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
   </main>
 </div>"
 `;

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -3,47 +3,49 @@
 exports[`Users view > list view > renders initially warning if filters are mandatory 1`] = `
 "<div data-v-32efd9c6="">
   <main data-v-32efd9c6="" class="oc-flex oc-height-1-1 app-content oc-width-1-1">
-    <div id="admin-settings-wrapper" class="oc-width-expand oc-height-1-1 oc-position-relative">
-      <div id="admin-settings-app-bar" class="oc-app-bar oc-py-s admin-settings-app-bar-sticky">
-        <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
-          <oc-breadcrumb-stub items="[object Object],[object Object]" contextmenupadding="medium" id="admin-settings-breadcrumb" maxwidth="-1" showcontextactions="false" truncationoffset="2" variation="default"></oc-breadcrumb-stub>
-          <portal-target name="app.runtime.mobile.nav"></portal-target>
-          <div class="oc-flex">
-            <view-options-stub perpagestorageprefix="admin-settings" hashiddenfiles="false" hasfileextensions="false" haspagination="true" paginationoptions="20,50,100,250" perpagequeryname="items-per-page" perpagedefault="50" viewmodedefault="resource-table" viewmodes=""></view-options-stub>
+    <div class="admin-settings-wrapper oc-flex oc-width-1-1 oc-width-expand oc-height-1-1 oc-flex-wrap">
+      <div id="admin-settings-view-wrapper" class="oc-width-expand oc-width-1-1 oc-height-1-1 oc-flex-wrap">
+        <div id="admin-settings-app-bar" class="oc-app-bar oc-py-s admin-settings-app-bar-sticky">
+          <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
+            <oc-breadcrumb-stub items="[object Object],[object Object]" contextmenupadding="medium" id="admin-settings-breadcrumb" maxwidth="-1" showcontextactions="false" truncationoffset="2" variation="default"></oc-breadcrumb-stub>
+            <portal-target name="app.runtime.mobile.nav"></portal-target>
+            <div class="oc-flex">
+              <view-options-stub perpagestorageprefix="admin-settings" hashiddenfiles="false" hasfileextensions="false" haspagination="true" paginationoptions="20,50,100,250" perpagequeryname="items-per-page" perpagedefault="50" viewmodedefault="resource-table" viewmodes=""></view-options-stub>
+            </div>
+          </div>
+          <div class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs">
+            <div data-v-32efd9c6="">
+              <oc-button-stub data-v-32efd9c6="" appearance="filled" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="primary" id="create-user-btn" class="oc-mr-s"></oc-button-stub>
+            </div>
+            <!--v-if-->
           </div>
         </div>
-        <div class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs">
-          <div data-v-32efd9c6="">
-            <oc-button-stub data-v-32efd9c6="" appearance="filled" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="primary" id="create-user-btn" class="oc-mr-s"></oc-button-stub>
-          </div>
-          <!--v-if-->
-        </div>
-      </div>
-      <div data-v-32efd9c6="" id="user-list" class="">
-        <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
-          <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
-            <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
-          </div>
-          <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
-            <div data-v-32efd9c6="" class=""><label class="oc-label" for="users-filter">Search</label>
-              <div class="oc-position-relative">
-                <!--v-if--> <input id="users-filter" modelmodifiers="[object Object]" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="text">
+        <div data-v-32efd9c6="" id="user-list" class="">
+          <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
+            <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
+              <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
+              <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
+              <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
+            </div>
+            <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
+              <div data-v-32efd9c6="" class=""><label class="oc-label" for="users-filter">Search</label>
+                <div class="oc-position-relative">
+                  <!--v-if--> <input id="users-filter" modelmodifiers="[object Object]" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="text">
+                  <!--v-if-->
+                </div>
+                <!--v-if-->
                 <!--v-if-->
               </div>
-              <!--v-if-->
-              <!--v-if-->
+              <oc-button-stub data-v-32efd9c6="" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" id="users-filter-confirm" class="oc-ml-xs"></oc-button-stub>
             </div>
-            <oc-button-stub data-v-32efd9c6="" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" id="users-filter-confirm" class="oc-ml-xs"></oc-button-stub>
+          </div>
+          <div>
+            <no-content-message-stub data-v-32efd9c6="" icon="error-warning" iconfilltype="fill"></no-content-message-stub>
           </div>
         </div>
-        <div>
-          <no-content-message-stub data-v-32efd9c6="" icon="error-warning" iconfilltype="fill"></no-content-message-stub>
-        </div>
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
   </main>
 </div>"
 `;
@@ -51,105 +53,107 @@ exports[`Users view > list view > renders initially warning if filters are manda
 exports[`Users view > list view > renders list initially 1`] = `
 "<div data-v-32efd9c6="">
   <main data-v-32efd9c6="" class="oc-flex oc-height-1-1 app-content oc-width-1-1">
-    <div id="admin-settings-wrapper" class="oc-width-expand oc-height-1-1 oc-position-relative">
-      <div id="admin-settings-app-bar" class="oc-app-bar oc-py-s admin-settings-app-bar-sticky">
-        <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
-          <oc-breadcrumb-stub items="[object Object],[object Object]" contextmenupadding="medium" id="admin-settings-breadcrumb" maxwidth="-1" showcontextactions="false" truncationoffset="2" variation="default"></oc-breadcrumb-stub>
-          <portal-target name="app.runtime.mobile.nav"></portal-target>
-          <div class="oc-flex">
-            <view-options-stub perpagestorageprefix="admin-settings" hashiddenfiles="false" hasfileextensions="false" haspagination="true" paginationoptions="20,50,100,250" perpagequeryname="items-per-page" perpagedefault="50" viewmodedefault="resource-table" viewmodes=""></view-options-stub>
+    <div class="admin-settings-wrapper oc-flex oc-width-1-1 oc-width-expand oc-height-1-1 oc-flex-wrap">
+      <div id="admin-settings-view-wrapper" class="oc-width-expand oc-width-1-1 oc-height-1-1 oc-flex-wrap">
+        <div id="admin-settings-app-bar" class="oc-app-bar oc-py-s admin-settings-app-bar-sticky">
+          <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
+            <oc-breadcrumb-stub items="[object Object],[object Object]" contextmenupadding="medium" id="admin-settings-breadcrumb" maxwidth="-1" showcontextactions="false" truncationoffset="2" variation="default"></oc-breadcrumb-stub>
+            <portal-target name="app.runtime.mobile.nav"></portal-target>
+            <div class="oc-flex">
+              <view-options-stub perpagestorageprefix="admin-settings" hashiddenfiles="false" hasfileextensions="false" haspagination="true" paginationoptions="20,50,100,250" perpagequeryname="items-per-page" perpagedefault="50" viewmodedefault="resource-table" viewmodes=""></view-options-stub>
+            </div>
+          </div>
+          <div class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs">
+            <div data-v-32efd9c6="">
+              <oc-button-stub data-v-32efd9c6="" appearance="filled" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="primary" id="create-user-btn" class="oc-mr-s"></oc-button-stub>
+            </div>
+            <!--v-if-->
           </div>
         </div>
-        <div class="admin-settings-app-bar-actions oc-flex oc-flex-middle oc-mt-xs">
-          <div data-v-32efd9c6="">
-            <oc-button-stub data-v-32efd9c6="" appearance="filled" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="primary" id="create-user-btn" class="oc-mr-s"></oc-button-stub>
-          </div>
-          <!--v-if-->
-        </div>
-      </div>
-      <div data-v-32efd9c6="" id="user-list" class="">
-        <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
-          <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
-            <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
-          </div>
-          <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
-            <div data-v-32efd9c6="" class=""><label class="oc-label" for="users-filter">Search</label>
-              <div class="oc-position-relative">
-                <!--v-if--> <input id="users-filter" modelmodifiers="[object Object]" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="text">
+        <div data-v-32efd9c6="" id="user-list" class="">
+          <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
+            <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
+              <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
+              <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
+              <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
+            </div>
+            <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
+              <div data-v-32efd9c6="" class=""><label class="oc-label" for="users-filter">Search</label>
+                <div class="oc-position-relative">
+                  <!--v-if--> <input id="users-filter" modelmodifiers="[object Object]" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="text">
+                  <!--v-if-->
+                </div>
+                <!--v-if-->
                 <!--v-if-->
               </div>
-              <!--v-if-->
-              <!--v-if-->
+              <oc-button-stub data-v-32efd9c6="" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" id="users-filter-confirm" class="oc-ml-xs"></oc-button-stub>
             </div>
-            <oc-button-stub data-v-32efd9c6="" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" id="users-filter-confirm" class="oc-ml-xs"></oc-button-stub>
+          </div>
+          <div>
+            <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu users-table">
+              <thead class="oc-thead">
+                <tr class="oc-table-header-row">
+                  <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
+                    <div><span class="oc-table-thead-content"><span class="oc-ml-s"><input id="oc-checkbox-1" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select all users"> <!--v-if--></span></span></div>
+                  </th>
+                  <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-th oc-table-header-cell oc-table-header-cell-avatar" style="top: 0px;">
+                    <div><span class="oc-table-thead-content header-text"></span></div>
+                  </th>
+                  <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-onPremisesSamAccountName" style="top: 0px;" aria-sort="ascending">
+                    <oc-button-stub arialabel="Sort by onPremisesSamAccountName" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                  </th>
+                  <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-displayName" style="top: 0px;" aria-sort="none">
+                    <oc-button-stub arialabel="Sort by displayName" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                  </th>
+                  <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-mail" style="top: 0px;" aria-sort="none">
+                    <oc-button-stub arialabel="Sort by mail" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                  </th>
+                  <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-role" style="top: 0px;" aria-sort="none">
+                    <oc-button-stub arialabel="Sort by role" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                  </th>
+                  <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-accountEnabled" style="top: 0px;" aria-sort="none">
+                    <oc-button-stub arialabel="Sort by accountEnabled" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                  </th>
+                  <th class="oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-actions oc-pr-s" style="top: 0px;">
+                    <div><span class="oc-table-thead-content header-text">Actions</span></div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="has-item-context-menu">
+                <tr class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
+                  <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s"><span class="oc-ml-s"><input id="oc-checkbox-2" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select Admin" value="[object Object]"> <!--v-if--></span></td>
+                  <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-avatar">
+                    <avatar-image width="32" userid="1" user-name="Admin"></avatar-image>
+                  </td>
+                  <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-onPremisesSamAccountName"></td>
+                  <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-displayName mark-element">Admin</td>
+                  <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-mail">admin@example.org</td>
+                  <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-role">Admin</td>
+                  <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-accountEnabled"><span class="oc-flex oc-flex-middle"><span class="oc-icon oc-icon-m oc-icon-passive oc-mr-s"><!----></span><span>Allowed</span></span></td>
+                  <td class="oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-actions oc-pr-s">
+                    <oc-button-stub arialabel="Show details" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-mr-xs quick-action-button oc-p-xs users-table-btn-details"></oc-button-stub>
+                    <oc-button-stub arialabel="Edit" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-mr-xs quick-action-button oc-p-xs users-table-btn-edit"></oc-button-stub>
+                    <oc-button-stub arialabel="Show context menu" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" id="context-menu-trigger-1" class="users-table-btn-action-dropdown"></oc-button-stub>
+                  </td>
+                </tr>
+              </tbody>
+              <tfoot class="oc-table-footer">
+                <tr class="oc-table-footer-row">
+                  <td colspan="8" class="oc-table-footer-cell">
+                    <!-- @slot Footer of the table -->
+                    <!--v-if-->
+                    <div class="oc-text-center oc-width-1-1 oc-my-s">
+                      <p class="oc-text-muted">1 users in total</p>
+                    </div>
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
           </div>
         </div>
-        <div>
-          <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu users-table">
-            <thead class="oc-thead">
-              <tr class="oc-table-header-row">
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
-                  <div><span class="oc-table-thead-content"><span class="oc-ml-s"><input id="oc-checkbox-1" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select all users"> <!--v-if--></span></span></div>
-                </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-th oc-table-header-cell oc-table-header-cell-avatar" style="top: 0px;">
-                  <div><span class="oc-table-thead-content header-text"></span></div>
-                </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-onPremisesSamAccountName" style="top: 0px;" aria-sort="ascending">
-                  <oc-button-stub arialabel="Sort by onPremisesSamAccountName" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
-                </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-displayName" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub arialabel="Sort by displayName" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
-                </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-mail" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub arialabel="Sort by mail" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
-                </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-role" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub arialabel="Sort by role" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
-                </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-accountEnabled" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub arialabel="Sort by accountEnabled" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-button-sort oc-width-1-1"></oc-button-stub>
-                </th>
-                <th class="oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-th oc-table-header-cell oc-table-header-cell-actions oc-pr-s" style="top: 0px;">
-                  <div><span class="oc-table-thead-content header-text">Actions</span></div>
-                </th>
-              </tr>
-            </thead>
-            <tbody class="has-item-context-menu">
-              <tr class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s"><span class="oc-ml-s"><input id="oc-checkbox-2" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select Admin" value="[object Object]"> <!--v-if--></span></td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-avatar">
-                  <avatar-image width="32" userid="1" user-name="Admin"></avatar-image>
-                </td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-onPremisesSamAccountName"></td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-displayName mark-element">Admin</td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-mail">admin@example.org</td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-role">Admin</td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-accountEnabled"><span class="oc-flex oc-flex-middle"><span class="oc-icon oc-icon-m oc-icon-passive oc-mr-s"><!----></span><span>Allowed</span></span></td>
-                <td class="oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-actions oc-pr-s">
-                  <oc-button-stub arialabel="Show details" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-mr-xs quick-action-button oc-p-xs users-table-btn-details"></oc-button-stub>
-                  <oc-button-stub arialabel="Edit" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" class="oc-mr-xs quick-action-button oc-p-xs users-table-btn-edit"></oc-button-stub>
-                  <oc-button-stub arialabel="Show context menu" appearance="raw" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive" id="context-menu-trigger-1" class="users-table-btn-action-dropdown"></oc-button-stub>
-                </td>
-              </tr>
-            </tbody>
-            <tfoot class="oc-table-footer">
-              <tr class="oc-table-footer-row">
-                <td colspan="8" class="oc-table-footer-cell">
-                  <!-- @slot Footer of the table -->
-                  <!--v-if-->
-                  <div class="oc-text-center oc-width-1-1 oc-my-s">
-                    <p class="oc-text-muted">1 users in total</p>
-                  </div>
-                </td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
   </main>
 </div>"
 `;

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -15,7 +15,7 @@
       :button-hidden="true"
       :show-cancel-button="showCancelButton"
       :show-advanced-search-button="listProviderAvailable"
-      cancel-button-variation="brand"
+      cancel-button-variation="primary"
       cancel-button-appearance="raw-inverse"
       :cancel-handler="cancelSearch"
       @advanced-search="onKeyUpEnter"
@@ -545,12 +545,12 @@ export default defineComponent({
   #files-global-search-bar {
     width: 452px;
     @media (max-width: 959px) {
-      width: 300px;
+      width: 240px;
     }
 
     @media (max-width: 639px) {
       visibility: hidden;
-      background-color: var(--oc-color-swatch-brand-default);
+      background-color: var(--oc-color-background-chrome);
       position: absolute;
       height: 48px;
       left: 0;

--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -206,7 +206,7 @@ export default defineComponent({
 
     const windowWidth = ref(window.innerWidth)
 
-    const fullWidthSideBar = computed(() => unref(windowWidth) <= 960)
+    const fullWidthSideBar = computed(() => unref(windowWidth) <= 580)
     const backgroundContentEl = computed(() => {
       return unref(appSideBar)?.parentElement?.querySelector('div') as HTMLElement
     })
@@ -308,7 +308,7 @@ export default defineComponent({
   width: 100% !important;
 }
 
-@media only screen and (max-width: $oc-breakpoint-medium-default) {
+@media only screen and (max-width: $oc-breakpoint-small-default) {
   .files-wrapper {
     flex-wrap: nowrap !important;
   }
@@ -327,9 +327,7 @@ export default defineComponent({
   top: 0;
   position: absolute;
   transform: translateX(100%);
-  transition:
-    transform 0.4s ease,
-    visibility 0.4s 0s;
+  transition: transform 0.4s ease, visibility 0.4s 0s;
   // visibility is here to prevent focusing panel child elements,
   // the transition delay keeps care that it will only apply if the element is visible or not.
   // hidden: if element is off screen

--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -98,14 +98,12 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import {
   computed,
-  defineComponent,
   nextTick,
   onBeforeUnmount,
   onMounted,
-  PropType,
   ref,
   unref,
   useTemplateRef,
@@ -114,177 +112,150 @@ import {
 import { SideBarPanel, SideBarPanelContext } from './types'
 import { useGettext } from 'vue3-gettext'
 
-export default defineComponent({
-  props: {
-    isOpen: {
-      type: Boolean,
-      required: true
-    },
-    loading: {
-      type: Boolean,
-      required: true
-    },
-    availablePanels: {
-      type: Array as PropType<SideBarPanel<unknown, unknown, unknown>[]>,
-      required: true
-    },
-    panelContext: {
-      type: Object as PropType<SideBarPanelContext<unknown, unknown, unknown>>,
-      required: true
-    },
-    activePanel: {
-      type: String,
-      required: false,
-      default: ''
+const {
+  isOpen,
+  loading,
+  availablePanels,
+  panelContext,
+  activePanel = ''
+} = defineProps<{
+  isOpen: boolean
+  loading: boolean
+  availablePanels: SideBarPanel<unknown, unknown, unknown>[]
+  panelContext: SideBarPanelContext<unknown, unknown, unknown>
+  activePanel?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'selectPanel', panel: string): void
+  (e: 'close'): void
+}>()
+
+defineSlots<{
+  body: () => unknown
+  rootHeader: () => unknown
+  subHeader: () => unknown
+}>()
+
+const { $gettext } = useGettext()
+const appSideBar = useTemplateRef<HTMLElement>('appSideBar')
+
+const rootPanels = computed(() => {
+  return availablePanels.filter((p) => p.isVisible(panelContext) && p.isRoot?.(panelContext))
+})
+const subPanels = computed(() =>
+  availablePanels.filter((p) => p.isVisible(panelContext) && !p.isRoot?.(panelContext))
+)
+const displayPanels = computed<SideBarPanel<unknown, unknown, unknown>[]>(() => {
+  if (unref(rootPanels).length) {
+    return [unref(rootPanels)[0], ...unref(subPanels)]
+  }
+  return unref(subPanels)
+})
+
+const activeSubPanelName = computed(() => {
+  const panelName = activePanel?.split('#')[0]
+  if (!panelName) {
+    return null
+  }
+  if (
+    !unref(subPanels)
+      .map((p) => p.name)
+      .includes(panelName)
+  ) {
+    return null
+  }
+  return panelName
+})
+const hasActiveSubPanel = computed(() => {
+  return unref(activeSubPanelName) !== null
+})
+const hasActiveRootPanel = computed(() => {
+  return unref(activeSubPanelName) === null
+})
+
+const oldPanelName = ref<string>(null)
+const setOldPanelName = (name: string) => {
+  oldPanelName.value = name
+}
+const activePanelName = computed<string>(() => {
+  if (unref(hasActiveSubPanel)) {
+    return unref(activeSubPanelName)
+  }
+  return unref(rootPanels)[0].name
+})
+
+const accessibleLabelBack = computed(() => {
+  if (unref(rootPanels).length === 1) {
+    return $gettext('Back to %{panel} panel', {
+      panel: unref(rootPanels)[0].title(panelContext)
+    })
+  }
+  return $gettext('Back to main panels')
+})
+
+const windowWidth = ref(window.innerWidth)
+
+const fullWidthSideBar = computed(() => unref(windowWidth) <= 580)
+const backgroundContentEl = computed(() => {
+  return unref(appSideBar)?.parentElement?.querySelector('div') as HTMLElement
+})
+
+const onResize = () => {
+  if (!isOpen) {
+    return
+  }
+
+  windowWidth.value = window.innerWidth
+}
+
+watch(
+  () => isOpen,
+  async (isOpen) => {
+    if (!isOpen) {
+      return
+    }
+    await nextTick()
+    if (unref(fullWidthSideBar) && unref(backgroundContentEl)) {
+      // hide content behind sidebar when it has full width to avoid focusable elements
+      unref(backgroundContentEl).style.visibility = 'hidden'
     }
   },
-  emits: ['close', 'selectPanel'],
-  setup(props) {
-    const { $gettext } = useGettext()
-    const appSideBar = useTemplateRef<HTMLElement>('appSideBar')
+  { immediate: true }
+)
 
-    const rootPanels = computed(() => {
-      return props.availablePanels.filter(
-        (p) => p.isVisible(props.panelContext) && p.isRoot?.(props.panelContext)
-      )
-    })
-    const subPanels = computed(() =>
-      props.availablePanels.filter(
-        (p) => p.isVisible(props.panelContext) && !p.isRoot?.(props.panelContext)
-      )
-    )
-    const displayPanels = computed<SideBarPanel<unknown, unknown, unknown>[]>(() => {
-      if (unref(rootPanels).length) {
-        return [unref(rootPanels)[0], ...unref(subPanels)]
-      }
-      return unref(subPanels)
-    })
+const setSidebarPanel = (panel: string) => {
+  emit('selectPanel', panel)
+}
 
-    const activeSubPanelName = computed(() => {
-      const panelName = props.activePanel?.split('#')[0]
-      if (!panelName) {
-        return null
-      }
-      if (
-        !unref(subPanels)
-          .map((p) => p.name)
-          .includes(panelName)
-      ) {
-        return null
-      }
-      return panelName
-    })
-    const hasActiveSubPanel = computed(() => {
-      return unref(activeSubPanelName) !== null
-    })
-    const hasActiveRootPanel = computed(() => {
-      return unref(activeSubPanelName) === null
-    })
+const resetSidebarPanel = () => {
+  emit('selectPanel', null)
+}
 
-    const oldPanelName = ref<string>(null)
-    const clearOldPanelName = () => {
-      oldPanelName.value = null
-    }
-    const setOldPanelName = (name: string) => {
-      oldPanelName.value = name
-    }
-    const activePanelName = computed<string>(() => {
-      if (unref(hasActiveSubPanel)) {
-        return unref(activeSubPanelName)
-      }
-      return unref(rootPanels)[0].name
-    })
+const closeSidebar = () => {
+  emit('close')
+}
 
-    const accessibleLabelBack = computed(() => {
-      if (unref(rootPanels).length === 1) {
-        return $gettext('Back to %{panel} panel', {
-          panel: unref(rootPanels)[0].title(props.panelContext)
-        })
-      }
-      return $gettext('Back to main panels')
-    })
+const openPanel = (panel: string) => {
+  setOldPanelName(unref(activePanelName))
+  setSidebarPanel(panel)
+}
 
-    const windowWidth = ref(window.innerWidth)
+const closePanel = () => {
+  setOldPanelName(unref(activePanelName))
+  resetSidebarPanel()
+  unref(appSideBar).focus()
+}
 
-    const fullWidthSideBar = computed(() => unref(windowWidth) <= 580)
-    const backgroundContentEl = computed(() => {
-      return unref(appSideBar)?.parentElement?.querySelector('div') as HTMLElement
-    })
+onMounted(() => {
+  window.addEventListener('resize', onResize)
+})
 
-    const onResize = () => {
-      if (!props.isOpen) {
-        return
-      }
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', onResize)
 
-      windowWidth.value = window.innerWidth
-    }
-
-    watch(
-      () => props.isOpen,
-      async (isOpen) => {
-        if (!isOpen) {
-          return
-        }
-        await nextTick()
-        if (unref(fullWidthSideBar) && unref(backgroundContentEl)) {
-          // hide content behind sidebar when it has full width to avoid focusable elements
-          unref(backgroundContentEl).style.visibility = 'hidden'
-        }
-      },
-      { immediate: true }
-    )
-
-    onMounted(() => {
-      window.addEventListener('resize', onResize)
-    })
-
-    onBeforeUnmount(() => {
-      window.removeEventListener('resize', onResize)
-
-      if (unref(backgroundContentEl)) {
-        unref(backgroundContentEl).style.visibility = 'visible'
-      }
-    })
-
-    return {
-      appSideBar,
-      displayPanels,
-      rootPanels,
-      subPanels,
-      activeSubPanelName,
-      activePanelName,
-      oldPanelName,
-      clearOldPanelName,
-      setOldPanelName,
-      hasActiveSubPanel,
-      hasActiveRootPanel,
-      accessibleLabelBack,
-      fullWidthSideBar
-    }
-  },
-  methods: {
-    setSidebarPanel(panel: string) {
-      this.$emit('selectPanel', panel)
-    },
-
-    resetSidebarPanel() {
-      this.$emit('selectPanel', null)
-    },
-
-    closeSidebar() {
-      this.$emit('close')
-    },
-
-    openPanel(panel: string) {
-      this.setOldPanelName(this.activePanelName)
-      this.setSidebarPanel(panel)
-    },
-
-    closePanel() {
-      this.setOldPanelName(this.activePanelName)
-      this.resetSidebarPanel()
-      this.appSideBar.focus()
-    }
+  if (unref(backgroundContentEl)) {
+    unref(backgroundContentEl).style.visibility = 'visible'
   }
 })
 </script>

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -258,14 +258,9 @@ export default {
   }
 
   .oc-topbar-right {
-    gap: 10px;
+    gap: 20px;
     grid-area: right;
-    justify-content: space-between;
-
-    @media (min-width: $oc-breakpoint-small-default) {
-      gap: 20px;
-      justify-content: flex-end;
-    }
+    justify-content: flex-end;
   }
 }
 </style>

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -49,7 +49,8 @@ import {
   useAppsStore,
   useAuthStore,
   useExtensionRegistry,
-  useLocalStorage
+  useLocalStorage,
+  useSideBar
 } from '@opencloud-eu/web-pkg'
 import TopBar from '../components/Topbar/TopBar.vue'
 import MessageBar from '../components/MessageBar.vue'
@@ -57,7 +58,6 @@ import SidebarNav from '../components/SidebarNav/SidebarNav.vue'
 import UploadInfo from '../components/UploadInfo.vue'
 import MobileNav from '../components/MobileNav.vue'
 import { NavItem, getExtensionNavItems } from '../helpers/navItems'
-
 import { useActiveApp, useRoute, useRouteMeta, useSpacesLoading } from '@opencloud-eu/web-pkg'
 import {
   computed,
@@ -97,6 +97,7 @@ export default defineComponent({
     const authStore = useAuthStore()
     const activeApp = useActiveApp()
     const extensionRegistry = useExtensionRegistry()
+    const { isSideBarOpen } = useSideBar()
 
     const appsStore = useAppsStore()
     const { apps } = storeToRefs(appsStore)
@@ -136,9 +137,22 @@ export default defineComponent({
 
     const isMobileWidth = ref<boolean>(window.innerWidth < MOBILE_BREAKPOINT)
     provide('isMobileWidth', isMobileWidth)
+
+    const handleLeftSideBarOnResize = () => {
+      const breakpoint = unref(isSideBarOpen) ? 1200 : 960
+      if (window.innerWidth < breakpoint) {
+        setNavBarClosed(true)
+        return
+      }
+      setNavBarClosed(false)
+    }
+
     const onResize = () => {
       isMobileWidth.value = window.innerWidth < MOBILE_BREAKPOINT
+      handleLeftSideBarOnResize()
     }
+
+    watch(isSideBarOpen, handleLeftSideBarOnResize)
 
     const navItems = computed<NavItem[]>(() => {
       if (!authStore.userContextReady) {


### PR DESCRIPTION
Reworks how the sidebars on the left and right behave on smaller screens to improve the mobile experience. The left sidebar now toggles automatically with smaller screen sizes. The right sidebar on the other hand only snaps on screens <580px.

As discussed with @tbsbdr , we currently don't care about the user setting for the left sidebar. That means resizing the screen could potentially expand the sidebar despite the user having it toggled in general. We can tackle this as soon as we correctly persist this setting.

Also fixes the search bar appearance in the mobile view and refactors 2 components to use script setup. So this PR is best reviewed by commits.

closes https://github.com/opencloud-eu/web/issues/212