### PR TITLE
fix: empty public link or OCM share page title

### DIFF
--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -284,7 +284,12 @@ export default defineComponent({
     )
 
     const titleSegments = computed(() => {
-      const segments = [unref(space).name]
+      let title = unref(space).name
+      if (isPublicSpaceResource(unref(space))) {
+        title = unref(space).publicLinkType === 'ocm' ? $gettext('OCM share') : $gettext('Public files')
+      }
+
+      const segments = [title]
       if (props.item !== '/') {
         segments.unshift(basename(props.item))
       }

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -254,10 +254,11 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
       const publicLinkToken = authStore.publicLinkToken
       const publicLinkPassword = authStore.publicLinkPassword
       const publicLinkType = authStore.publicLinkType
+      const publicLinkName = publicLinkType === 'ocm' ? app.config.globalProperties.$gettext('OCM share') : app.config.globalProperties.$gettext('Public files')
 
       const space = buildPublicSpaceResource({
         id: publicLinkToken,
-        name: app.config.globalProperties.$gettext('Public files'),
+        name: publicLinkName,
         ...(publicLinkPassword && { publicLinkPassword }),
         serverUrl: configStore.serverUrl,
         publicLinkType: publicLinkType

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -115,11 +115,16 @@ export default defineComponent({
       return unref(isOcmLink) ? 'ocm' : 'public-link'
     })
 
+    const publicLinkName = computed(() => {
+      return unref(isOcmLink) ? $gettext('OCM share') : $gettext('Public files')
+    })
+
     const publicLinkSpace = computed(() =>
       buildPublicSpaceResource({
         id: unref(token),
         driveType: 'public',
         publicLinkType: unref(publicLinkType),
+        name: unref(publicLinkName),
         ...(unref(password) && { publicLinkPassword: unref(password) })
       })
     )


### PR DESCRIPTION
## Description

Fixes that public link page titles and OCM share page titles looked broken.

## Types of changes

- [x] Bugfix
- [ ] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
