### PR TITLE
chore: remove hoisted dependencies that do not need to be hoisted

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,18 +1,13 @@
 auto-install-peers=true
 shared-workspace-lockfile=true
 
-# @vue/component-compiler-utils
-hoist-pattern[]=sass
+# for md-editor-v3
 hoist-pattern[]=*@codemirror*
 hoist-pattern[]=*@lezer*
-
-# eslint (public so they are picked up by IDEs)
-public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
-
-# Make ODS available to tests, even if the main package does not require it
-public-hoist-pattern[]=@opencloud-eu/design-system
 
 # c.f. https://github.com/vuejs/test-utils/pull/2197
 hoist-pattern[]=@vue/server-renderer
 
+# eslint and prettier (public so they are picked up by IDEs)
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*prettier*


### PR DESCRIPTION
Removes `sass` and `@opencloud-eu/design-system` from our hoisted dependencies because it's not necessary to hoist them. Seems to be a left over from the past.