### PR TITLE
feat: redesign tooltips

### DIFF
--- a/packages/design-system/src/directives/OcTooltip.ts
+++ b/packages/design-system/src/directives/OcTooltip.ts
@@ -23,13 +23,14 @@ export const hideOnEsc = {
   }
 }
 
-export const ariaHidden = {
-  name: 'ariaHidden',
+export const customProps = {
+  name: 'customProps',
   defaultValue: true,
   fn(instance: Instance) {
     return {
       onCreate() {
         instance.popper.setAttribute('aria-hidden', 'true')
+        instance.popper.classList.add('oc-tooltip')
       }
     }
   }
@@ -61,7 +62,7 @@ const initOrUpdate = (el: HTMLElement & { tooltip: any }, { value = {} }: any) =
   const props = merge.all([
     {
       ignoreAttributes: true,
-      interactive: true,
+      interactive: false,
       aria: {
         content: null,
         expanded: false
@@ -73,7 +74,7 @@ const initOrUpdate = (el: HTMLElement & { tooltip: any }, { value = {} }: any) =
   if (!el.tooltip) {
     el.tooltip = tippy(el, {
       ...props,
-      plugins: [hideOnEsc, ariaHidden]
+      plugins: [hideOnEsc, customProps]
     })
     return
   }

--- a/packages/design-system/src/styles/theme/oc-text.scss
+++ b/packages/design-system/src/styles/theme/oc-text.scss
@@ -204,3 +204,7 @@ td.oc-text-break {
     font-weight: $weightValue;
   }
 }
+
+.oc-tooltip .tippy-content {
+  font-size: var(--oc-font-size-small);
+}


### PR DESCRIPTION
Redesigns the tooltips so they are a bit smaller and hide when leaving the root element.

<img width="304" alt="image" src="https://github.com/user-attachments/assets/f2365414-c0d5-4819-ac90-813f13a956b7" />

fixes https://github.com/opencloud-eu/web/issues/295