### PR TITLE
fix: right sidebar snapping in app wrapper

### DIFF
--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -705,7 +705,7 @@ export default defineComponent({
 })
 </script>
 <style lang="scss">
-@media (max-width: $oc-breakpoint-medium-default) {
+@media (max-width: 580px) {
   .app-sidebar-open > *:not(:last-child) {
     display: none;
   }


### PR DESCRIPTION
Follow-up after #251 where we changed the snapping point of the right sidebar.
