### PR TITLE
fix username in e2e test

### DIFF
--- a/tests/e2e/cucumber/features/smoke/activity.feature
+++ b/tests/e2e/cucumber/features/smoke/activity.feature
@@ -54,7 +54,7 @@ Feature: Users can see all activities of the resources and spaces
       | sharedFolder | Alice Hansen renamed textfile.txt to new.txt     |
       | sharedFolder | Public updated textfile.txt in sharedFolder      |
       | sharedFolder | Alice Hansen shared sharedFolder via link        |
-      | sharedFolder | Alice Hansen shared sharedFolder with brian      |
+      | sharedFolder | Alice Hansen shared sharedFolder with Brian      |
       | sharedFolder | Alice Hansen added textfile.txt to sharedFolder  |
       | sharedFolder | Alice Hansen added subFolder to sharedFolder     |
       | sharedFolder | Alice Hansen added sharedFolder to Alice Hansen  |


### PR DESCRIPTION
## Description

after https://github.com/opencloud-eu/web/pull/32/ the activities show the full name of the user. `Brian`, without the surname, also works fine because the test only uses `toContainText` at the end 

## Related Issue
- needed for https://github.com/opencloud-eu/qa/issues/3

## How Has This Been Tested?

ran test case locally

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
