### PR TITLE
allow space activities be checked by regex

### DIFF
--- a/tests/e2e/cucumber/features/smoke/activity.feature
+++ b/tests/e2e/cucumber/features/smoke/activity.feature
@@ -72,6 +72,9 @@ Feature: Users can see all activities of the resources and spaces
       |Alice Hansen shared team via link|
       |Alice Hansen added brian as member of team|
       | Alice Hansen added readme.md to .space |
+    And "Brian" should see activities of the space mathing the following regex
+      | activity                                          |
+      | Alice Hansen added Brian-\w{3,} as member of team |
 
     # see activity in the shared resources
     When "Brian" navigates to the shared with me page

--- a/tests/e2e/cucumber/features/smoke/activity.feature
+++ b/tests/e2e/cucumber/features/smoke/activity.feature
@@ -69,8 +69,7 @@ Feature: Users can see all activities of the resources and spaces
     And "Brian" navigates to the project space "team.1"
     Then "Brian" should see activity of the space
       | activity                               |
-      |Alice Hansen shared team via link|
-      |Alice Hansen added brian as member of team|
+      | Alice Hansen shared team via link      |
       | Alice Hansen added readme.md to .space |
     And "Brian" should see activities of the space mathing the following regex
       | activity                                          |

--- a/tests/e2e/cucumber/steps/ui/spaces.ts
+++ b/tests/e2e/cucumber/steps/ui/spaces.ts
@@ -218,3 +218,15 @@ Then(
     }
   }
 )
+
+Then(
+  '{string} should see activities of the space mathing the following regex',
+  async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const spacesObject = new objects.applicationFiles.Spaces({ page })
+
+    for (const info of stepTable.hashes()) {
+      await spacesObject.checkSpaceActivity({ activity: new RegExp(info.activity) })
+    }
+  }
+)

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -306,7 +306,7 @@ export const checkSpaceActivity = async ({
   activity
 }: {
   page: Page
-  activity: string
+  activity: string|RegExp
 }): Promise<void> => {
   await openActivitiesPanel(page)
   await expect(page.getByTestId(activitySidebarPanel)).toBeVisible()

--- a/tests/e2e/support/objects/app-files/spaces/index.ts
+++ b/tests/e2e/support/objects/app-files/spaces/index.ts
@@ -104,7 +104,7 @@ export class Spaces {
     return po.downloadSpace(this.#page)
   }
 
-  async checkSpaceActivity({ activity }: { activity: string }): Promise<void> {
+  async checkSpaceActivity({ activity }: { activity: string|RegExp }): Promise<void> {
     await po.checkSpaceActivity({ page: this.#page, activity })
   }
 }


### PR DESCRIPTION
## Description

since #32 the activity will contain a random suffix to the user-name. This fixes the issue by allowing to check the string by using regular expressions

## Related Issue

needed for https://github.com/opencloud-eu/qa/issues/3

## How Has This Been Tested?

ran test cases locally

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
