### PR TITLE
Style fixes

### DIFF
--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -58,7 +58,7 @@
     "lodash-es": "^4.17.21",
     "luxon": "^3.5.0",
     "mark.js": "^8.11.1",
-    "md-editor-v3": "^5.2.1",
+    "md-editor-v3": "^5.4.1",
     "oidc-client-ts": "^2.4.0 || ^3.0.0",
     "p-queue": "^8.0.0",
     "password-sheriff": "^1.1.1",

--- a/packages/web-pkg/src/components/AppTopBar.vue
+++ b/packages/web-pkg/src/components/AppTopBar.vue
@@ -221,6 +221,13 @@ export default defineComponent({
   svg {
     fill: var(--oc-role-on-chrome) !important;
   }
+
+  &:hover:not(:disabled) {
+    color: var(--oc-role-on-surface) !important;
+    svg {
+      fill: var(--oc-role-on-surface) !important;
+    }
+  }
 }
 
 .open-file-bar {

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="observerTarget"
-    class="oc-tile-card oc-card oc-card-default oc-rounded"
+    class="oc-tile-card oc-card oc-card-default"
     :data-item-id="resource.id"
     :class="{
       'oc-tile-card-selected': isResourceSelected,
@@ -228,7 +228,7 @@ export default defineComponent({
 
 <style lang="scss">
 .oc-tile-card {
-  background-color: var(--oc-role-surface-container);
+  background-color: var(--oc-role-surface-container) !important;
   box-shadow: none;
   height: 100%;
   display: flex;
@@ -294,7 +294,7 @@ export default defineComponent({
     }
   }
   &:hover {
-    background-color: var(--oc-role-secondary-container);
+    background-color: var(--oc-role-secondary-container) !important;
   }
   &-selected {
     background-color: var(--oc-role-surface-container-high) !important;

--- a/packages/web-pkg/src/components/TextEditor/TextEditor.vue
+++ b/packages/web-pkg/src/components/TextEditor/TextEditor.vue
@@ -164,6 +164,7 @@ export default defineComponent({
     display: none;
   }
 
+  .cm-line:has(.ͼy),
   .cm-line:has(.ͼ1h) {
     max-height: 60px;
     overflow: auto;

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTile.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTile.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`OcTile component > renders default space correctly 1`] = `
-"<div class="oc-tile-card oc-card oc-card-default oc-rounded">
+"<div class="oc-tile-card oc-card oc-card-default">
   <resource-link-stub resource="[object Object]" isresourceclickable="true" class="oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1">
     <div class="oc-tile-card-selection"></div>
     <!--v-if-->
@@ -26,7 +26,7 @@ exports[`OcTile component > renders default space correctly 1`] = `
 `;
 
 exports[`OcTile component > renders disabled space correctly 1`] = `
-"<div class="oc-tile-card oc-card oc-card-default oc-rounded oc-tile-card-disabled">
+"<div class="oc-tile-card oc-card oc-card-default oc-tile-card-disabled">
   <resource-link-stub resource="[object Object]" isresourceclickable="true" class="oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1">
     <div class="oc-tile-card-selection"></div>
     <!--v-if-->

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
   </div>
   <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles">
     <li class="oc-tiles-item has-item-context-menu">
-      <div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
+      <div class="oc-tile-card oc-card oc-card-default" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">
@@ -48,7 +48,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
       </div>
     </li>
     <li class="oc-tiles-item has-item-context-menu">
-      <div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="2" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
+      <div class="oc-tile-card oc-card oc-card-default" data-item-id="2" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,8 +883,8 @@ importers:
         specifier: ^8.11.1
         version: 8.11.1
       md-editor-v3:
-        specifier: ^5.2.1
-        version: 5.3.2(vue@3.5.13(typescript@5.8.2))
+        specifier: ^5.4.1
+        version: 5.4.1(vue@3.5.13(typescript@5.8.2))
       oidc-client-ts:
         specifier: ^2.4.0 || ^3.0.0
         version: 3.1.0
@@ -3016,6 +3016,9 @@ packages:
   '@vavt/cm-extension@1.8.0':
     resolution: {integrity: sha512-lqz5mfyeiWb3iqasvEfgFZsxil8wd5iuRqWeX6eKcGhGN0+Wh+Sbi1qmlNzqyaXngC5EFgZ12hR6NI4XKuY65g==}
 
+  '@vavt/copy2clipboard@1.0.1':
+    resolution: {integrity: sha512-XkULyKbB4KeYOn2q2JxMbhu2+UiSrwMU745dfwaYC/oFPsYaXPdGed/zV34xGP59+fgI2VqeQ2xmfKkMSvRvzw==}
+
   '@vavt/util@2.1.0':
     resolution: {integrity: sha512-YIfAvArSFVXmWvoF+DEGD0FhkhVNcCtVWWkfYtj76eSrwHh/wuEEFhiEubg1XLNM3tChO8FH8xJCT/hnizjgFQ==}
 
@@ -3688,9 +3691,6 @@ packages:
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
-
-  copy-to-clipboard@3.3.3:
-    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
   core-js-compat@3.40.0:
     resolution: {integrity: sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==}
@@ -4918,8 +4918,8 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  md-editor-v3@5.3.2:
-    resolution: {integrity: sha512-O3gV4X3+x8QZava2pzJfVb06dqO1Y1UrmUpHS0E7htblqq0MQ67yrLLkTkVYIxF04Tj8Ub67pc8fypR3uT8FUA==}
+  md-editor-v3@5.4.1:
+    resolution: {integrity: sha512-G/jxlB8yyrh2RDAHb1DOA31Q54Bz+ftxBc2xNlQ02GDvNBplI1PpVCrkW3zsy1+r4GdLyXzuxdQeJSiyX531/Q==}
     peerDependencies:
       vue: ^3.5.3
 
@@ -6090,9 +6090,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  toggle-selection@1.0.6:
-    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
@@ -8950,6 +8947,8 @@ snapshots:
 
   '@vavt/cm-extension@1.8.0': {}
 
+  '@vavt/copy2clipboard@1.0.1': {}
+
   '@vavt/util@2.1.0': {}
 
   '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.13.2)(sass@1.85.1))(vue@3.5.13(typescript@5.8.2))':
@@ -9706,10 +9705,6 @@ snapshots:
   copy-anything@3.0.5:
     dependencies:
       is-what: 4.1.16
-
-  copy-to-clipboard@3.3.3:
-    dependencies:
-      toggle-selection: 1.0.6
 
   core-js-compat@3.40.0:
     dependencies:
@@ -11035,14 +11030,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  md-editor-v3@5.3.2(vue@3.5.13(typescript@5.8.2)):
+  md-editor-v3@5.4.1(vue@3.5.13(typescript@5.8.2)):
     dependencies:
       '@codemirror/lang-markdown': 6.3.2
       '@codemirror/language-data': 6.5.1
       '@types/markdown-it': 14.1.2
+      '@vavt/copy2clipboard': 1.0.1
       '@vavt/util': 2.1.0
       codemirror: 6.0.1
-      copy-to-clipboard: 3.3.3
       lru-cache: 11.0.2
       lucide-vue-next: 0.453.0(vue@3.5.13(typescript@5.8.2))
       markdown-it: 14.1.0
@@ -12252,8 +12247,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toggle-selection@1.0.6: {}
 
   toposort@2.0.2: {}
 


### PR DESCRIPTION
## Description

Same style fixes, namely:
1. Resource tile background was `surface` instead of `surface-container` when built trough `pnpm build` (was ok when built through `pnpm vite`).
2. Text editor long URLs were not collapsed in a production build (css class names for the selector are different in `pnpm build` and `pnpm vite`)
3. hover color on AppTopBar action buttons

## Types of changes
- [x] Bugfix
- [ ] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
