### PR TITLE
e2e. fix collaboration sharing flaky

### DIFF
--- a/tests/e2e/support/objects/app-files/share/collaborator.ts
+++ b/tests/e2e/support/objects/app-files/share/collaborator.ts
@@ -60,8 +60,7 @@ export type CollaboratorType = 'user' | 'group'
 export default class Collaborator {
   private static readonly invitePanel = '//*[@id="oc-files-sharing-sidebar"]'
   private static readonly inviteInput = '#files-share-invite-input'
-  private static readonly newCollaboratorRoleDropdown =
-    '//*[@id="files-collaborators-role-button-new"]'
+  private static readonly newCollaboratorRoleDropdown = '#files-collaborators-role-button-new'
   private static readonly sendInvitationButton = '#new-collaborators-form-create-button'
   public static readonly collaboratorRoleDropdownButton =
     '%s//button[contains(@class,"files-recipient-role-select-btn")]'
@@ -155,8 +154,9 @@ export default class Collaborator {
       dropdownSelector = Collaborator.newCollaboratorRoleDropdown
       itemSelector = util.format(Collaborator.collaboratorRoleItemSelector, '')
     }
-    await page.click(dropdownSelector)
-
+    // added an additional click to remove flaky
+    await page.locator('#new-collaborators-form').click()
+    await page.locator(dropdownSelector).click()
     return await page.click(util.format(itemSelector, role))
   }
 


### PR DESCRIPTION
file-action/groupActions.feature:7 
```
✖ And "Alice" shares the following resources using the sidebar panel # file:/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/cucumber/steps/ui/shares.ts:23
       | resource     | recipient | type  | role     |
       | sharedFolder | Brian     | user  | Can edit |
       | sharedFolder | Carol     | user  | Can edit |
       | sharedFolder | David     | user  | Can edit |
       | sharedFolder | Edith     | user  | Can edit |
       | sharedFolder | sales     | group | Can edit |
       | sharedFolder | finance   | group | Can edit |
       | sharedFolder | security  | group | Can edit |
       page.click: Timeout 30000ms exceeded.
       Call log:
         - waiting for locator('//span[contains(@class,"roles-select-role-item")]/span[text()="Can edit"]')

           at Collaborator.setCollaboratorRole (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/support/objects/app-files/share/collaborator.ts:72:27)
```

after the recipients have been added, tests tries to click by role dropdown. but in this particular test (probably because there are many recipients) an additional click is required. 

https://github.com/user-attachments/assets/199422d4-667b-4efa-8666-7dfc4a33fc77

that was the reason flaky test https://ci.opencloud.eu/repos/3/pipeline/403/169