### PR TITLE
chore: group renovate dev dependencies

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,5 +4,13 @@
   "prConcurrentLimit": 15,
   "ignoreDeps": ["@adobe/leonardo-contrast-colors"],
   "postUpdateOptions": ["pnpmDedupe"],
-  "labels": ["Type:Dependencies"]
+  "labels": ["Type:Dependencies"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)",
+      "groupSlug": "dev-dependencies"
+    }
+  ]
 }


### PR DESCRIPTION
There is no need for renovate to create a separate PR for every (minor) dev dependency upgrade, hence group them together.
