### PR TITLE
chore(prettier-config): make prettier a peer dependency

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -14,7 +14,7 @@
   "exports": {
     ".": "./index.js"
   },
-  "dependencies": {
+  "peerDependencies": {
     "prettier": "^3.0.0"
   }
 }


### PR DESCRIPTION
Declares `prettier` as a peer dependency because it's supposed to be provided by the user of this package. The package should only provide the config for it.
