### PR TITLE
fix: file, folder and space count in right sidebar

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetailsMultiple.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetailsMultiple.vue
@@ -14,68 +14,59 @@
     </div>
   </div>
 </template>
-<script lang="ts">
-import { computed, defineComponent, unref } from 'vue'
+<script setup lang="ts">
+import { computed, unref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { formatFileSize, useResourcesStore } from '@opencloud-eu/web-pkg'
 import { useGettext } from 'vue3-gettext'
 
-export default defineComponent({
-  name: 'FileDetailsMultiple',
-  props: {
-    showSpaceCount: { type: Boolean, default: false }
-  },
-  setup() {
-    const { $gettext, current: currentLanguage } = useGettext()
-    const resourcesStore = useResourcesStore()
-    const { selectedResources } = storeToRefs(resourcesStore)
+const { showSpaceCount = false } = defineProps<{ showSpaceCount?: boolean }>()
 
-    const hasSize = computed(() => {
-      return unref(selectedResources).some((resource) => Object.hasOwn(resource, 'size'))
-    })
+const { $gettext, $ngettext, current: currentLanguage } = useGettext()
+const resourcesStore = useResourcesStore()
+const { selectedResources } = storeToRefs(resourcesStore)
 
-    const filesCount = computed(() => {
-      return unref(selectedResources).filter((i) => i.type === 'file').length
-    })
+const hasSize = computed(() => {
+  return unref(selectedResources).some((resource) => Object.hasOwn(resource, 'size'))
+})
 
-    const foldersCount = computed(() => {
-      return unref(selectedResources).filter((i) => i.type === 'folder').length
-    })
+const filesCount = computed(() => {
+  return unref(selectedResources).filter((i) => i.type === 'file').length
+})
 
-    const spacesCount = computed(() => {
-      return unref(selectedResources).filter((i) => i.type === 'space').length
-    })
+const foldersCount = computed(() => {
+  return unref(selectedResources).filter((i) => i.type === 'folder').length
+})
 
-    const sizeValue = computed(() => {
-      let size = 0
-      unref(selectedResources).forEach((i) => (size += parseInt(i.size?.toString() || '0')))
-      return formatFileSize(size, currentLanguage)
-    })
+const spacesCount = computed(() => {
+  return unref(selectedResources).filter((i) => i.type === 'space').length
+})
 
-    const details = computed(() => [
-      { term: $gettext('Files'), definition: unref(filesCount) },
-      { term: $gettext('Folders'), definition: unref(foldersCount) },
-      { term: $gettext('Spaces'), definition: unref(spacesCount) },
-      { term: $gettext('Size'), definition: unref(sizeValue) }
-    ])
+const sizeValue = computed(() => {
+  let size = 0
+  unref(selectedResources).forEach((i) => (size += parseInt(i.size?.toString() || '0')))
+  return formatFileSize(size, currentLanguage)
+})
 
-    return { hasSize, selectedResources, details }
-  },
-  computed: {
-    selectedFilesCount() {
-      return this.selectedResources.length
-    },
-    selectedFilesString() {
-      return this.$ngettext(
-        '%{ itemCount } item selected',
-        '%{ itemCount } items selected',
-        this.selectedFilesCount,
-        {
-          itemCount: this.selectedFilesCount.toString()
-        }
-      )
+const details = computed(() => [
+  { term: $gettext('Files'), definition: unref(filesCount) },
+  { term: $gettext('Folders'), definition: unref(foldersCount) },
+  ...((showSpaceCount && [{ term: $gettext('Spaces'), definition: unref(spacesCount) }]) || []),
+  ...((unref(hasSize) && [{ term: $gettext('Size'), definition: unref(sizeValue) }]) || [])
+])
+
+const selectedFilesCount = computed(() => {
+  return unref(selectedResources).length
+})
+const selectedFilesString = computed(() => {
+  return $ngettext(
+    '%{ itemCount } item selected',
+    '%{ itemCount } items selected',
+    unref(selectedFilesCount),
+    {
+      itemCount: unref(selectedFilesCount).toString()
     }
-  }
+  )
 })
 </script>
 <style lang="scss" scoped>

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetailsMultiple.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetailsMultiple.vue
@@ -52,12 +52,12 @@ export default defineComponent({
       return formatFileSize(size, currentLanguage)
     })
 
-    const details = [
+    const details = computed(() => [
       { term: $gettext('Files'), definition: unref(filesCount) },
       { term: $gettext('Folders'), definition: unref(foldersCount) },
       { term: $gettext('Spaces'), definition: unref(spacesCount) },
       { term: $gettext('Size'), definition: unref(sizeValue) }
-    ]
+    ])
 
     return { hasSize, selectedResources, details }
   },

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetailsMultiple.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetailsMultiple.vue
@@ -73,13 +73,13 @@ export default defineComponent({
       )
     })
 
-    const items = [
+    const items = computed(() => [
       { term: $gettext('Total quota:'), definition: unref(totalSelectedSpaceQuotaTotal) },
       { term: $gettext('Remaining quota:'), definition: unref(totalSelectedSpaceQuotaRemaining) },
       { term: $gettext('Used quota:'), definition: unref(totalSelectedSpaceQuotaUsed) },
       { term: $gettext('Enabled:'), definition: unref(totalEnabledSpaces) },
       { term: $gettext('Disabled:'), definition: unref(totalDisabledSpaces) }
-    ]
+    ])
 
     return {
       detailsTableLabel,

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetailsMultiple.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetailsMultiple.vue
@@ -9,85 +9,72 @@
     <oc-definition-list :aria-label="detailsTableLabel" :items="items" />
   </div>
 </template>
-<script lang="ts">
+<script setup lang="ts">
 import { formatFileSize } from '../../../../helpers'
-import { computed, defineComponent, PropType, unref } from 'vue'
+import { computed, unref } from 'vue'
 import { SpaceResource } from '@opencloud-eu/web-client'
 import { useGettext } from 'vue3-gettext'
 
-export default defineComponent({
-  name: 'SpaceDetailsMultiple',
-  props: {
-    selectedSpaces: {
-      type: Array as PropType<Array<SpaceResource>>,
-      required: true
-    }
-  },
-  setup(props) {
-    const language = useGettext()
-    const { $gettext, $ngettext } = language
-    const totalSelectedSpaceQuotaTotal = computed(() => {
-      let total = 0
-      props.selectedSpaces.forEach((space) => {
-        total += space.spaceQuota.total
-      })
-      return formatFileSize(total, language.current)
-    })
-    const totalSelectedSpaceQuotaRemaining = computed(() => {
-      let remaining = 0
-      props.selectedSpaces.forEach((space) => {
-        if (space.disabled) {
-          return
-        }
-        remaining += space.spaceQuota.remaining
-      })
-      return formatFileSize(remaining, language.current)
-    })
-    const totalSelectedSpaceQuotaUsed = computed(() => {
-      let used = 0
-      props.selectedSpaces.forEach((space) => {
-        if (space.disabled) {
-          return
-        }
-        used += space.spaceQuota.used
-      })
-      return formatFileSize(used, language.current)
-    })
-    const totalEnabledSpaces = computed(() => {
-      return props.selectedSpaces.filter((s) => !s.disabled).length
-    })
-    const totalDisabledSpaces = computed(() => {
-      return props.selectedSpaces.filter((s) => s.disabled).length
-    })
-    const detailsTableLabel = computed(() => {
-      return $gettext('Overview of the information about the selected spaces')
-    })
-    const selectedSpacesString = computed(() => {
-      return $ngettext(
-        '%{ itemCount } space selected',
-        '%{ itemCount } spaces selected',
-        props.selectedSpaces.length,
-        {
-          itemCount: props.selectedSpaces.length.toString()
-        }
-      )
-    })
+const { selectedSpaces } = defineProps<{
+  selectedSpaces: SpaceResource[]
+}>()
 
-    const items = computed(() => [
-      { term: $gettext('Total quota:'), definition: unref(totalSelectedSpaceQuotaTotal) },
-      { term: $gettext('Remaining quota:'), definition: unref(totalSelectedSpaceQuotaRemaining) },
-      { term: $gettext('Used quota:'), definition: unref(totalSelectedSpaceQuotaUsed) },
-      { term: $gettext('Enabled:'), definition: unref(totalEnabledSpaces) },
-      { term: $gettext('Disabled:'), definition: unref(totalDisabledSpaces) }
-    ])
-
-    return {
-      detailsTableLabel,
-      items,
-      selectedSpacesString
-    }
-  }
+const language = useGettext()
+const { $gettext, $ngettext } = language
+const totalSelectedSpaceQuotaTotal = computed(() => {
+  let total = 0
+  selectedSpaces.forEach((space) => {
+    total += space.spaceQuota.total
+  })
+  return formatFileSize(total, language.current)
 })
+const totalSelectedSpaceQuotaRemaining = computed(() => {
+  let remaining = 0
+  selectedSpaces.forEach((space) => {
+    if (space.disabled) {
+      return
+    }
+    remaining += space.spaceQuota.remaining
+  })
+  return formatFileSize(remaining, language.current)
+})
+const totalSelectedSpaceQuotaUsed = computed(() => {
+  let used = 0
+  selectedSpaces.forEach((space) => {
+    if (space.disabled) {
+      return
+    }
+    used += space.spaceQuota.used
+  })
+  return formatFileSize(used, language.current)
+})
+const totalEnabledSpaces = computed(() => {
+  return selectedSpaces.filter((s) => !s.disabled).length
+})
+const totalDisabledSpaces = computed(() => {
+  return selectedSpaces.filter((s) => s.disabled).length
+})
+const detailsTableLabel = computed(() => {
+  return $gettext('Overview of the information about the selected spaces')
+})
+const selectedSpacesString = computed(() => {
+  return $ngettext(
+    '%{ itemCount } space selected',
+    '%{ itemCount } spaces selected',
+    selectedSpaces.length,
+    {
+      itemCount: selectedSpaces.length.toString()
+    }
+  )
+})
+
+const items = computed(() => [
+  { term: $gettext('Total quota:'), definition: unref(totalSelectedSpaceQuotaTotal) },
+  { term: $gettext('Remaining quota:'), definition: unref(totalSelectedSpaceQuotaRemaining) },
+  { term: $gettext('Used quota:'), definition: unref(totalSelectedSpaceQuotaUsed) },
+  { term: $gettext('Enabled:'), definition: unref(totalEnabledSpaces) },
+  { term: $gettext('Disabled:'), definition: unref(totalDisabledSpaces) }
+])
 </script>
 <style lang="scss" scoped>
 #oc-spaces-details-multiple-sidebar {


### PR DESCRIPTION
Fixes the file, folder and space count in the right sidebar when selecting multiple items and refactors the components to script setup (separated into multiple commits to ease review).

fixes https://github.com/opencloud-eu/web/issues/351