### PR TITLE
Be less strict when waiting for the "change quota" responses

### DIFF
--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -107,7 +107,7 @@ export const changeQuota = async (args: {
   await Promise.all([
     page.waitForResponse(
       (resp) =>
-        resp.url().endsWith(encodeURIComponent(uuid)) &&
+        resp.url().includes('drives') &&
         resp.status() === 200 &&
         resp.request().method() === 'PATCH'
     ),
@@ -130,7 +130,7 @@ export const changeQuotaUsingBatchAction = async (args: {
     checkResponses.push(
       page.waitForResponse(
         (resp) =>
-          resp.url().endsWith(encodeURIComponent(id)) &&
+          resp.url().includes('drives') &&
           resp.status() === 200 &&
           resp.request().method() === 'PATCH'
       )


### PR DESCRIPTION
That fixes a problem when running against a posix storage because posix does not use the user ids as the personal space ids.