### PR TITLE
feat(runtime): enhance app token modal copy view styling

### DIFF
--- a/packages/web-runtime/src/components/Modals/AppTokenModal.vue
+++ b/packages/web-runtime/src/components/Modals/AppTokenModal.vue
@@ -33,24 +33,26 @@
       "
     />
     <div class="oc-mt-m oc-mb-s oc-flex oc-flex-middle oc-rounded">
-      <div class="created-token-container oc-pr-m">
-        <span class="created-token" v-text="createdToken" />
-        <div class="oc-text-small">
+      <div class="created-token-container">
+        <div class="created-token oc-rounded oc-p-s">
+          {{ createdToken }}
+          <oc-button
+            v-oc-tooltip="$gettext('Copy app token to clipboard')"
+            appearance="raw"
+            class="copy-app-token-btn oc-ml-s oc-p-xs"
+            :aria-label="$gettext('Copy app token to clipboard')"
+            @click="copy(createdToken)"
+          >
+            <oc-icon :name="copied ? 'check' : 'file-copy'" fill-type="line" />
+          </oc-button>
+        </div>
+        <div class="oc-text-small oc-text-right oc-mt-s">
           <span v-text="$gettext('Expires on:')" />
           <span v-text="formatDateFromDateTime(expiryDate, currentLanguage)" />
         </div>
       </div>
-      <oc-button
-        v-oc-tooltip="$gettext('Copy app token to clipboard')"
-        appearance="raw"
-        class="copy-app-token-btn oc-ml-s oc-p-xs"
-        :aria-label="$gettext('Copy app token to clipboard')"
-        @click="copy(createdToken)"
-      >
-        <oc-icon :name="copied ? 'check' : 'file-copy'" fill-type="line" />
-      </oc-button>
     </div>
-    <div class="link-modal-actions oc-flex oc-flex-right oc-flex-middle oc-mt-s">
+    <div class="link-modal-actions oc-flex oc-flex-right oc-flex-middle oc-mt-l">
       <oc-button
         class="oc-modal-body-actions-confirm oc-ml-s"
         appearance="filled"
@@ -102,8 +104,13 @@ const createAppToken = async () => {
 <style lang="scss" scoped>
 .created-token {
   font-weight: bold;
+  background-color: var(--oc-role-surface-container-high);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
   &-container {
-    border-right: 0.5px solid var(--oc-role-outline-variant);
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## Description

Since the app token passwords will be longer from now on, the modal was looking weird. Restyled it a little bit.

<img width="523" alt="Screenshot 2025-03-20 at 11 22 34" src="https://github.com/user-attachments/assets/76f97641-bd01-4aaf-91a9-a184fdb39fac" />


## Types of changes

- [ ] Bugfix
- [x] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)

