### PR TITLE
fix(pkg): add missing delete queue to tiles view

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -55,6 +55,7 @@
         v-if="isResourceInDeleteQueue(item.id)"
         class="resource-table-activity-indicator"
         size="medium"
+        :aria-label="$gettext('File is being processed')"
       />
 
       <oc-checkbox

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -86,8 +86,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType } from 'vue'
+<script setup lang="ts">
+import { computed, customRef, ref, unref } from 'vue'
 import ResourceIcon from './ResourceIcon.vue'
 import ResourceListItem from './ResourceListItem.vue'
 import ResourceLink from './ResourceLink.vue'
@@ -96,141 +96,111 @@ import { useGettext } from 'vue3-gettext'
 import { isSpaceResource } from '@opencloud-eu/web-client'
 import { RouteLocationRaw } from 'vue-router'
 import { useIsVisible } from '@opencloud-eu/design-system/composables'
-import { customRef, ref, unref } from 'vue'
+import { SizeType } from '@opencloud-eu/design-system/helpers'
 
-export default defineComponent({
-  name: 'ResourceTile',
-  components: { ResourceListItem, ResourceIcon, ResourceLink },
-  props: {
-    /**
-     * Resource to be displayed within the tile
-     */
-    resource: {
-      type: Object as PropType<Resource>,
-      default: () => ({})
+const {
+  resource,
+  resourceRoute,
+  isResourceSelected = false,
+  isResourceClickable = true,
+  isResourceDisabled = false,
+  isExtensionDisplayed = true,
+  resourceIconSize = 'xlarge',
+  lazy = false,
+  isLoading = false
+} = defineProps<{
+  resource?: Resource
+  resourceRoute?: RouteLocationRaw
+  isResourceSelected?: boolean
+  isResourceClickable?: boolean
+  isResourceDisabled?: boolean
+  isExtensionDisplayed?: boolean
+  resourceIconSize?: SizeType
+  lazy?: boolean
+  isLoading?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'click'): void
+  (e: 'contextmenu', event: Event): void
+  (e: 'itemVisible'): void
+}>()
+
+defineSlots<{
+  actions?: (props: { item: Resource }) => unknown
+  contextMenu?: (props: { item: Resource }) => unknown
+  imageField?: (props: { item: Resource }) => unknown
+  indicators?: (props: { item: Resource }) => unknown
+  selection?: (props: { item: Resource }) => unknown
+}>()
+
+const { $gettext } = useGettext()
+
+const observerTarget = customRef((track, trigger) => {
+  let $el: HTMLElement
+  return {
+    get() {
+      track()
+      return $el
     },
-    resourceRoute: {
-      type: Object as PropType<RouteLocationRaw>,
-      required: false,
-      default: null
-    },
-    isResourceSelected: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    isResourceClickable: {
-      type: Boolean,
-      required: false,
-      default: true
-    },
-    isResourceDisabled: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    isExtensionDisplayed: {
-      type: Boolean,
-      default: true
-    },
-    resourceIconSize: {
-      type: String,
-      default: 'xlarge',
-      validator: (value: string) => {
-        return ['large', 'xlarge', 'xxlarge', 'xxxlarge'].includes(value)
-      }
-    },
-    lazy: {
-      type: Boolean,
-      default: false
-    },
-    isLoading: {
-      type: Boolean,
-      default: false
-    }
-  },
-  emits: ['click', 'contextmenu', 'itemVisible'],
-  setup(props, { emit }) {
-    const { $gettext } = useGettext()
-
-    const observerTarget = customRef((track, trigger) => {
-      let $el: HTMLElement
-      return {
-        get() {
-          track()
-          return $el
-        },
-        set(value) {
-          $el = value
-          trigger()
-        }
-      }
-    })
-
-    const showStatusIcon = computed(() => {
-      return props.resource.locked || props.resource.processing
-    })
-
-    const statusIconAttrs = computed(() => {
-      if (props.resource.locked) {
-        return {
-          name: 'lock',
-          fillType: 'fill'
-        }
-      }
-
-      if (props.resource.processing) {
-        return {
-          name: 'loop-right',
-          fillType: 'line'
-        }
-      }
-
-      return {}
-    })
-
-    const tooltipLabelIcon = computed(() => {
-      if (props.resource.locked) {
-        return $gettext('This item is locked')
-      }
-      return null
-    })
-    const resourceDescription = computed(() => {
-      if (isSpaceResource(props.resource)) {
-        return props.resource.description
-      }
-      return ''
-    })
-
-    const shouldDisplayThumbnails = (resource: Resource) => {
-      return resource.thumbnail
-    }
-
-    const { isVisible } = props.lazy
-      ? useIsVisible({
-          target: observerTarget,
-          onVisibleCallback: () => emit('itemVisible')
-        })
-      : { isVisible: ref(true) }
-
-    const isHidden = computed(() => !unref(isVisible))
-
-    if (!props.lazy) {
-      emit('itemVisible')
-    }
-
-    return {
-      statusIconAttrs,
-      showStatusIcon,
-      tooltipLabelIcon,
-      resourceDescription,
-      shouldDisplayThumbnails,
-      isProjectSpaceResource,
-      isHidden,
-      observerTarget
+    set(value) {
+      $el = value
+      trigger()
     }
   }
 })
+
+const showStatusIcon = computed(() => {
+  return resource.locked || resource.processing
+})
+
+const statusIconAttrs = computed(() => {
+  if (resource.locked) {
+    return {
+      name: 'lock',
+      fillType: 'fill'
+    }
+  }
+
+  if (resource.processing) {
+    return {
+      name: 'loop-right',
+      fillType: 'line'
+    }
+  }
+
+  return {}
+})
+
+const tooltipLabelIcon = computed(() => {
+  if (resource.locked) {
+    return $gettext('This item is locked')
+  }
+  return null
+})
+const resourceDescription = computed(() => {
+  if (isSpaceResource(resource)) {
+    return resource.description
+  }
+  return ''
+})
+
+const shouldDisplayThumbnails = (resource: Resource) => {
+  return resource.thumbnail
+}
+
+const { isVisible } = lazy
+  ? useIsVisible({
+      target: observerTarget,
+      onVisibleCallback: () => emit('itemVisible')
+    })
+  : { isVisible: ref(true) }
+
+const isHidden = computed(() => !unref(isVisible))
+
+if (!lazy) {
+  emit('itemVisible')
+}
 </script>
 
 <style lang="scss">

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -21,7 +21,10 @@
         @click="$emit('click')"
       >
         <div class="oc-tile-card-selection">
-          <slot name="selection" :item="resource" />
+          <div v-if="isLoading" class="oc-tile-card-loading-spinner oc-m-s">
+            <oc-spinner :aria-label="$gettext('File is being processed')" />
+          </div>
+          <slot v-else name="selection" :item="resource" />
         </div>
         <oc-tag
           v-if="isResourceDisabled && isProjectSpaceResource(resource)"
@@ -140,6 +143,10 @@ export default defineComponent({
     lazy: {
       type: Boolean,
       default: false
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['click', 'contextmenu', 'itemVisible'],
@@ -244,6 +251,10 @@ export default defineComponent({
     span.oc-status-indicators-indicator {
       pointer-events: all;
     }
+  }
+
+  &-loading-spinner {
+    z-index: 99;
   }
 
   &.state-trashed {

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -39,11 +39,7 @@
           :aria-label="tooltipLabelIcon"
         >
           <slot name="imageField" :item="resource">
-            <oc-image
-              v-if="shouldDisplayThumbnails(resource)"
-              class="tile-preview"
-              :src="resource.thumbnail"
-            />
+            <oc-image v-if="resource.thumbnail" class="tile-preview" :src="resource.thumbnail" />
             <resource-icon
               v-else
               :resource="resource"
@@ -184,10 +180,6 @@ const resourceDescription = computed(() => {
   }
   return ''
 })
-
-const shouldDisplayThumbnails = (resource: Resource) => {
-  return resource.thumbnail
-}
 
 const { isVisible } = lazy
   ? useIsVisible({

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -176,6 +176,7 @@ import {
   routeToContextQuery,
   useRouter
 } from '../../composables'
+import { SizeType } from '@opencloud-eu/design-system/helpers'
 
 type ResourceTileRef = ComponentPublicInstance<typeof ResourceTile>
 type ContextMenuQuickActionRef = ComponentPublicInstance<typeof ContextMenuQuickAction>
@@ -450,7 +451,7 @@ const selectSorting = (field: SortField) => {
   emit('sort', { sortBy: field.name, sortDir: field.sortDir })
 }
 
-const resourceIconSize = computed(() => {
+const resourceIconSize = computed<SizeType>(() => {
   const sizeMap: Record<number, string> = {
     1: 'xlarge',
     2: 'xlarge',
@@ -460,7 +461,7 @@ const resourceIconSize = computed(() => {
     6: 'xxxlarge'
   }
   const size = unref(viewSizeCurrent)
-  return sizeMap[size] ?? 'xxlarge'
+  return (sizeMap[size] ?? 'xxlarge') as SizeType
 })
 onBeforeUpdate(() => {
   tileRefs.value = {

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -60,6 +60,7 @@
           :resource-icon-size="resourceIconSize"
           :draggable="dragDrop"
           :lazy="lazy"
+          :is-loading="isResourceInDeleteQueue(resource.id)"
           @vue:mounted="
             $emit('rowMounted', resource, tileRefs.tiles[resource.id], ImageDimension.Tile)
           "
@@ -347,6 +348,10 @@ const isResourceDisabled = (resource: Resource) => {
     )
   }
 
+  if (isResourceInDeleteQueue(resource.id)) {
+    return true
+  }
+
   return resource.processing === true
 }
 
@@ -563,6 +568,10 @@ const areAllResourcesSelected = computed(() => {
 
   return !allResourcesDisabled && allSelected
 })
+
+const isResourceInDeleteQueue = (id: string): boolean => {
+  return resourcesStore.deleteQueue.includes(id)
+}
 
 watch(
   tileSizePixels,

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTile.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTile.spec.ts
@@ -30,6 +30,10 @@ describe('OcTile component', () => {
       expect(wrapper.find('resource-icon-stub').attributes().size).toEqual(resourceIconSize)
     }
   )
+  it('shows a loading spinner if isLoading is set to true', () => {
+    const wrapper = getWrapper({ resource: getSpaceMock(), isLoading: true })
+    expect(wrapper.find('.oc-tile-card-loading-spinner').exists()).toBeTruthy()
+  })
 
   function getWrapper(props = {}) {
     return shallowMount(ResourceTile, {

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -245,6 +245,12 @@ describe('ResourceTiles component', () => {
       expect(Object.keys(checkbox.attributes())).toContain('disabled')
     })
   })
+  describe('delete queue', () => {
+    it('sets resources that are in the delete queue in a loading state', () => {
+      const { wrapper } = getWrapper({ props: { resources }, deleteQueue: [resources[0].id] })
+      expect(wrapper.find('.oc-tile-card-loading-spinner').exists()).toBeTruthy()
+    })
+  })
 
   it.each([
     { viewSize: 1, expected: 'xlarge' },
@@ -267,7 +273,8 @@ describe('ResourceTiles component', () => {
     props = {},
     slots = {},
     stubs = {},
-    canBeOpenedWithSecureView = true
+    canBeOpenedWithSecureView = true,
+    deleteQueue = []
   } = {}) {
     const mocks = defaultComponentMocks()
 
@@ -286,7 +293,7 @@ describe('ResourceTiles component', () => {
           ...slots
         },
         global: {
-          plugins: [...defaultPlugins()],
+          plugins: [...defaultPlugins({ piniaOptions: { resourcesStore: { deleteQueue } } })],
           mocks: mocks,
           provide: mocks,
           stubs


### PR DESCRIPTION
Adds the missing delete queue to the tiles view by also adding a loading state to the component. Refactors it to script setup on the way. This PR is best reviewed by its individual commits.

fixes https://github.com/opencloud-eu/web/issues/380