### PR TITLE
Make app token "label" field available to users

### DIFF
--- a/packages/design-system/src/helpers/types.ts
+++ b/packages/design-system/src/helpers/types.ts
@@ -46,10 +46,10 @@ export type FieldType = {
   headerType?: string
   type?: string
   callback?: any
-  alignH?: string
-  alignV?: string
-  width?: string
-  wrap?: string
+  alignH?: 'left' | 'center' | 'right'
+  alignV?: 'top' | 'middle' | 'bottom'
+  width?: 'auto' | 'shrink' | 'expand'
+  wrap?: 'break' | 'nowrap' | 'truncate'
   thClass?: string
   tdClass?: string
   sortable?: boolean

--- a/packages/web-runtime/src/components/Account/AppTokens.vue
+++ b/packages/web-runtime/src/components/Account/AppTokens.vue
@@ -30,6 +30,11 @@
     />
     <div v-else>
       <oc-table :data="visibleAppTokens" :fields="tableFields">
+        <template #label="{ item }">
+          <div class="oc-width-1-1 oc-text-truncate">
+            <span v-text="item.label || '-'" />
+          </div>
+        </template>
         <template #creationDate="{ item }">
           <div class="oc-width-1-1 oc-text-truncate">
             <span v-text="formatDateFromISO(item.created_date, currentLanguage)" />
@@ -151,6 +156,13 @@ const visibleAppTokens = computed(() => {
 const tableFields = computed(() => {
   return [
     {
+      name: 'label',
+      type: 'slot',
+      wrap: 'truncate',
+      width: 'expand',
+      title: $gettext('Note')
+    },
+    {
       name: 'creationDate',
       type: 'slot',
       wrap: 'truncate',
@@ -166,6 +178,7 @@ const tableFields = computed(() => {
       name: 'actions',
       type: 'slot',
       alignH: 'right',
+      width: 'shrink',
       title: $gettext('Actions')
     }
   ]

--- a/packages/web-runtime/tests/unit/components/Modals/AppTokenModal.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Modals/AppTokenModal.spec.ts
@@ -82,12 +82,12 @@ describe('AppTokenModal component', () => {
   })
 })
 
-const emitNoteInput = (wrapper: VueWrapper<any>, note: string) => {
+const emitNoteInput = (wrapper: VueWrapper<typeof AppTokenModal.vm>, note: string) => {
   wrapper
     .findComponent<typeof OcTextInput>('oc-text-input-stub')
     .vm.$emit('update:modelValue', note)
 }
-const emitDateInput = (wrapper: VueWrapper<any>, date: DateTime) => {
+const emitDateInput = (wrapper: VueWrapper<typeof AppTokenModal.vm>, date: DateTime) => {
   wrapper
     .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
     .vm.$emit('dateChanged', { date, error: null })

--- a/packages/web-runtime/tests/unit/components/Modals/AppTokenModal.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Modals/AppTokenModal.spec.ts
@@ -7,8 +7,9 @@ import {
 } from '@opencloud-eu/web-test-helpers'
 import { mockDeep } from 'vitest-mock-extended'
 import { ClientService } from '@opencloud-eu/web-pkg'
-import { OcButton, OcDatepicker } from '@opencloud-eu/design-system/components'
+import { OcButton, OcDatepicker, OcTextInput } from '@opencloud-eu/design-system/components'
 import { DateTime } from 'luxon'
+import { VueWrapper } from '@vue/test-utils'
 
 const copyMock = vi.fn()
 vi.mock('@vueuse/core', () => ({
@@ -16,30 +17,44 @@ vi.mock('@vueuse/core', () => ({
 }))
 
 describe('AppTokenModal component', () => {
+  it('should display an input for the label', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.find('oc-text-input-stub').exists()).toBeTruthy()
+  })
   it('should display an input for the expiration date', () => {
     const { wrapper } = getWrapper()
     expect(wrapper.find('oc-datepicker-stub').exists()).toBeTruthy()
   })
   describe('confirm button', () => {
-    it('should be disabled when no date has been entered', () => {
+    it('should be disabled when no data has been entered', () => {
       const { wrapper } = getWrapper()
       const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
       expect(btn.props('disabled')).toBeTruthy()
     })
-    it('should not be disabled when a date has been entered', async () => {
+    it('should be disabled when only a note has been entered', async () => {
       const { wrapper } = getWrapper()
-      wrapper
-        .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
-        .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+      emitNoteInput(wrapper, 'someNote')
+      const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
+      expect(btn.props('disabled')).toBeTruthy()
+    })
+    it('should be disabled when only a date has been entered', async () => {
+      const { wrapper } = getWrapper()
+      emitDateInput(wrapper, DateTime.now())
+      const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
+      expect(btn.props('disabled')).toBeTruthy()
+    })
+    it('should not be disabled when a note and date has been entered', async () => {
+      const { wrapper } = getWrapper()
+      emitNoteInput(wrapper, 'someNote')
+      emitDateInput(wrapper, DateTime.now())
       const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
       await wrapper.vm.$nextTick()
       expect(btn.props('disabled')).toBeFalsy()
     })
     it('should create a token on submit', async () => {
       const { wrapper, mocks } = getWrapper()
-      wrapper
-        .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
-        .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+      emitNoteInput(wrapper, 'someNote')
+      emitDateInput(wrapper, DateTime.now())
       const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
       await wrapper.vm.$nextTick()
       await btn.trigger('click')
@@ -48,9 +63,8 @@ describe('AppTokenModal component', () => {
   })
   it('should display the created token', async () => {
     const { wrapper } = getWrapper()
-    wrapper
-      .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
-      .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+    emitNoteInput(wrapper, 'someNote')
+    emitDateInput(wrapper, DateTime.now())
     const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
     await wrapper.vm.$nextTick()
     await btn.trigger('click')
@@ -58,9 +72,8 @@ describe('AppTokenModal component', () => {
   })
   it('the created token can be copied', async () => {
     const { wrapper } = getWrapper()
-    wrapper
-      .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
-      .vm.$emit('dateChanged', { date: DateTime.now(), error: null })
+    emitNoteInput(wrapper, 'someNote')
+    emitDateInput(wrapper, DateTime.now())
     const btn = wrapper.findComponent<typeof OcButton>('.oc-modal-body-actions-confirm')
     await wrapper.vm.$nextTick()
     await btn.trigger('click')
@@ -68,6 +81,17 @@ describe('AppTokenModal component', () => {
     expect(copyMock).toHaveBeenCalled()
   })
 })
+
+const emitNoteInput = (wrapper: VueWrapper<any>, note: string) => {
+  wrapper
+    .findComponent<typeof OcTextInput>('oc-text-input-stub')
+    .vm.$emit('update:modelValue', note)
+}
+const emitDateInput = (wrapper: VueWrapper<any>, date: DateTime) => {
+  wrapper
+    .findComponent<typeof OcDatepicker>('oc-datepicker-stub')
+    .vm.$emit('dateChanged', { date, error: null })
+}
 
 const getWrapper = () => {
   const clientService = mockDeep<ClientService>()


### PR DESCRIPTION
## Description

This PR adds the `label` field of an app token to the creation modal (text input) and to the listing (table column) and adjusts tests accordingly.

Note: this needs an up to date OpenCloud backend, the last rolling is insufficient. The latest daily should work, otherwise you need to build your own OpenCloud image based on current main. This PR is the underlying prerequisite: https://github.com/opencloud-eu/opencloud/pull/433

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/392

## How Has This Been Tested?

- Unit tests
- Manual testing

## Screenshots

<img width="513" alt="Screenshot 2025-03-21 at 06 03 38" src="https://github.com/user-attachments/assets/d99124a7-503b-4933-ad4b-21f9d6996be7" />
<img width="509" alt="Screenshot 2025-03-21 at 06 03 58" src="https://github.com/user-attachments/assets/e17e3d76-4364-4f44-8555-157d71ea5847" />
<img width="1158" alt="Screenshot 2025-03-21 at 06 04 56" src="https://github.com/user-attachments/assets/9aacc466-cd7c-4ab6-a455-3a905ca1512e" />


## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [x] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
