### PR TITLE
Enable e2e tests in CI

### DIFF
--- a/tests/e2e/cucumber/features/app-store/details.feature
+++ b/tests/e2e/cucumber/features/app-store/details.feature
@@ -6,7 +6,7 @@ Feature: details
     Then "Admin" should see the app store
     When "Admin" clicks on the app "Development boilerplate"
     Then "Admin" should see the app details of "Development boilerplate"
-    And "Admin" downloads app version "0.1.0"
+    And "Admin" downloads app version "1.0.0"
     When "Admin" navigates back to the app store overview
     Then "Admin" should see the app store
     And "Admin" downloads the latest version of the app "Development boilerplate"


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

This PR enables the following e2e test pipelines to run in CI:
``` console
1. e2e-tests-1
2. e2e-tests-2
3. e2e-tests-3
4. e2e-tests-4
5. e2e-tests-oidc-iframe
6. e2e-tests-oidc-refresh-token
```

And also changes the version number in in `details.feature` to `1.0.0`.
![Screenshot from 2025-03-25 12-44-54](https://github.com/user-attachments/assets/44f77d51-3461-4feb-b2b0-cf2c9144536f)


## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Part of: https://github.com/opencloud-eu/qa/issues/3
- Sub-Issue: https://github.com/opencloud-eu/qa/issues/23

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- :robot: 

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
