### PR TITLE
delete last (skipped) call to changelog function

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -230,7 +230,6 @@ def beforePipelines(ctx):
            pipelinesDependsOn(pnpmlint(ctx, "lint"), pnpmCache(ctx)) + \
            pipelinesDependsOn(pnpmlint(ctx, "format"), pnpmCache(ctx))
     # documentation(ctx) + \ # ToDo used to be before pnpmCache
-    # changelog(ctx) + \ # ToDo used to be before pnpmCache
 
 def stagePipelines(ctx):
     unit_test_pipelines = unitTests(ctx)


### PR DESCRIPTION
## Description

we are not running that changelog pipeline and it actually do not exist anymore

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes https://github.com/opencloud-eu/qa/issues/33

## How Has This Been Tested?

nothing to do

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] New feature (an additional functionality that doesn't break existing code)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
