### PR TITLE
fix unit test not running on merge event

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1144,7 +1144,16 @@ def checkStarlark():
             },
         ],
         "when": [
-            {"event": "pull_request"},
+            {
+                "event": ["push", "manual"],
+                "branch": ["main", "stable-*"],
+            },
+            {
+                "event": "pull_request",
+            },
+            {
+                "event": "tag",
+            },
         ],
     }]
 


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

Check starlark didn't run on merge event. Since check starlark pipeline is in beforePipelines and unit tests depends on it, the unit tests didn't run on merge event.
https://ci.opencloud.eu/repos/6/pipeline/340

Follow up of PR https://github.com/opencloud-eu/web/pull/413
