### PR TITLE
Disable the 'exclude' patterns on the path conditional for now

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1202,6 +1202,11 @@ def getPipelineNames(pipelines = []):
     return names
 
 def skipIfUnchanged(ctx, type):
+    ## FIXME: the 'exclude' feature (https://woodpecker-ci.org/docs/usage/workflow-syntax#path) does not seem to provide
+    # what we need. It seems to skip the build as soon as one of the changed files matches an exclude pattern, we only
+    # want to skip of ALL changed files match. So skip this condition for now:
+    return []
+
     if "full-ci" in ctx.build.title.lower() or ctx.build.event == "tag" or ctx.build.event == "cron":
         return []
 


### PR DESCRIPTION
the 'exclude' feature
(https://woodpecker-ci.org/docs/usage/workflow-syntax#path) does not seem to provide # what we need. It seems to skip the build as soon as one of the changed files matches an exclude pattern, we only # want to skip of ALL changed files match. So skip this condition for now:

This should just be a temporary fix until we figured out what's wrong with the `when` conditions. (See https://github.com/opencloud-eu/opencloud/pull/438 )

Same as https://github.com/opencloud-eu/opencloud/pull/439