### PR TITLE
chore: adjust Collabora app name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       MICRO_REGISTRY_ADDRESS: 0.0.0.0:9233
       PROXY_CSP_CONFIG_FILE_LOCATION: /etc/opencloud/csp.yaml
       COLLABORA_DOMAIN: host.docker.internal:9980
-      FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: eu.opencloud.api.collaboration.CollaboraOnline
+      FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: eu.opencloud.api.collaboration.Collabora
       # Needed for enabling all roles
       GRAPH_AVAILABLE_ROLES: b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6,63e64e19-8d43-42ec-a738-2b6af2610efa
     labels:
@@ -155,7 +155,7 @@ services:
       MICRO_REGISTRY: nats-js-kv
       MICRO_REGISTRY_ADDRESS: opencloud:9233
       COLLABORATION_WOPI_SRC: https://${WOPISERVER_DOMAIN:-host.docker.internal:9300}
-      COLLABORATION_APP_NAME: 'CollaboraOnline'
+      COLLABORATION_APP_NAME: 'Collabora'
       COLLABORATION_APP_PRODUCT: 'Collabora'
       COLLABORATION_APP_ADDR: https://${COLLABORA_DOMAIN:-host.docker.internal:9980}
       COLLABORATION_APP_ICON: https://${COLLABORA_DOMAIN:-host.docker.internal:9980}/favicon.ico


### PR DESCRIPTION
Adjusts the Collabora app name to "Collabora" in our dev setup since this gets displayed in the UI.

Follow-up of https://github.com/opencloud-eu/web/pull/418.