### PR TITLE
fix: remove invalid doc links

### DIFF
--- a/packages/web-app-app-store/src/components/AppContextualHelper.vue
+++ b/packages/web-app-app-store/src/components/AppContextualHelper.vue
@@ -6,6 +6,5 @@
         'The App Store app lets you download apps as .zip files. Please follow the link below to learn how to install these apps into your OpenCloud.'
       )
     "
-    read-more-link="https://docs.opencloud.eu/services/web/#web-apps"
   />
 </template>

--- a/packages/web-app-files/src/helpers/contextualHelpers.ts
+++ b/packages/web-app-files/src/helpers/contextualHelpers.ts
@@ -41,8 +41,7 @@ export const shareInviteCollaboratorHelp = (options: ContextualHelperOptions) =>
             'The “via folder” is shown next to a share, if access has already been given via a parent folder. Click on the “via folder” to edit the share on its parent folder.'
           )
         }
-      ],
-      readMoreLink: 'https://docs.opencloud.eu/go?to=webui-users-sharing'
+      ]
     },
     options
   )
@@ -81,8 +80,7 @@ export const shareSpaceAddMemberHelp = (options: ContextualHelperOptions) =>
             'Members with the Manager role are able to edit all properties and content of a Space, such as adding or removing members, sharing subfolders with non-members, or creating links to share.'
           )
         }
-      ],
-      readMoreLink: 'https://docs.opencloud.eu/go?to=webui-users-sharing'
+      ]
     },
     options
   )
@@ -96,8 +94,7 @@ export const shareViaLinkHelp = (options: ContextualHelperOptions) =>
             'No login required. Everyone with the link can access. If you share this link with people from the list "Invited people", they need to login so that their individual assigned permissions can take effect. If they are not logged-in, the permissions of the link take effect.'
           )
         }
-      ],
-      readMoreLink: 'https://docs.opencloud.eu/go?to=webui-users-sharing'
+      ]
     },
     options
   )
@@ -116,8 +113,7 @@ export const shareViaIndirectLinkHelp = (options: ContextualHelperOptions) =>
             'Indirect links can only be edited in their parent folder. Click on the folder icon below the link to navigate to the parent folder.'
           )
         }
-      ],
-      readMoreLink: 'https://docs.opencloud.eu/go?to=webui-users-sharing'
+      ]
     },
     options
   )

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`FileShares > collaborators list > renders sharedWithLabel and sharee li
   <div data-v-5d17c3fa="" class="oc-flex oc-flex-between oc-flex-middle">
     <div data-v-5d17c3fa="" class="oc-flex">
       <h3 data-v-5d17c3fa="" class="oc-text-bold oc-text-medium oc-m-rm" data-msgid="Share with people" data-current-language="en">Share with people</h3>
-      <oc-contextual-helper-stub data-v-5d17c3fa="" title="Share with people" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="https://docs.opencloud.eu/go?to=webui-users-sharing" text="Use the input field to search for users and groups. Select them to share the item." class="oc-pl-xs"></oc-contextual-helper-stub>
+      <oc-contextual-helper-stub data-v-5d17c3fa="" title="Share with people" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="" text="Use the input field to search for users and groups. Select them to share the item." class="oc-pl-xs"></oc-contextual-helper-stub>
     </div>
     <copy-private-link-stub data-v-5d17c3fa="" resource="undefined"></copy-private-link-stub>
   </div>
@@ -42,7 +42,7 @@ exports[`FileShares > current space > loads space members if a space is given an
   <div data-v-5d17c3fa="" class="oc-flex oc-flex-between oc-flex-middle">
     <div data-v-5d17c3fa="" class="oc-flex">
       <h3 data-v-5d17c3fa="" class="oc-text-bold oc-text-medium oc-m-rm" data-msgid="Share with people" data-current-language="en">Share with people</h3>
-      <oc-contextual-helper-stub data-v-5d17c3fa="" title="Share with people" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="https://docs.opencloud.eu/go?to=webui-users-sharing" text="Use the input field to search for users and groups. Select them to share the item." class="oc-pl-xs"></oc-contextual-helper-stub>
+      <oc-contextual-helper-stub data-v-5d17c3fa="" title="Share with people" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="" text="Use the input field to search for users and groups. Select them to share the item." class="oc-pl-xs"></oc-contextual-helper-stub>
     </div>
     <copy-private-link-stub data-v-5d17c3fa="" resource="undefined"></copy-private-link-stub>
   </div>


### PR DESCRIPTION
Removes links to dev docs that are not working currently. They need to be re-added later.

refs https://github.com/opencloud-eu/web/issues/429