### PR TITLE
🎉 Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.1.1](https://github.com/opencloud-eu/web/releases/tag/v2.1.1) - 2025-03-27
+
+### ❤️ Thanks to all contributors! ❤️
+
+@amrita-shrestha
+
+### 📦️ Dependencies
+
+- chore(deps): update dependency @types/semver to v7.7.0 [[#439](https://github.com/opencloud-eu/web/pull/439)]
+
 ## [2.1.0](https://github.com/opencloud-eu/web/releases/tag/v2.1.0) - 2025-03-26
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.1.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.1.1](https://github.com/opencloud-eu/web/releases/tag/v2.1.1) - 2025-03-27

### 📦️ Dependencies

- chore(deps): update dependency @types/semver to v7.7.0 [[#439](https://github.com/opencloud-eu/web/pull/439)]