### PR TITLE
fix: archive download with archives >2GB

### DIFF
--- a/packages/web-pkg/src/services/archiver.ts
+++ b/packages/web-pkg/src/services/archiver.ts
@@ -92,7 +92,17 @@ export class ArchiverService {
         responseType: 'arraybuffer'
       })
 
-      const blob = new Blob([response.data], { type: 'application/octet-stream' })
+      // create 500MB chunks because blobs have a limit of 2GB
+      const chunkSize = 500 * 1024 * 1024
+      const chunks: ArrayBuffer[] = []
+      let offset = 0
+
+      while (offset < response.data.byteLength) {
+        chunks.push(response.data.slice(offset, offset + chunkSize))
+        offset += chunkSize
+      }
+
+      const blob = new Blob(chunks, { type: 'application/octet-stream' })
       const objectUrl = URL.createObjectURL(blob)
       const fileName = this.getFileNameFromResponseHeaders(response.headers)
       triggerDownloadWithFilename(objectUrl, fileName)


### PR DESCRIPTION
Picks https://github.com/opencloud-eu/web/pull/465 to stable branch.

Adds a chunking mechanism when creating blobs from the archiver because blobs have a limit of roughly 2GB. This ensures that larger archives can still be downloaded.