### PR TITLE
fix: remove zoom indicator to avoid confusion

### DIFF
--- a/packages/web-app-preview/src/components/MediaControls.vue
+++ b/packages/web-app-preview/src/components/MediaControls.vue
@@ -55,15 +55,6 @@
             <oc-icon fill-type="line" name="zoom-out" />
           </oc-button>
           <oc-button
-            v-oc-tooltip="imageOriginalSizeDescription"
-            class="preview-controls-image-original-size raw-hover-surface oc-p-xs oc-ml-s oc-mr-s"
-            appearance="raw"
-            :aria-label="imageOriginalSizeDescription"
-            @click="$emit('setZoom', 1)"
-          >
-            <span v-text="currentZoomDisplayValue" />
-          </oc-button>
-          <oc-button
             v-oc-tooltip="imageZoomDescription"
             class="preview-controls-image-zoom raw-hover-surface oc-p-xs"
             appearance="raw"
@@ -199,7 +190,6 @@ export default defineComponent({
       imageShrinkDescription: $gettext('Shrink the image'),
       imageZoomDescription: $gettext('Enlarge the image'),
       imageResetDescription: $gettext('Reset'),
-      imageOriginalSizeDescription: $gettext('Show the image at its normal size'),
       imageRotateLeftDescription: $gettext('Rotate the image 90 degrees to the left'),
       imageRotateRightDescription: $gettext('Rotate the image 90 degrees to the right'),
       previousDescription: $gettext('Show previous media file in folder'),

--- a/packages/web-app-preview/tests/unit/components/MediaControls.spec.ts
+++ b/packages/web-app-preview/tests/unit/components/MediaControls.spec.ts
@@ -72,17 +72,6 @@ describe('MediaControls component', () => {
         expect(wrapper.emitted('setZoom').length).toBeDefined()
       })
     })
-    describe('original size button', () => {
-      it('exists if file is an image', () => {
-        const { wrapper } = getWrapper({ showImageControls: true })
-        expect(wrapper.find(selectors.controlsImageOriginalSize).exists()).toBeTruthy()
-      })
-      it('emits "setZoom"-event on click', async () => {
-        const { wrapper } = getWrapper({ showImageControls: true })
-        await wrapper.find(selectors.controlsImageOriginalSize).trigger('click')
-        expect(wrapper.emitted('setZoom').length).toBeDefined()
-      })
-    })
   })
   describe('rotation', () => {
     describe('left button', () => {


### PR DESCRIPTION
## Description

Removes the zoom percentage to avoid confusion.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes #452 

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
