### PR TITLE
[full-ci]use Playwright api instead of node fetch

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -208,7 +208,7 @@ const cleanUpSpaces = async (adminUser: User) => {
           space
         })
         .then(async (res) => {
-          if (res.status === 204) {
+          if (res.status() === 204) {
             await api.graph.deleteSpace({
               user: adminUser,
               space

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -19,7 +19,7 @@ export const folderExists = async ({
     user: user
   })
 
-  return getResponse.status === 200
+  return getResponse.status() === 200
 }
 
 const createFolder = async ({

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -69,7 +69,7 @@ const createFile = async ({
     body: content,
     user: user,
     header: mtimeDeltaDays
-      ? { 'X-OC-Mtime': today.getTime() / 1000 + parseInt(mtimeDeltaDays) * 86400 }
+      ? { 'X-OC-Mtime': String(today.getTime() / 1000 + parseInt(mtimeDeltaDays) * 86400) }
       : {}
   })
 

--- a/tests/e2e/support/api/graph/spaces.ts
+++ b/tests/e2e/support/api/graph/spaces.ts
@@ -127,7 +127,13 @@ export const updateSpaceSpecialSection = async ({
   )
 }
 
-export const disableSpace = ({ user, space }: { user: User; space: Space }): Promise<APIResponse> => {
+export const disableSpace = ({
+  user,
+  space
+}: {
+  user: User
+  space: Space
+}): Promise<APIResponse> => {
   return request({
     method: 'DELETE',
     path: join('graph', 'v1.0', 'drives', space.id),
@@ -135,7 +141,13 @@ export const disableSpace = ({ user, space }: { user: User; space: Space }): Pro
   })
 }
 
-export const deleteSpace = ({ user, space }: { user: User; space: Space }): Promise<APIResponse> => {
+export const deleteSpace = ({
+  user,
+  space
+}: {
+  user: User
+  space: Space
+}): Promise<APIResponse> => {
   return request({
     method: 'DELETE',
     path: join('graph', 'v1.0', 'drives', space.id),

--- a/tests/e2e/support/api/graph/spaces.ts
+++ b/tests/e2e/support/api/graph/spaces.ts
@@ -1,4 +1,4 @@
-import { Response } from 'node-fetch'
+import { APIResponse } from '@playwright/test'
 import join from 'join-path'
 import { checkResponseStatus, request } from '../http'
 import { Space, User } from '../../types'
@@ -47,10 +47,10 @@ export const createSpace = async ({
   user: User
   space: Space
 }): Promise<string> => {
-  const body = JSON.stringify({
+  const body = {
     id: space.id,
     name: space.name
-  })
+  }
 
   const response = await request({
     method: 'POST',
@@ -104,7 +104,7 @@ export const updateSpaceSpecialSection = async ({
   } else {
     type = 'image'
   }
-  const body = JSON.stringify({
+  const body = {
     special: [
       {
         specialFolder: {
@@ -113,7 +113,7 @@ export const updateSpaceSpecialSection = async ({
         id: fileId
       }
     ]
-  })
+  }
 
   const response = await request({
     method: 'PATCH',
@@ -127,7 +127,7 @@ export const updateSpaceSpecialSection = async ({
   )
 }
 
-export const disableSpace = ({ user, space }: { user: User; space: Space }): Promise<Response> => {
+export const disableSpace = ({ user, space }: { user: User; space: Space }): Promise<APIResponse> => {
   return request({
     method: 'DELETE',
     path: join('graph', 'v1.0', 'drives', space.id),
@@ -135,7 +135,7 @@ export const disableSpace = ({ user, space }: { user: User; space: Space }): Pro
   })
 }
 
-export const deleteSpace = ({ user, space }: { user: User; space: Space }): Promise<Response> => {
+export const deleteSpace = ({ user, space }: { user: User; space: Space }): Promise<APIResponse> => {
   return request({
     method: 'DELETE',
     path: join('graph', 'v1.0', 'drives', space.id),

--- a/tests/e2e/support/api/graph/userManagement.ts
+++ b/tests/e2e/support/api/graph/userManagement.ts
@@ -22,12 +22,12 @@ export const me = async ({ user }: { user: User }): Promise<Me> => {
 }
 
 export const createUser = async ({ user, admin }: { user: User; admin: User }): Promise<User> => {
-  const body = JSON.stringify({
+  const body = {
     displayName: user.displayName,
     mail: user.email,
     onPremisesSamAccountName: user.username,
     passwordProfile: { password: user.password }
-  })
+  }
 
   const response = await request({
     method: 'POST',
@@ -79,9 +79,9 @@ export const createGroup = async ({
   group: Group
   admin: User
 }): Promise<Group> => {
-  const body = JSON.stringify({
+  const body = {
     displayName: group.displayName
-  })
+  }
 
   const response = await request({
     method: 'POST',
@@ -125,9 +125,9 @@ export const addUserToGroup = async ({
   groupId: string
   admin: User
 }): Promise<void> => {
-  const body = JSON.stringify({
+  const body = {
     '@odata.id': join(config.baseUrl, 'graph', 'v1.0', 'users', userId)
-  })
+  }
 
   const response = await request({
     method: 'POST',
@@ -153,11 +153,11 @@ export const assignRole = async (admin: User, id: string, role: string): Promise
     method: 'POST',
     path: join('graph', 'v1.0', 'users', id, 'appRoleAssignments'),
     user: admin,
-    body: JSON.stringify({
+    body: {
       principalId: id,
       appRoleId: userRoleStore.get(role),
       resourceId: applicationEntity.id
-    })
+    }
   })
   checkResponseStatus(response, 'Failed while assigning role to the user')
 }

--- a/tests/e2e/support/api/keycloak/openCloudUserToken.ts
+++ b/tests/e2e/support/api/keycloak/openCloudUserToken.ts
@@ -1,7 +1,7 @@
-import fetch from 'node-fetch'
 import { TokenEnvironmentFactory } from '../../environment'
 import { config } from '../../../config'
 import { User } from '../../types'
+import { request, APIRequestContext } from '@playwright/test'
 
 interface openCloudTokenForKeycloak {
   access_token: string
@@ -11,8 +11,9 @@ interface openCloudTokenForKeycloak {
 const authorizationEndpoint = config.keycloakUrl + '/realms/openCloud/protocol/openid-connect/auth'
 const tokenEndpoint = config.keycloakUrl + '/realms/openCloud/protocol/openid-connect/token'
 const redirectUrl = config.baseUrl + '/oidc-callback.html'
+const tokenMasterEndpoint = config.keycloakUrl + '/realms/master/protocol/openid-connect/token'
 
-async function getAuthorizationEndPoint() {
+async function getAuthorizationEndPoint(context: APIRequestContext): Promise<string> {
   const loginParams = {
     client_id: 'web',
     redirect_uri: redirectUrl,
@@ -23,23 +24,21 @@ async function getAuthorizationEndPoint() {
   const queryString = new URLSearchParams(loginParams).toString()
   const authorizationUrl = `${authorizationEndpoint}?${queryString}`
 
-  const authorizationResponse = await fetch(authorizationUrl, {
-    method: 'GET',
-    redirect: 'manual'
+  const authorizationResponse = await context.get(authorizationUrl, {
+    maxRedirects: 0
   })
 
-  if (authorizationResponse.status === 302) {
-    const locationHeader = authorizationResponse.headers.get('location')
+  if (authorizationResponse.status() === 302) {
+    const locationHeader = authorizationResponse.headers()['location']
     const urlParams = new URLSearchParams(new URL(locationHeader).search)
     const errorDescription = urlParams.get('error_description')
     throw new Error(`Unexpected redirection. ${errorDescription}`)
-  } else if (authorizationResponse.status !== 200) {
+  } else if (authorizationResponse.status() !== 200) {
     throw new Error(
-      `Authorization failed: Expected status code to be 200 but received ${authorizationResponse.status}. \nMessage: ${authorizationResponse.statusText}`
+      `Authorization failed: Expected status code to be 200 but received ${authorizationResponse.status()}. \nMessage: ${authorizationResponse.statusText()}`
     )
   }
 
-  const cookies = authorizationResponse.headers.raw()['set-cookie']?.[0]
   const htmlData = await authorizationResponse.text()
 
   // authorization url for login is send back from server in the HTML body.
@@ -48,53 +47,44 @@ async function getAuthorizationEndPoint() {
     throw new Error('No authorization url found in the HTML response body.')
   }
   const auhorizationUrl = match[1]
-  return [auhorizationUrl, cookies]
+  return auhorizationUrl
 }
 
-const getCode = async ({
-  user,
-  auhorizationUrl,
-  cookies
-}: {
-  user: User
+const getCode = async (
+  context: APIRequestContext,
+  user: User,
   auhorizationUrl: string
-  cookies: string
-}) => {
-  const authCodeResponse = await fetch(auhorizationUrl, {
-    method: 'POST',
-    body: new URLSearchParams({
+): Promise<string> => {
+  const authCodeResponse = await context.post(auhorizationUrl, {
+    form: {
       username: user.username,
       password: user.password
-    }),
-    redirect: 'manual',
-    headers: {
-      Cookie: cookies
-    }
+    },
+    maxRedirects: 0
   })
 
-  if (authCodeResponse.status !== 302) {
+  if (authCodeResponse.status() !== 302) {
     throw new Error(
-      `Login failed: Expected status code to be 302 but received ${authCodeResponse.status}. \nMessage: ${authCodeResponse.statusText}`
+      `Login failed: Expected status code to be 302 but received ${authCodeResponse.status()}. \nMessage: ${authCodeResponse.statusText()}`
     )
   }
 
-  const locationHeader = authCodeResponse.headers.get('location')
+  const locationHeader = authCodeResponse.headers()['location'] || ''
   const urlParams = new URLSearchParams(new URL(locationHeader).search)
   return urlParams.get('code')
 }
 
-const getToken = async (authorizationCode: string) => {
-  const tokenResponse = await fetch(tokenEndpoint, {
-    method: 'POST',
-    body: new URLSearchParams({
+const getToken = async (context: APIRequestContext, authorizationCode: string) => {
+  const tokenResponse = await context.post(tokenEndpoint, {
+    form: {
       client_id: 'web',
       code: authorizationCode,
       redirect_uri: redirectUrl,
       grant_type: 'authorization_code'
-    })
+    }
   })
 
-  if (tokenResponse.status !== 200) {
+  if (tokenResponse.status() !== 200) {
     throw new Error(
       `Failed to retrieve token: Expected status code to be 200 but received ${tokenResponse.status}. \nMessage: ${tokenResponse.statusText}`
     )
@@ -104,9 +94,10 @@ const getToken = async (authorizationCode: string) => {
 }
 
 export const setAccessTokenForKeycloakOpenCloudUser = async (user: User) => {
-  const [auhorizationUrl, cookies] = await getAuthorizationEndPoint()
-  const authorizationCode = await getCode({ user, auhorizationUrl, cookies })
-  const tokenResponse = await getToken(authorizationCode)
+  const context = await request.newContext()
+  const auhorizationUrl = await getAuthorizationEndPoint(context)
+  const authorizationCode = await getCode(context, user, auhorizationUrl)
+  const tokenResponse = await getToken(context, authorizationCode)
   const token = (await tokenResponse.json()) as openCloudTokenForKeycloak
 
   const tokenEnvironment = TokenEnvironmentFactory()
@@ -121,17 +112,17 @@ export const setAccessTokenForKeycloakOpenCloudUser = async (user: User) => {
 }
 
 export const refreshAccessTokenForKeycloakOpenCloudUser = async (user: User) => {
+  const context = await request.newContext()
   const tokenEnvironment = TokenEnvironmentFactory()
   const refreshToken = tokenEnvironment.getToken({ user }).refreshToken
-  const tokenResponse = await fetch(tokenEndpoint, {
-    method: 'POST',
-    body: new URLSearchParams({
+  const tokenResponse = await context.post(tokenEndpoint, {
+    form: {
       client_id: 'web',
       refresh_token: refreshToken,
       grant_type: 'refresh_token'
-    })
+    }
   })
-  if (tokenResponse.status !== 200) {
+  if (tokenResponse.status() !== 200) {
     throw new Error(
       `Failed to retrieve token: Expected status code to be 200 but received ${tokenResponse.status}. \nMessage: ${tokenResponse.statusText}`
     )
@@ -144,6 +135,69 @@ export const refreshAccessTokenForKeycloakOpenCloudUser = async (user: User) => 
       userId: user.username,
       accessToken: token.access_token,
       refreshToken: token.refresh_token
+    }
+  })
+}
+
+interface KeycloakToken {
+  access_token: string
+  refresh_token: string
+}
+
+export const refreshAccessTokenForKeycloakUser = async (user: User): Promise<void> => {
+  const tokenEnvironment = TokenEnvironmentFactory('keycloak')
+  const refreshToken = tokenEnvironment.getToken({ user }).refreshToken
+  const context = await request.newContext()
+
+  const refreshResponse = await context.post(tokenMasterEndpoint, {
+    form: {
+      client_id: 'admin-cli',
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken
+    }
+    // header: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  })
+  if (refreshResponse.status() !== 200) {
+    throw new Error(
+      `Failed to retrieve token: Expected status code to be 200 but received ${refreshResponse.status()}. \nMessage: ${refreshResponse.statusText()}`
+    )
+  }
+
+  const resBody = (await refreshResponse.json()) as KeycloakToken
+
+  // update tokens
+  tokenEnvironment.setToken({
+    user: { ...user },
+    token: {
+      userId: user.username,
+      accessToken: resBody.access_token,
+      refreshToken: resBody.refresh_token
+    }
+  })
+}
+
+export const setAccessTokenForKeycloakUser = async (user: User): Promise<void> => {
+  const context = await request.newContext()
+  const response = await context.post(tokenMasterEndpoint, {
+    // password grant type is used to get keycloak token.
+    // This approach is not recommended and used only for the test
+    form: {
+      client_id: 'admin-cli',
+      username: config.keycloakAdminUser,
+      password: config.keycloakAdminUser,
+      grant_type: 'password'
+    }
+  })
+
+  const resBody = (await response.json()) as KeycloakToken
+  const tokenEnvironment = TokenEnvironmentFactory('keycloak')
+
+  tokenEnvironment.setToken({
+    user: { ...user },
+    token: {
+      userId: user.username,
+      accessToken: resBody.access_token,
+      refreshToken: resBody.refresh_token
     }
   })
 }

--- a/tests/e2e/support/api/keycloak/openCloudUserToken.ts
+++ b/tests/e2e/support/api/keycloak/openCloudUserToken.ts
@@ -155,7 +155,6 @@ export const refreshAccessTokenForKeycloakUser = async (user: User): Promise<voi
       grant_type: 'refresh_token',
       refresh_token: refreshToken
     }
-    // header: { 'Content-Type': 'application/x-www-form-urlencoded' },
   })
   if (refreshResponse.status() !== 200) {
     throw new Error(

--- a/tests/e2e/support/api/keycloak/user.ts
+++ b/tests/e2e/support/api/keycloak/user.ts
@@ -18,7 +18,7 @@ const openCloudKeycloakUserRoles: Record<string, string> = {
 
 export const createUser = async ({ user, admin }: { user: User; admin: User }): Promise<User> => {
   const fullName = user.displayName.split(' ')
-  const body = JSON.stringify({
+  const body = {
     username: user.username,
     credentials: [{ value: user.password, type: 'password' }],
     firstName: fullName[0],
@@ -31,7 +31,7 @@ export const createUser = async ({ user, admin }: { user: User; admin: User }): 
     //  - https://github.com/keycloak/keycloak/issues/16449
     // realmRoles: ['openCloudUser', 'offline_access'],
     enabled: true
-  })
+  }
 
   // create a user
   const creationRes = await request({
@@ -85,10 +85,10 @@ export const assignRole = async ({
   return request({
     method: 'POST',
     path: join(realmBasePath, 'users', uuid, 'role-mappings', 'realm'),
-    body: JSON.stringify([
+    body: [
       await getRealmRole(openCloudKeycloakUserRoles[role], admin),
       await getRealmRole('offline_access', admin)
-    ]),
+    ],
     user: admin,
     header: { 'Content-Type': 'application/json' }
   })
@@ -107,7 +107,7 @@ export const unAssignRole = async ({
   const response = await request({
     method: 'DELETE',
     path: join(realmBasePath, 'users', uuid, 'role-mappings', 'realm'),
-    body: JSON.stringify([await getRealmRole(openCloudKeycloakUserRoles[role], admin)]),
+    body: [await getRealmRole(openCloudKeycloakUserRoles[role], admin)],
     user: admin,
     header: { 'Content-Type': 'application/json' }
   })

--- a/tests/e2e/support/api/keycloak/utils.ts
+++ b/tests/e2e/support/api/keycloak/utils.ts
@@ -1,5 +1,5 @@
 import join from 'join-path'
-import { BodyInit, Response } from 'node-fetch'
+import { APIResponse } from '@playwright/test'
 import { request as httpRequest, checkResponseStatus } from '../http'
 import { User } from '../../types'
 import { TokenEnvironmentFactory } from '../../environment'
@@ -15,25 +15,25 @@ export const realmBasePath = `admin/realms/${config.keycloakRealm}`
 export const request = async (args: {
   method: 'POST' | 'DELETE' | 'PUT' | 'GET' | 'MKCOL' | 'PROPFIND' | 'PATCH'
   path: string
-  body?: BodyInit
+  body?: Record<string, any> | null
   user?: User
   header?: object
-}): Promise<Response> => {
+}): Promise<APIResponse> => {
   return await httpRequest({ ...args, isKeycloakRequest: true })
 }
 
-export const getUserIdFromResponse = (response: Response): string => {
-  return response.headers.get('location').split('/').pop()
+export const getUserIdFromResponse = (response: APIResponse): string => {
+  return response.headers()['location'].split('/').pop()
 }
 
 export const refreshAccessTokenForKeycloakUser = async (user: User): Promise<void> => {
   const tokenEnvironment = TokenEnvironmentFactory('keycloak')
 
-  const body = new URLSearchParams()
-  // client-id `admin-cli` enables us to use password grant type to get access token
-  body.append('client_id', 'admin-cli')
-  body.append('grant_type', 'refresh_token')
-  body.append('refresh_token', tokenEnvironment.getToken({ user }).refreshToken)
+  const body = {
+    client_id: 'admin-cli',
+    grant_type: 'refresh_token',
+    refresh_token: tokenEnvironment.getToken({ user }).refreshToken
+  }
 
   const response = await request({
     method: 'POST',

--- a/tests/e2e/support/api/share/share.ts
+++ b/tests/e2e/support/api/share/share.ts
@@ -144,7 +144,7 @@ export const createShare = async ({
   const response = await request({
     method: 'POST',
     path: join('graph', 'v1beta1', 'drives', driveId, 'items', itemId, 'invite'),
-    body: JSON.stringify({
+    body: {
       recipients: [
         {
           '@libre.graph.recipient.type': shareType,
@@ -152,7 +152,7 @@ export const createShare = async ({
         }
       ],
       roles: [roleId]
-    }),
+    },
     user
   })
   checkResponseStatus(response, 'Failed while creating share')
@@ -182,7 +182,7 @@ export const addMembersToTheProjectSpace = async ({
   const response = await request({
     method: 'POST',
     path: join('graph', 'v1beta1', 'drives', driveId, 'root', 'invite'),
-    body: JSON.stringify({
+    body: {
       recipients: [
         {
           '@libre.graph.recipient.type': shareType,
@@ -190,7 +190,7 @@ export const addMembersToTheProjectSpace = async ({
         }
       ],
       roles: [roleId]
-    }),
+    },
     user
   })
 
@@ -237,11 +237,11 @@ export const createLinkShare = async ({
   const response = await request({
     method: 'POST',
     path: join('graph', 'v1beta1', 'drives', driveId, 'items', itemId, 'createLink'),
-    body: JSON.stringify({
+    body: {
       type: roleType,
       password,
       displayName: name
-    }),
+    },
     user
   })
 
@@ -281,11 +281,11 @@ export const createSpaceLinkShare = async ({
   const response = await request({
     method: 'POST',
     path: join('graph', 'v1beta1', 'drives', driveId, 'root', 'createLink'),
-    body: JSON.stringify({
+    body: {
       type: roleType,
       password,
       displayName: name
-    }),
+    },
     user
   })
 

--- a/tests/e2e/support/api/token/utils.ts
+++ b/tests/e2e/support/api/token/utils.ts
@@ -1,108 +1,17 @@
 import { TokenEnvironmentFactory } from '../../environment'
 import { config } from '../../../config'
-import fetch, { Response } from 'node-fetch'
+import { request, APIRequestContext } from '@playwright/test'
 import { User } from '../../types'
 
 const logonUrl = '/signin/v1/identifier/_/logon'
 const redirectUrl = '/oidc-callback.html'
 const tokenUrl = '/konnect/v1/token'
 
-interface Token {
-  access_token: string
-  refresh_token: string
-}
-
-const getAuthorizedEndPoint = async (user: User): Promise<Array<string>> => {
-  const logonResponse = await fetch(config.baseUrl + logonUrl, {
-    method: 'POST',
-    headers: {
-      'Kopano-Konnect-XSRF': '1',
-      Referer: config.baseUrl,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      params: [user.username, user.password, '1'],
-      hello: {
-        scope: 'openid profile email',
-        client_id: 'web',
-        redirect_uri: config.baseUrl + redirectUrl,
-        flow: 'oidc'
-      }
-    })
-  })
-  if (logonResponse.status !== 200) {
-    throw new Error(
-      `Logon failed: Expected status code be 200 but received ${logonResponse.status} Message: ${logonResponse.statusText}`
-    )
-  }
-
-  const cookies = logonResponse.headers.raw()['set-cookie']?.[0] || ''
-  const data = (await logonResponse.json()) as { hello: { continue_uri: string } }
-  const authorizedUrl = data.hello.continue_uri
-  return [authorizedUrl, cookies]
-}
-
-const getCode = async ({
-  continueUrl,
-  cookies
-}: {
-  continueUrl: string
-  cookies: string
-}): Promise<string> => {
-  const params = new URLSearchParams({
-    client_id: 'web',
-    prompt: 'none',
-    redirect_uri: config.baseUrl + redirectUrl,
-    response_mode: 'query',
-    response_type: 'code',
-    scope: 'openid profile offline_access email'
-  })
-  const authorizeResponse = await fetch(`${continueUrl}?${params.toString()}`, {
-    method: 'GET',
-    redirect: 'manual',
-    headers: {
-      Cookie: cookies
-    }
-  })
-  if (authorizeResponse.status !== 302) {
-    throw new Error(
-      `Authorization failed: Expected status code be 302 but received ${authorizeResponse.status} Message: ${authorizeResponse.statusText}`
-    )
-  }
-
-  const locationHeader = authorizeResponse.headers.get('location')
-  const urlParams = new URLSearchParams(new URL(locationHeader).search)
-
-  if (locationHeader.includes('error=login_required')) {
-    const errorDescription = urlParams.get('error_description')
-    throw new Error(`Redirection failed. ${errorDescription}`)
-  }
-  return urlParams.get('code')
-}
-
-const getToken = async (code: string): Promise<Response> => {
-  const response = await fetch(config.baseUrl + tokenUrl, {
-    method: 'POST',
-    body: new URLSearchParams({
-      client_id: 'web',
-      code: code,
-      redirect_uri: config.baseUrl + redirectUrl,
-      grant_type: 'authorization_code'
-    })
-  })
-  if (response.status !== 200) {
-    throw new Error(
-      `Request failed: Expected status code be 200 but received ${response.status} Message: ${response.statusText}`
-    )
-  }
-  return response
-}
-
 export const setAccessAndRefreshToken = async (user: User) => {
-  const [authorizedUrl, cookies] = await getAuthorizedEndPoint(user)
-  const code = await getCode({ continueUrl: authorizedUrl, cookies })
-  const response = await getToken(code)
-  const tokenList = (await response.json()) as Token
+  const context = await request.newContext()
+  const continueUrl = await getAuthorizedEndPoint(context, user)
+  const code = await getCode(context, continueUrl)
+  const tokenList = await getToken(context, code)
 
   const tokenEnvironment = TokenEnvironmentFactory()
   tokenEnvironment.setToken({
@@ -113,4 +22,83 @@ export const setAccessAndRefreshToken = async (user: User) => {
       refreshToken: tokenList.refresh_token
     }
   })
+}
+
+const getAuthorizedEndPoint = async (context: APIRequestContext, user: User): Promise<string> => {
+  const logonResponse = await context.post(config.baseUrl + logonUrl, {
+    headers: {
+      'Kopano-Konnect-XSRF': '1',
+      Referer: config.baseUrl,
+      'Content-Type': 'application/json'
+    },
+    data: {
+      params: [user.username, user.password, '1'],
+      hello: {
+        scope: 'openid profile email',
+        client_id: 'web',
+        redirect_uri: config.baseUrl + redirectUrl,
+        flow: 'oidc'
+      }
+    }
+  })
+  if (logonResponse.status() !== 200) {
+    throw new Error(
+      `Logon failed: Expected status code be 200 but received ${logonResponse.status} Message: ${logonResponse.statusText}`
+    )
+  }
+
+  const data = (await logonResponse.json()) as { hello: { continue_uri: string } }
+  return data.hello.continue_uri
+}
+
+const getCode = async (
+  context: APIRequestContext,
+  continueUrl: string
+): Promise<string> => {
+  const params = new URLSearchParams({
+    client_id: 'web',
+    prompt: 'none',
+    redirect_uri: config.baseUrl + redirectUrl,
+    response_mode: 'query',
+    response_type: 'code',
+    scope: 'openid profile offline_access email'
+  })
+  const authorizeResponse = await context.get(continueUrl, {
+    params: params,
+    maxRedirects: 0
+  })
+
+  if (authorizeResponse.status() !== 302) {
+    throw new Error(
+      `Authorization failed: Expected status code be 302 but received ${authorizeResponse.status} Message: ${authorizeResponse.statusText}`
+    )
+  }
+
+  const location = authorizeResponse.headers()['location'] || ''
+  const code = new URLSearchParams(location.split('?')[1]).get('code')
+  if (!code) throw new Error('Missing auth code')
+
+  return code
+}
+
+interface Token {
+  access_token: string
+  refresh_token: string
+}
+
+const getToken = async (context: APIRequestContext, code: string): Promise<Token> => {
+  const response = await context.post(config.baseUrl + tokenUrl, {
+    form: {
+      client_id: 'web',
+      code: code,
+      redirect_uri: config.baseUrl + redirectUrl,
+      grant_type: 'authorization_code'
+    }
+  })
+  if (response.status() !== 200) {
+    throw new Error(
+      `Request failed: Expected status code be 200 but received ${response.status} Message: ${response.statusText}`
+    )
+  }
+  return (await response.json()) as Token
 }

--- a/tests/e2e/support/api/token/utils.ts
+++ b/tests/e2e/support/api/token/utils.ts
@@ -51,10 +51,7 @@ const getAuthorizedEndPoint = async (context: APIRequestContext, user: User): Pr
   return data.hello.continue_uri
 }
 
-const getCode = async (
-  context: APIRequestContext,
-  continueUrl: string
-): Promise<string> => {
+const getCode = async (context: APIRequestContext, continueUrl: string): Promise<string> => {
   const params = new URLSearchParams({
     client_id: 'web',
     prompt: 'none',

--- a/tests/e2e/support/api/token/utils.ts
+++ b/tests/e2e/support/api/token/utils.ts
@@ -43,7 +43,7 @@ const getAuthorizedEndPoint = async (context: APIRequestContext, user: User): Pr
   })
   if (logonResponse.status() !== 200) {
     throw new Error(
-      `Logon failed: Expected status code be 200 but received ${logonResponse.status} Message: ${logonResponse.statusText}`
+      `Logon failed: Expected status code be 200 but received ${logonResponse.status()} Message: ${logonResponse.statusText()}`
     )
   }
 
@@ -67,7 +67,7 @@ const getCode = async (context: APIRequestContext, continueUrl: string): Promise
 
   if (authorizeResponse.status() !== 302) {
     throw new Error(
-      `Authorization failed: Expected status code be 302 but received ${authorizeResponse.status} Message: ${authorizeResponse.statusText}`
+      `Authorization failed: Expected status code be 302 but received ${authorizeResponse.status()} Message: ${authorizeResponse.statusText()}`
     )
   }
 
@@ -94,7 +94,7 @@ const getToken = async (context: APIRequestContext, code: string): Promise<Token
   })
   if (response.status() !== 200) {
     throw new Error(
-      `Request failed: Expected status code be 200 but received ${response.status} Message: ${response.statusText}`
+      `Request failed: Expected status code be 200 but received ${response.status()} Message: ${response.statusText()}`
     )
   }
   return (await response.json()) as Token


### PR DESCRIPTION
This PR replaces the usage of node-fetch with Playwright’s request API
We no longer need to save cookies and send them in another request because playwright saves cookies in each context and reuses them