### PR TITLE
feat(WIP): preview image loading failover

### DIFF
--- a/packages/web-app-preview/src/components/Errors/ErrorDefault.vue
+++ b/packages/web-app-preview/src/components/Errors/ErrorDefault.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="oc-width-1-1 oc-flex oc-flex-column oc-flex-middle oc-flex-center">
+    <oc-icon name="file-damage" size="xlarge" color="var(--oc-role-error)" />
+    <p>
+      {{ $gettext('Failed to load "%{filename}"', { filename: activeMediaFileCached.name }) }}
+    </p>
+  </div>
+</template>
+<script setup lang="ts">
+import { CachedFile } from '../../helpers/types'
+
+const { activeMediaFileCached } = defineProps<{
+  activeMediaFileCached: CachedFile
+}>()
+</script>

--- a/packages/web-app-preview/src/components/Errors/ErrorImage.vue
+++ b/packages/web-app-preview/src/components/Errors/ErrorImage.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="oc-width-1-1 oc-flex oc-flex-column oc-flex-middle oc-flex-center">
+    <oc-icon name="file-damage" size="xlarge" color="var(--oc-role-error)" />
+    <p>
+      {{ $gettext('Failed to load "%{filename}"', { filename: activeMediaFileCached.name }) }}
+    </p>
+    <oc-button @click="loadOriginalFile">
+      {{ $gettext('Load Original') }}
+    </oc-button>
+  </div>
+</template>
+<script setup lang="ts">
+import { CachedFile } from '../../helpers/types'
+
+const { activeMediaFileCached } = defineProps<{
+  activeMediaFileCached: CachedFile
+}>()
+
+const emit = defineEmits<{
+  (e: 'replaceUrl', { url }: { url: string }): void
+}>()
+
+const loadOriginalFile = () => {
+  emit('replaceUrl', { url: activeMediaFileCached.fallbackUrl })
+}
+</script>

--- a/packages/web-app-preview/src/helpers/types.ts
+++ b/packages/web-app-preview/src/helpers/types.ts
@@ -4,6 +4,7 @@ export type CachedFile = {
   id: string
   name: string
   url: string
+  fallbackUrl?: string
   ext: string
   mimeType: string
   isVideo: boolean


### PR DESCRIPTION
## Description

Allow using resource url for image when preview loading failed.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/456

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
