### PR TITLE
Revert "Disable the 'exclude' patterns on the path conditional for now"

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1195,11 +1195,6 @@ def getPipelineNames(pipelines = []):
     return names
 
 def skipIfUnchanged(ctx, type):
-    ## FIXME: the 'exclude' feature (https://woodpecker-ci.org/docs/usage/workflow-syntax#path) does not seem to provide
-    # what we need. It seems to skip the build as soon as one of the changed files matches an exclude pattern, we only
-    # want to skip of ALL changed files match. So skip this condition for now:
-    return []
-
     if "full-ci" in ctx.build.title.lower() or ctx.build.event == "tag" or ctx.build.event == "cron":
         return []
 


### PR DESCRIPTION
This reverts commit 767877c6d1c7fb33cac37ad94176998b879b5301.

The exclude feature has been fixed in woodpecker 3.5.0

Partial fixes: https://github.com/opencloud-eu/qa/issues/37

