### PR TITLE
chore: remove web tag from tag create/push-script

### DIFF
--- a/dev/scripts/create_and_push_tags.sh
+++ b/dev/scripts/create_and_push_tags.sh
@@ -5,12 +5,6 @@
 APPS=("design-system" "eslint-config" "extension-sdk" "prettier-config" "tsconfig" "web-pkg" "web-client" "web-test-helpers")
 
 cd "$(dirname "$0")/../.."
-VERSION=$(node -p "require('./package.json').version")
-TAG="v${VERSION}"
-
-git tag -s -a "$TAG" -m "$TAG"
-git push origin "$TAG"
-echo "v$VERSION has been created and pushed"
 
 for app in "${APPS[@]}"; do
 	cd "./packages/$app"


### PR DESCRIPTION
We don't need this anymore since Web tagging if being handled by the release go bot.