### PR TITLE
do not overwrite release when uploading artifacts

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -722,7 +722,6 @@ def buildAndPublishRelease(ctx):
                         "sha256",
                     ],
                     "title": ctx.build.ref.replace("refs/tags/v", ""),
-                    "overwrite": True,
                     "prerelease": len(ctx.build.ref.split("-")) > 1,
                 },
                 "when": [


### PR DESCRIPTION
## Description

This pipeline runs after ready-release-go, which generates the title and changelogs in the notes.
We don't want to overwrite the existing notes

## Related Issue

- Fixes [#45](https://github.com/opencloud-eu/qa/issues/45)

## How Has This Been Tested?

@kulmann I think for testing you would have to create a new release with ready-release-go

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
