### PR TITLE
fix: use native fetch for downloading archives

### DIFF
--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -113,6 +113,13 @@ export class ClientService {
     return this.language.current
   }
 
+  public getRequestHeaders = ({ useAuth = true }: { useAuth?: boolean } = {}) => {
+    return {
+      ...this.staticHeaders,
+      ...this.getDynamicHeaders({ useAuth })
+    }
+  }
+
   private initGraphClient() {
     const axiosClient = axios.create({ headers: this.staticHeaders })
     axiosClient.interceptors.request.use((config) => {


### PR DESCRIPTION
Axios seems to have problems with requests that exceed a certain size which results in data streams that can't be read. Use fetch instead to ensure big archives can still be downloaded.

This is a follow-up of https://github.com/opencloud-eu/web/pull/465.

refs https://github.com/opencloud-eu/opencloud/issues/537