### PR TITLE
ci: enable ready-release-go for stable-2.1

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -356,6 +356,7 @@ def readyReleaseGo():
                     "settings": {
                         "git_email": "devops@opencloud.eu",
                         "forge_type": "github",
+                        "release_branch": "stable-2.1",
                         "forge_token": {
                             "from_secret": "github_token",
                         },
@@ -365,7 +366,7 @@ def readyReleaseGo():
             "when": [
                 {
                     "event": ["push"],
-                    "branch": "${CI_REPO_DEFAULT_BRANCH}",
+                    "branch": "stable-2.1",
                 },
             ],
         },


### PR DESCRIPTION
## Description

Enable ready-release-go for the `stable-2.1` branch.

## Related Issue

- relates to #526 

## Types of changes

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
