### PR TITLE
ci: do not overwrite release when uploading artifacts

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -729,7 +729,6 @@ def buildAndPublishRelease(ctx):
                         "sha256",
                     ],
                     "title": ctx.build.ref.replace("refs/tags/v", ""),
-                    "overwrite": True,
                     "prerelease": len(ctx.build.ref.split("-")) > 1,
                 },
                 "when": [


### PR DESCRIPTION
Picks https://github.com/opencloud-eu/web/pull/502 to the stable branch.