### PR TITLE
🎉 Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.2.1](https://github.com/opencloud-eu/web/releases/tag/v2.2.1) - 2025-04-10
+
+### ❤️ Thanks to all contributors! ❤️
+
+@AlexAndBear, @JammingBen, @kulmann
+
+### 🐛 Bug Fixes
+
+- fix: use native fetch for downloading archives [[#525](https://github.com/opencloud-eu/web/pull/525)]
+- fix: hide request-id when it's undefined [[#470](https://github.com/opencloud-eu/web/pull/470)]
+- fix(files): truncation on long link names [[#489](https://github.com/opencloud-eu/web/pull/489)]
+- fix: archive download with archives >2GB [[#467](https://github.com/opencloud-eu/web/pull/467)]
+- Don't show backend edition when not set [[#443](https://github.com/opencloud-eu/web/pull/443)]
+
 ## [2.1.1](https://github.com/opencloud-eu/web/releases/tag/v2.1.1) - 2025-04-09
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.2.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.1` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.2.1](https://github.com/opencloud-eu/web/releases/tag/v2.2.1) - 2025-04-10

### 🐛 Bug Fixes

- fix: use native fetch for downloading archives [[#525](https://github.com/opencloud-eu/web/pull/525)]
- fix: hide request-id when it's undefined [[#470](https://github.com/opencloud-eu/web/pull/470)]
- fix(files): truncation on long link names [[#489](https://github.com/opencloud-eu/web/pull/489)]
- fix: archive download with archives >2GB [[#467](https://github.com/opencloud-eu/web/pull/467)]
- Don't show backend edition when not set [[#443](https://github.com/opencloud-eu/web/pull/443)]