### PR TITLE
fix: added avatar styling and truncated user name to avoid compressed…

### DIFF
--- a/packages/design-system/src/components/OcAvatar/OcAvatar.vue
+++ b/packages/design-system/src/components/OcAvatar/OcAvatar.vue
@@ -131,6 +131,7 @@ const randomBackgroundColor = (seed: number, colors: string[]) => {
   text-align: center;
   user-select: none;
   display: flex;
+  flex-shrink: 0;
   border-radius: 50%;
 
   .avatarImg {

--- a/packages/web-app-admin-settings/src/components/Groups/SideBar/MembersRoleSection.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/SideBar/MembersRoleSection.vue
@@ -7,7 +7,9 @@
       data-testid="group-members-list"
     >
       <oc-avatar :user-name="member.displayName" :width="36" class="oc-mr-s" />
-      <span>{{ member.displayName }}</span>
+      <span class="oc-text-truncate" :title="member.displayName">
+        {{ member.displayName }}
+      </span>
     </li>
   </ul>
 </template>


### PR DESCRIPTION
A new styling was added to oc-avatar so that user avatars are no longer compressed.

Additionally, a truncate was added to make the display more consistent.

fixes: #548 