### PR TITLE
fix: removed unnecessary oc-text-truncate to avoid a cut off

### DIFF
--- a/packages/web-app-admin-settings/src/components/Groups/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/SideBar/MembersPanel.vue
@@ -2,7 +2,7 @@
   <div class="oc-ml-s">
     <oc-text-input
       v-model="filterTerm"
-      class="oc-text-truncate oc-mr-s oc-mt-m"
+      class="oc-mr-s oc-mt-m"
       :label="$gettext('Filter members')"
     />
     <div ref="membersListRef" data-testid="space-members">

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/__snapshots__/MembersPanel.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/__snapshots__/MembersPanel.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MembersPanel > should display an empty result if no matching members found 1`] = `
 "<div class="oc-ml-s">
-  <oc-text-input-stub label="Filter members" id="oc-textinput-3" type="text" modelvalue="no-match" clearbuttonenabled="false" clearbuttonaccessiblelabel="" disabled="false" fixmessageline="false" readonly="false" passwordpolicy="[object Object]" class="oc-text-truncate oc-mr-s oc-mt-m"></oc-text-input-stub>
+  <oc-text-input-stub label="Filter members" id="oc-textinput-3" type="text" modelvalue="no-match" clearbuttonenabled="false" clearbuttonaccessiblelabel="" disabled="false" fixmessageline="false" readonly="false" passwordpolicy="[object Object]" class="oc-mr-s oc-mt-m"></oc-text-input-stub>
   <div data-testid="space-members">
     <div>
       <h3 class="oc-text-bold oc-text-medium">No members found</h3>
@@ -14,7 +14,7 @@ exports[`MembersPanel > should display an empty result if no matching members fo
 
 exports[`MembersPanel > should render all members accordingly to their role assignments 1`] = `
 "<div class="oc-ml-s">
-  <oc-text-input-stub label="Filter members" id="oc-textinput-1" type="text" modelvalue="" clearbuttonenabled="false" clearbuttonaccessiblelabel="" disabled="false" fixmessageline="false" readonly="false" passwordpolicy="[object Object]" class="oc-text-truncate oc-mr-s oc-mt-m"></oc-text-input-stub>
+  <oc-text-input-stub label="Filter members" id="oc-textinput-1" type="text" modelvalue="" clearbuttonenabled="false" clearbuttonaccessiblelabel="" disabled="false" fixmessageline="false" readonly="false" passwordpolicy="[object Object]" class="oc-mr-s oc-mt-m"></oc-text-input-stub>
   <div data-testid="space-members">
     <!--v-if-->
     <div class="oc-mb-m" data-testid="group-members">


### PR DESCRIPTION
Removed unnecessary oc-text-truncate to avoid the cut off inside the outline of the group member input field, when it has focus.

fixes: #540 