### PR TITLE
fix: added oc-text-truncate to avoid line overflows in search preview

### DIFF
--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -115,7 +115,7 @@
             <!-- eslint-disable vue/no-v-html -->
             <span
               v-if="resource.highlights"
-              class="files-search-resource-highlights oc-text-truncate"
+              class="files-search-resource-highlights oc-text-truncate oc-display-inline-block"
               v-html="resource.highlights"
             />
             <!--eslint-enable-->


### PR DESCRIPTION
Added oc-text-truncate to avoid line overflows into other columns in search preview

fixes: #546 