### PR TITLE
ci: add workflow for design-system docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 NAME := web
 DIST := ${CURDIR}/dist
-HUGO := ${CURDIR}/hugo
 RELEASE := ${CURDIR}/release
 NODE_MODULES := ${CURDIR}/node_modules
 
@@ -10,7 +9,7 @@ node_modules: package.json pnpm-lock.yaml
 
 .PHONY: clean
 clean:
-	rm -rf ${DIST} ${HUGO} ${RELEASE} ${NODE_MODULES}
+	rm -rf ${DIST} ${RELEASE} ${NODE_MODULES}
 
 .PHONY: release
 release: clean
@@ -24,26 +23,6 @@ release: clean
 .PHONY: dist
 dist:
 	make -f Makefile.release
-
-.PHONY: docs
-docs: docs-copy docs-build
-
-.PHONY: docs-copy
-docs-copy:
-	mkdir -p $(HUGO); \
-	mkdir -p $(HUGO)/content/extensions; \
-	cd $(HUGO); \
-	git init; \
-	git remote rm origin; \
-	git remote add origin https://github.com/opencloud-eu/opencloud-eu.github.io; \
-	git fetch; \
-	git checkout origin/main -f; \
-	make -C $(HUGO) theme; \
-	rsync --delete -ax ../docs/ content/$(NAME)
-
-.PHONY: docs-build
-docs-build:
-	cd $(HUGO); hugo
 
 .PHONY: l10n-push
 l10n-push:

--- a/packages/design-system/docs/.vitepress/components/ComponentApi.vue
+++ b/packages/design-system/docs/.vitepress/components/ComponentApi.vue
@@ -107,7 +107,7 @@ const isLoading = ref(true)
 const load = async (type: string, componentName: string) => {
   try {
     const response = await fetch(`../${type}/${componentName}.json`)
-    if (response.headers?.get('content-type') === 'application/json') {
+    if (response.headers?.get('content-type')?.startsWith('application/json')) {
       return response.json()
     }
     return []

--- a/packages/design-system/docs/.vitepress/config.ts
+++ b/packages/design-system/docs/.vitepress/config.ts
@@ -11,7 +11,7 @@ const stripScssMarker = '/* STYLES STRIP IMPORTS MARKER */'
 export default defineConfig({
   title: 'OpenCloud Design System',
   description: 'Design System for OpenCloud',
-  base: '/',
+  base: '/design-system/',
   appearance: false,
   head: [['link', { rel: 'icon', href: '/logo.svg' }]],
   vite: {


### PR DESCRIPTION
Adds a workflow for building and publishing the design-system to a branch called `design-system-docs`. From there it can be fetched and integrated by our Docusaurus docs.

refs https://github.com/opencloud-eu/web/issues/217