### PR TITLE
enhancement: disabled preview for txt files

### DIFF
--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -43,7 +43,6 @@ export class PreviewService {
         'image/gif',
         'image/png',
         'image/jpeg',
-        'text/plain',
         'image/tiff',
         'image/bmp',
         'image/x-ms-bmp',

--- a/packages/web-pkg/tests/unit/services/previewService.spec.ts
+++ b/packages/web-pkg/tests/unit/services/previewService.spec.ts
@@ -35,7 +35,7 @@ describe('PreviewService', () => {
       expect(previewService.getSupportedMimeTypes()).toEqual(supportedMimeTypes)
     })
     it('filters the supported mime types from the capabilities', () => {
-      const supportedMimeTypes = ['image/png', 'text/plain']
+      const supportedMimeTypes = ['image/png', 'image/jpeg']
       const { previewService } = getWrapper({ supportedMimeTypes })
       expect(previewService.getSupportedMimeTypes('image')).toEqual([supportedMimeTypes[0]])
     })


### PR DESCRIPTION
The preview for text/plain has been removed from all views to create a consistent view. Other text files are also not displayed with a preview.

solve: #545 