### PR TITLE
fix: chrome oh snap errors

### DIFF
--- a/packages/web-app-files/src/components/SideBar/ActivitiesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/ActivitiesPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div ref="rootElement">
-    <app-loading-spinner v-if="isLoading" />
+  <div v-if="isActive">
+    <oc-loader v-if="isLoading" />
     <template v-else>
       <p v-if="!activities.length" v-text="$gettext('No activities')" />
       <div v-else class="oc-ml-s">
@@ -19,123 +19,74 @@
   </div>
 </template>
 
-<script lang="ts">
-import {
-  computed,
-  defineComponent,
-  inject,
-  onBeforeUnmount,
-  onMounted,
-  Ref,
-  ref,
-  unref,
-  watch
-} from 'vue'
+<script setup lang="ts">
+import { computed, inject, Ref, ref, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
-import {
-  AppLoadingSpinner,
-  formatDateFromDateTime,
-  useClientService,
-  VisibilityObserver
-} from '@opencloud-eu/web-pkg'
+import { formatDateFromDateTime, useClientService } from '@opencloud-eu/web-pkg'
 import { useTask } from 'vue-concurrency'
 import { call, Resource } from '@opencloud-eu/web-client'
 import { DateTime } from 'luxon'
 import { Activity } from '@opencloud-eu/web-client/graph/generated'
 import escape from 'lodash-es/escape'
 
-const visibilityObserver = new VisibilityObserver()
-export default defineComponent({
-  name: 'ActivitiesPanel',
-  components: { AppLoadingSpinner },
-  setup() {
-    const rootElement = ref<HTMLElement>()
-    const { $ngettext, current: currentLanguage } = useGettext()
-    const clientService = useClientService()
-    const resource = inject<Ref<Resource>>('resource')
-    const activities = ref<Activity[]>([])
-    const activitiesLimit = 200
+const { isActive } = defineProps<{ isActive: boolean }>()
 
-    const activitiesFooterText = computed(() => {
-      return $ngettext(
-        'Showing %{activitiesCount} activity',
-        'Showing %{activitiesCount} activities',
-        unref(activities).length,
-        {
-          activitiesCount: unref(activities).length.toString()
-        }
-      )
-    })
+const { $ngettext, current: currentLanguage } = useGettext()
+const clientService = useClientService()
+const resource = inject<Ref<Resource>>('resource')
+const activities = ref<Activity[]>([])
+const activitiesLimit = 200
 
-    const loadActivitiesTask = useTask(function* (signal) {
-      activities.value = yield* call(
-        clientService.graphAuthenticated.activities.listActivities(
-          `itemid:${unref(resource).fileId} AND limit:${activitiesLimit} AND sort:desc`,
-          { signal }
-        )
-      )
-    }).restartable()
-
-    const isLoading = computed(() => {
-      return loadActivitiesTask.isRunning || !loadActivitiesTask.last
-    })
-
-    const getHtmlFromActivity = (activity: Activity) => {
-      let message = activity.template.message
-      for (const [key, value] of Object.entries(activity.template.variables)) {
-        const escapedValue = escape(value.displayName || value.name)
-
-        message = message.replace(`{${key}}`, `<strong>${escapedValue}</strong>`)
-      }
-      return message
+const activitiesFooterText = computed(() => {
+  return $ngettext(
+    'Showing %{activitiesCount} activity',
+    'Showing %{activitiesCount} activities',
+    unref(activities).length,
+    {
+      activitiesCount: unref(activities).length.toString()
     }
-
-    const getTimeFromActivity = (activity: Activity) => {
-      const dateTime = DateTime.fromISO(activity.times.recordedTime)
-      return formatDateFromDateTime(dateTime, currentLanguage)
-    }
-
-    const isVisible = ref(false)
-    watch(
-      [resource, isVisible],
-      () => {
-        if (!unref(isVisible)) {
-          return
-        }
-        loadActivitiesTask.perform()
-      },
-      {
-        immediate: true,
-        deep: true
-      }
-    )
-
-    onMounted(() => {
-      visibilityObserver.observe(unref(rootElement), {
-        onEnter: () => {
-          isVisible.value = true
-        },
-        onExit: () => {
-          isVisible.value = false
-        }
-      })
-    })
-
-    onBeforeUnmount(() => {
-      visibilityObserver.disconnect()
-    })
-
-    return {
-      rootElement,
-      activities,
-      activitiesLimit,
-      activitiesFooterText,
-      isLoading,
-      isVisible,
-      loadActivitiesTask,
-      getHtmlFromActivity,
-      getTimeFromActivity
-    }
-  }
+  )
 })
+
+const loadActivitiesTask = useTask(function* (signal) {
+  activities.value = yield* call(
+    clientService.graphAuthenticated.activities.listActivities(
+      `itemid:${unref(resource).fileId} AND limit:${activitiesLimit} AND sort:desc`,
+      { signal }
+    )
+  )
+}).restartable()
+
+const isLoading = computed(() => {
+  return loadActivitiesTask.isRunning || !loadActivitiesTask.last
+})
+
+const getHtmlFromActivity = (activity: Activity) => {
+  let message = activity.template.message
+  for (const [key, value] of Object.entries(activity.template.variables)) {
+    const escapedValue = escape(value.displayName || value.name)
+
+    message = message.replace(`{${key}}`, `<strong>${escapedValue}</strong>`)
+  }
+  return message
+}
+
+const getTimeFromActivity = (activity: Activity) => {
+  const dateTime = DateTime.fromISO(activity.times.recordedTime)
+  return formatDateFromDateTime(dateTime, currentLanguage)
+}
+
+watch(
+  () => [resource, isActive],
+  () => {
+    if (!unref(isActive)) {
+      return
+    }
+    loadActivitiesTask.perform()
+  },
+  {
+    immediate: true,
+    deep: true
+  }
+)
 </script>

--- a/packages/web-app-files/src/components/SideBar/ActivitiesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/ActivitiesPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isActive">
+  <div>
     <oc-loader v-if="isLoading" />
     <template v-else>
       <p v-if="!activities.length" v-text="$gettext('No activities')" />
@@ -28,8 +28,6 @@ import { call, Resource } from '@opencloud-eu/web-client'
 import { DateTime } from 'luxon'
 import { Activity } from '@opencloud-eu/web-client/graph/generated'
 import escape from 'lodash-es/escape'
-
-const { isActive } = defineProps<{ isActive: boolean }>()
 
 const { $ngettext, current: currentLanguage } = useGettext()
 const clientService = useClientService()
@@ -77,11 +75,8 @@ const getTimeFromActivity = (activity: Activity) => {
 }
 
 watch(
-  () => [resource, isActive],
+  resource,
   () => {
-    if (!unref(isActive)) {
-      return
-    }
     loadActivitiesTask.perform()
   },
   {

--- a/packages/web-app-files/tests/unit/components/SideBar/ActivitiesPanel.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/ActivitiesPanel.spec.ts
@@ -83,10 +83,6 @@ const defaultActivities = [
   }
 ]
 describe('ActivitiesPanel', () => {
-  it('should not render the panel if not active', () => {
-    const { wrapper } = getMountedWrapper({ isActive: false })
-    expect(wrapper.find('div').exists()).toBeFalsy()
-  })
   it('should show no activities message if there is no data', async () => {
     const { wrapper } = getMountedWrapper({ activities: [] })
     await flushPromises()
@@ -104,8 +100,7 @@ describe('ActivitiesPanel', () => {
 })
 
 function getMountedWrapper({
-  activities = defaultActivities,
-  isActive = true
+  activities = defaultActivities
 }: {
   activities?: any[]
   isActive?: boolean
@@ -117,7 +112,6 @@ function getMountedWrapper({
 
   return {
     wrapper: mount(ActivitiesPanel, {
-      props: { isActive },
       global: {
         mocks,
         plugins: [...defaultPlugins()],

--- a/packages/web-app-files/tests/unit/components/SideBar/ActivitiesPanel.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/ActivitiesPanel.spec.ts
@@ -2,7 +2,7 @@ import ActivitiesPanel from '../../../../src/components/SideBar/ActivitiesPanel.
 import { defaultComponentMocks, defaultPlugins, mount } from '@opencloud-eu/web-test-helpers'
 import { Resource } from '@opencloud-eu/web-client'
 import { mock } from 'vitest-mock-extended'
-import { nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 
 const defaultActivities = [
   {
@@ -83,32 +83,32 @@ const defaultActivities = [
   }
 ]
 describe('ActivitiesPanel', () => {
+  it('should not render the panel if not active', () => {
+    const { wrapper } = getMountedWrapper({ isActive: false })
+    expect(wrapper.find('div').exists()).toBeFalsy()
+  })
   it('should show no activities message if there is no data', async () => {
     const { wrapper } = getMountedWrapper({ activities: [] })
-    wrapper.vm.isVisible = true
-    await nextTick()
-    await wrapper.vm.loadActivitiesTask.last
+    await flushPromises()
     expect(wrapper.html()).toContain('No activities')
   })
-  it('should show loading spinner when fetching data', async () => {
+  it('should show loading spinner when fetching data', () => {
     const { wrapper } = getMountedWrapper()
-    wrapper.vm.isVisible = true
-    await nextTick()
-    expect(wrapper.find('#app-loading-spinner').exists()).toBeTruthy()
+    expect(wrapper.find('.oc-loader').exists()).toBeTruthy()
   })
   it('should render a list of activities when data is present', async () => {
     const { wrapper } = getMountedWrapper()
-    wrapper.vm.isVisible = true
-    await nextTick()
-    await wrapper.vm.loadActivitiesTask.last
+    await flushPromises()
     expect(wrapper.html()).toMatchSnapshot()
   })
 })
 
 function getMountedWrapper({
-  activities = defaultActivities
+  activities = defaultActivities,
+  isActive = true
 }: {
   activities?: any[]
+  isActive?: boolean
 } = {}) {
   const mocks = {
     ...defaultComponentMocks()
@@ -117,6 +117,7 @@ function getMountedWrapper({
 
   return {
     wrapper: mount(ActivitiesPanel, {
+      props: { isActive },
       global: {
         mocks,
         plugins: [...defaultPlugins()],

--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -65,16 +65,17 @@
             :class="{ 'sidebar-panel__body-content-stretch': !panel.isRoot?.(panelContext) }"
           >
             <slot name="body">
-              <component
-                :is="p.component"
+              <div
                 v-for="(p, index) in panel.isRoot?.(panelContext) ? rootPanels : [panel]"
                 :key="`sidebar-panel-${p.name}`"
-                :class="{ 'multi-root-panel-separator oc-mt oc-pt-s': index > 0 }"
-                v-bind="{
-                  ...(p.componentAttrs?.(panelContext) || {}),
-                  isActive: activePanelName === p.name
-                }"
-              />
+              >
+                <component
+                  :is="p.component"
+                  v-if="[activePanelName, oldPanelName].includes(p.name)"
+                  :class="{ 'multi-root-panel-separator oc-mt oc-pt-s': index > 0 }"
+                  v-bind="p.componentAttrs?.(panelContext) || {}"
+                />
+              </div>
             </slot>
           </div>
 

--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -70,7 +70,10 @@
                 v-for="(p, index) in panel.isRoot?.(panelContext) ? rootPanels : [panel]"
                 :key="`sidebar-panel-${p.name}`"
                 :class="{ 'multi-root-panel-separator oc-mt oc-pt-s': index > 0 }"
-                v-bind="p.componentAttrs?.(panelContext) || {}"
+                v-bind="{
+                  ...(p.componentAttrs?.(panelContext) || {}),
+                  isActive: activePanelName === p.name
+                }"
               />
             </slot>
           </div>
@@ -199,7 +202,7 @@ const windowWidth = ref(window.innerWidth)
 
 const fullWidthSideBar = computed(() => unref(windowWidth) <= 580)
 const backgroundContentEl = computed(() => {
-  return unref(appSideBar)?.parentElement?.querySelector('div') as HTMLElement
+  return unref(appSideBar)?.parentElement?.querySelector('div')
 })
 
 const handleBackgroundContentVisibility = () => {
@@ -382,12 +385,6 @@ onBeforeUnmount(() => {
     &-content-stretch {
       flex: 1;
     }
-
-    // &-content {
-    //   background-color: var(--oc-role-surface-container);
-    //   border-radius: 5px;
-    //   padding: var(--oc-space-medium);
-    // }
   }
 
   &__navigation {


### PR DESCRIPTION
This happens sometimes (for me anyway) when there are too many css animations on the screen. The loading spinner in the activities panels seems to have pushed this over a limit, hence only render the panel content if the panel is active. Also refactors the activity panel to script setup.