### PR TITLE
chore(design-system): bundle css & externalize vue

### DIFF
--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -6,7 +6,7 @@ The **OpenCloud Design System** provides components and utilities for applicatio
 OpenCloud Web ecosystem. It can be developed standalone via the design system documentation. The documentation is
 built with [VitePress](https://vitepress.dev/).
 
-Head over to the [hosted docs](https://design.opencloud.eu/) for more information!
+Head over to the [hosted docs](https://docs.opencloud.eu/design-system/) for more information!
 
 ## Running the docs locally
 
@@ -24,14 +24,34 @@ pnpm docs:dev
 
 ## Usage as a package
 
-To use the components and utilities of the design-system in your application, you first need to install the package. Depending on your package manager, run one of the following commands:
+### Installation
+
+To use the design-system in your application, you first need to install the package. Depending on your package manager, run one of the following commands:
 
 ```
-$ npm install @opencloud-eu/design-system --save-dev
+$ npm install @opencloud-eu/design-system
 
 $ pnpm add -D @opencloud-eu/design-system
 
-$ yarn add @opencloud-eu/design-system --dev
+$ yarn add @opencloud-eu/design-system
 ```
 
-It's recommended to install this package as a dev dependency because it's only really needed for providing autocompletion in your IDE and unit tests. In a runtime context, the OpenCloud Web runtime provides the actual implementation.
+### Styles
+
+In order to use the provided CSS classes and to ensure the components are styled correctly, you need to import the styles like so:
+
+```
+import '@opencloud-eu/design-system/dist/design-system.css'
+```
+
+### Components
+
+To use the components, you need to import the component you want to use. For example, to use the `OcButton` component:
+
+```
+import { OcButton } from '@opencloud-eu/design-system/components'
+
+<oc-button>
+  Click me!
+</oc-button>
+```

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -31,10 +31,12 @@ To use the design-system in your application, you first need to install the pack
 ```
 $ npm install @opencloud-eu/design-system
 
-$ pnpm add -D @opencloud-eu/design-system
+$ pnpm add @opencloud-eu/design-system
 
 $ yarn add @opencloud-eu/design-system
 ```
+
+Note that if you're using the design-system in an OpenCloud Web app, it's recommended to install it as dev dependency. This is because the Web runtime already ships the design-system and you only need it for development purposes in your IDE.
 
 ### Styles
 
@@ -43,6 +45,8 @@ In order to use the provided CSS classes and to ensure the components are styled
 ```
 import '@opencloud-eu/design-system/dist/design-system.css'
 ```
+
+Again, this is not needed if you're using the design-system in an OpenCloud Web app because the styles are already available via the Web runtime.
 
 ### Components
 
@@ -54,4 +58,28 @@ import { OcButton } from '@opencloud-eu/design-system/components'
 <oc-button>
   Click me!
 </oc-button>
+```
+
+You can also register the components globally in your standalone Vue app. This way you don't need to import them any time you want to use them.
+
+```
+import { createApp } from 'vue'
+import DesignSystem from '@opencloud-eu/design-system'
+
+const app = createApp({ ... })
+app.use(DesignSystem)
+```
+
+Optionally, you can pass custom design tokens to the design-system. Check the [example theme](https://github.com/opencloud-eu/opencloud/blob/v2.2.0/services/web/assets/themes/opencloud/theme.json) for a list of available tokens.
+
+```
+const tokens = {
+  spacing: {
+    small: '4px',
+    medium: '8px',
+    large: '16px',
+  }
+}
+
+app.use(DesignSystem, { tokens })
 ```

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -50,7 +50,7 @@ Again, this is not needed if you're using the design-system in an OpenCloud Web 
 
 ### Components
 
-To use the components, you need to import the component you want to use. For example, to use the `OcButton` component:
+To use a component, you need to import it. For example, to use the `OcButton` component:
 
 ```
 import { OcButton } from '@opencloud-eu/design-system/components'

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -66,6 +66,9 @@
         "default": "./dist/design-system/helpers.js",
         "require": "./dist/design-system/helpers.cjs",
         "types": "./dist/src/helpers/index.d.ts"
+      },
+      "./dist/design-system.css": {
+        "default": "./dist/design-system.css"
       }
     }
   },

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -11,6 +11,7 @@ const initializeCustomProps = (tokens: string[] = [], prefix: string) => {
 }
 
 export default {
+  // TODO: properly type the options
   install(app: App, options: any = {}) {
     import('./utils/webFontLoader')
 

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -43,8 +43,14 @@ export default defineConfig({
             dep !== 'webfontloader'
         ),
         '**/tests',
-        '**/*.spec.ts'
-      ]
+        '**/*.spec.ts',
+        'vue'
+      ],
+      output: {
+        globals: {
+          vue: 'Vue'
+        }
+      }
     }
   },
   plugins: [vue(), dts({ exclude: ['**/tests', '**/*.spec.ts'] })]


### PR DESCRIPTION
* Makes sure the css styles get bundled correctly so they can be imported via `@opencloud-eu/design-system/dist/design-system.css`.
* Externalize vue during build. This ensures that the components can be used properly when importing the design-system as a module in other projects. Vue is a peer dependency and needs to be provided by the host application.
