### PR TITLE
fix: opening previews in share spaces

### DIFF
--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -167,15 +167,21 @@ export default defineComponent({
     const keyBindings: string[] = []
 
     const space = computed(() => {
+      if (!unref(activeFilteredFile)) {
+        return null
+      }
       return getMatchingSpace(unref(activeFilteredFile))
     })
 
-    const isDeleteButtonVisible = computed(() =>
-      unref(deleteFileActions)[0]?.isVisible({
+    const isDeleteButtonVisible = computed(() => {
+      if (!unref(space)) {
+        return false
+      }
+      return unref(deleteFileActions)[0]?.isVisible({
         space: unref(space),
         resources: [unref(activeFilteredFile)]
       })
-    )
+    })
 
     const sortBy = computed(() => {
       if (!unref(contextRouteQuery)) {


### PR DESCRIPTION
Opening previews was completely broken in share spaces because the `isDeleteButtonVisible` computed used the space before it's loaded. 