### PR TITLE
fix: bring back the left top rounded corner in the app bar

### DIFF
--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -347,6 +347,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 #files-app-bar {
   background-color: var(--oc-role-surface);
+  border-top-left-radius: 15px;
   border-top-right-radius: 15px;
   box-sizing: border-box;
   z-index: 2;


### PR DESCRIPTION
## Description

Bring back the left top rounded corner in the app bar.

<img width="467" alt="Screenshot 2025-05-07 at 10 51 30" src="https://github.com/user-attachments/assets/2f95c6ee-7eea-45e9-847e-29bab3837fb0" />


## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
