### PR TITLE
feat(design-system): add option for icon url prefix

### DIFF
--- a/packages/design-system/src/components/OcIcon/OcIcon.vue
+++ b/packages/design-system/src/components/OcIcon/OcIcon.vue
@@ -18,7 +18,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import InlineSvg from 'vue-inline-svg'
-import { FillType, getSizeClass, SizeType, uniqueId } from '../../helpers'
+import { FillType, getSizeClass, SizeType, uniqueId, getIconUrlPrefix } from '../../helpers'
 
 InlineSvg.name = 'inline-svg'
 
@@ -73,7 +73,7 @@ const emit = defineEmits<Emits>()
 const svgTitleId = computed(() => uniqueId('oc-icon-title-'))
 
 const nameWithFillType = computed(() => {
-  const path = 'icons/'
+  const path = `${getIconUrlPrefix()}icons/`
   const lowerFillType = fillType.toLowerCase()
   if (lowerFillType === 'none') {
     return `${path}${name}.svg`

--- a/packages/design-system/src/helpers/icons.ts
+++ b/packages/design-system/src/helpers/icons.ts
@@ -1,0 +1,9 @@
+let iconUrlPrefix = ''
+
+export const setIconUrlPrefix = (prefix: string) => {
+  iconUrlPrefix = prefix
+}
+
+export const getIconUrlPrefix = () => {
+  return iconUrlPrefix
+}

--- a/packages/design-system/src/helpers/index.ts
+++ b/packages/design-system/src/helpers/index.ts
@@ -1,6 +1,7 @@
 export * from './applyCustomProp'
 export * from './colors'
 export * from './constants'
+export * from './icons'
 export * from './sizeClasses'
 export * from './types'
 export * from './uniqueId'

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { applyCustomProp } from './helpers'
+import { applyCustomProp, setIconUrlPrefix } from './helpers'
 
 import * as components from './components'
 import * as directives from './directives'
@@ -16,6 +16,8 @@ const initializeCustomProps = (tokens: string[] = [], prefix: string) => {
 export default {
   // TODO: properly type the options
   install(app: App, options: any = {}) {
+    setIconUrlPrefix(options.iconUrlPrefix || '')
+
     const themeOptions = options.tokens
     initializeCustomProps(themeOptions?.breakpoints, 'breakpoint-')
     initializeCustomProps(themeOptions?.colorPalette, 'color-')

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -76,7 +76,7 @@ exports[`account page > public link context > should render a limited view 1`] =
                 </a></div>
             </td>
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td" data-testid="language">
-              <div options="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" model-value="[object Object]">
+              <div options="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" model-value="[object Object]">
                 <!--v-if-->
                 <!--v-if-->
                 <div dir="auto" class="v-select vs--single vs--searchable oc-select" style="background: transparent;">


### PR DESCRIPTION
This allows users of the design-system to specify a prefix for the icon loading. This might be useful when using it as a library.