### PR TITLE
[stable-2.1] fix: add missing icon for otp

### DIFF
--- a/packages/web-pkg/src/helpers/resource/icon.ts
+++ b/packages/web-pkg/src/helpers/resource/icon.ts
@@ -171,6 +171,7 @@ const fileIcon = {
     icon: { name: 'resource-type-presentation', color: 'var(--oc-color-icon-presentation)' },
     extensions: [
       'odp',
+      'otp',
       'pot',
       'potm',
       'potx',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-2.1`:
 - [fix: add missing icon for otp](https://github.com/opencloud-eu/web/pull/667)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)