### PR TITLE
fix(design-system): text input error message icon position

### DIFF
--- a/packages/design-system/src/components/OcTextInput/OcTextInput.vue
+++ b/packages/design-system/src/components/OcTextInput/OcTextInput.vue
@@ -304,12 +304,6 @@ const onFocus = async (target: HTMLInputElement) => {
   display: flex;
   align-items: center;
   position: relative;
-
-  .oc-icon {
-    position: absolute;
-    left: var(--oc-space-xsmall);
-    top: var(--oc-space-xsmall);
-  }
 }
 
 .oc-text-input {


### PR DESCRIPTION
Follow-up of https://github.com/opencloud-eu/web/pull/686.