### PR TITLE
feat: remove space membership info in file list

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -307,11 +307,7 @@ export default defineComponent({
     },
 
     showSpaceMembers() {
-      return (
-        this.space?.driveType === 'project' &&
-        this.resource.type !== 'space' &&
-        this.space?.isMember(this.user)
-      )
+      return isProjectSpaceResource(this.space) && this.resource.type !== 'space'
     }
   },
   methods: {

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -131,12 +131,6 @@
                 />
               </span>
             </template>
-            <template #manager="{ resource }">
-              {{ getManagerNames(resource) }}
-            </template>
-            <template #members="{ resource }">
-              {{ getMemberCount(resource) }}
-            </template>
             <template #totalQuota="{ resource }">
               {{ getTotalQuota(resource) }}
             </template>
@@ -186,7 +180,6 @@ import {
 } from '@opencloud-eu/web-pkg'
 import SpaceContextActions from '../../components/Spaces/SpaceContextActions.vue'
 import {
-  getSpaceManagers,
   isProjectSpaceResource,
   ProjectSpaceResource,
   SpaceResource
@@ -261,8 +254,6 @@ const selectedSpace = computed(() => {
 const tableDisplayFields = [
   'image',
   'name',
-  'manager',
-  'members',
   'totalQuota',
   'usedQuota',
   'remainingQuota',
@@ -355,18 +346,6 @@ useKeyboardFileNavigation(keyActions, runtimeSpaces, viewMode)
 useKeyboardFileMouseActions(keyActions, viewMode)
 useKeyboardFileActions(keyActions)
 
-const getManagerNames = (space: SpaceResource) => {
-  const allManagers = getSpaceManagers(space)
-  const managers = allManagers.length > 2 ? allManagers.slice(0, 2) : allManagers
-  let managerStr = managers
-    .map(({ grantedTo }) => (grantedTo.user || grantedTo.group).displayName)
-    .join(', ')
-  if (allManagers.length > 2) {
-    managerStr += `... +${allManagers.length - 2}`
-  }
-  return managerStr
-}
-
 const getTotalQuota = (space: SpaceResource) => {
   if (space.spaceQuota.total === 0) {
     return $gettext('Unrestricted')
@@ -388,9 +367,6 @@ const getRemainingQuota = (space: SpaceResource) => {
     return '-'
   }
   return formatFileSize(space.spaceQuota.remaining, language.current)
-}
-const getMemberCount = (space: SpaceResource) => {
-  return Object.keys(space.members).length
 }
 
 onMounted(async () => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -119,7 +119,7 @@ describe('FileShares', () => {
   describe('current space', () => {
     it('loads space members if a space is given and the current user is member', () => {
       const user = { id: '1' } as User
-      const space = mock<SpaceResource>({ driveType: 'project', isMember: () => true })
+      const space = mock<SpaceResource>({ driveType: 'project' })
       const spaceMembers = [
         { sharedWith: { id: user.id, displayName: '' }, resourceId: space.id, permissions: [] },
         { sharedWith: { id: '2', displayName: '' }, resourceId: space.id, permissions: [] }
@@ -133,20 +133,6 @@ describe('FileShares', () => {
       expect(wrapper.find('#files-collaborators-list').exists()).toBeTruthy()
       expect(wrapper.findAll('#files-collaborators-list li').length).toBe(1)
       expect(wrapper.html()).toMatchSnapshot()
-    })
-    it('does not load space members if a space is given but the current user not a member', () => {
-      const user = { id: '1' } as User
-      const space = mock<SpaceResource>({ driveType: 'project' })
-      const spaceMembers = [
-        { sharedWith: { id: `${user}-2`, displayName: '' }, resourceId: space.id, permissions: [] }
-      ] as CollaboratorShare[]
-      const collaborator = getCollaborator()
-      collaborator.sharedWith = {
-        ...collaborator.sharedWith,
-        id: user.id
-      }
-      const { wrapper } = getWrapper({ space, collaborators: [collaborator], user, spaceMembers })
-      expect(wrapper.find('#space-collaborators-list').exists()).toBeFalsy()
     })
   })
 

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -8,7 +8,6 @@ import {
 } from '../resource'
 import {
   isPersonalSpaceResource,
-  isPublicSpaceResource,
   PublicSpaceResource,
   ShareSpaceResource,
   SpaceMember,
@@ -19,7 +18,7 @@ import { DavProperty } from '../../webdav/constants'
 import { buildWebDavPublicPath, buildWebDavOcmPath } from '../publicLink'
 import { urlJoin } from '../../utils'
 import { Drive, DriveItem } from '@opencloud-eu/web-client/graph/generated'
-import { GraphSharePermission, ShareRole } from '../share'
+import { CollaboratorShare, GraphSharePermission, ShareRole } from '../share'
 
 export function buildWebDavSpacesPath(storageId: string, path?: string) {
   return urlJoin('spaces', storageId, path, {
@@ -53,6 +52,11 @@ export function getSpaceManagers(space: SpaceResource) {
     // delete permissions implies that the user/group is a manager
     permissions.includes(GraphSharePermission.deletePermissions)
   )
+}
+
+export function isManager(share: CollaboratorShare) {
+  // delete permissions implies that the user/group is a manager
+  return share.permissions.includes(GraphSharePermission.deletePermissions)
 }
 
 export type PublicLinkType = 'ocm' | 'public-link'
@@ -331,15 +335,6 @@ export function buildSpace(
     },
     getWebDavTrashUrl({ path }: { path: string }): string {
       return urlJoin(webDavTrashUrl, path)
-    },
-    isMember(user: User): boolean {
-      if (isPublicSpaceResource(this)) {
-        return false
-      }
-      if (this.isOwner(user) || !!this.members[user.id]) {
-        return true
-      }
-      return user.memberOf?.some((group) => !!this.members[group.id])
     },
     isOwner(user: User): boolean {
       return user?.id === this.owner?.id

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -49,7 +49,6 @@ export interface SpaceResource extends Resource {
   getWebDavTrashUrl({ path }: { path: string }): string
   getDriveAliasAndItem(resource: Resource): string
 
-  isMember(user: User): boolean
   isOwner(user: User): boolean
 }
 

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -238,8 +238,8 @@ export const useResourcesStore = defineStore('resources', () => {
     let fullyAccessibleSpace = true
     if (configStore.options.routing.fullShareOwnerPaths) {
       // keep logic in sync with "isResourceAccessible" from useGetMatchingSpace
-      const projectSpace = spaces.find((s) => isProjectSpaceResource(s) && s.id === space.id)
-      fullyAccessibleSpace = space.isOwner(userStore.user) || projectSpace?.isMember(userStore.user)
+      const projectSpace = spaces.some((s) => isProjectSpaceResource(s) && s.id === space.id)
+      fullyAccessibleSpace = space.isOwner(userStore.user) || projectSpace
     }
 
     for (const path of parentPaths) {

--- a/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
@@ -90,9 +90,8 @@ export const useGetMatchingSpace = (options?: GetMatchingSpaceOptions) => {
       return true
     }
 
-    const projectSpace = unref(spaces).find((s) => isProjectSpaceResource(s) && s.id === space.id)
-    const fullyAccessibleSpace =
-      space.isOwner(userStore.user) || projectSpace?.isMember(userStore.user)
+    const projectSpace = unref(spaces).some((s) => isProjectSpaceResource(s) && s.id === space.id)
+    const fullyAccessibleSpace = space.isOwner(userStore.user) || projectSpace
 
     return (
       fullyAccessibleSpace ||

--- a/packages/web-pkg/src/helpers/statusIndicators.ts
+++ b/packages/web-pkg/src/helpers/statusIndicators.ts
@@ -137,8 +137,7 @@ export const getIndicators = ({
   }
 
   const shareIndicatorsAllowed =
-    (isProjectSpaceResource(space) && space.isMember(user)) ||
-    (isPersonalSpaceResource(space) && space.isOwner(user))
+    isProjectSpaceResource(space) || (isPersonalSpaceResource(space) && space.isOwner(user))
 
   if (shareIndicatorsAllowed) {
     const parentShareTypes = Object.values(ancestorMetaData).reduce<number[]>((acc, data) => {

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
@@ -16,6 +16,7 @@ const spaceMock = {
   type: 'space',
   name: ' space',
   id: '1',
+  driveType: 'project',
   mdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
   members: [
     mock<SpaceMember>({
@@ -32,10 +33,12 @@ const spaceMock = {
 const spaceShare = {
   id: '1',
   sharedWith: {
-    id: 'Alice',
+    id: '1',
     displayName: 'alice'
   },
-  role: mock<ShareRole>()
+  resourceId: '1',
+  role: mock<ShareRole>(),
+  permissions: [GraphSharePermission.deletePermissions]
 } as CollaboratorShare
 
 const selectors = {
@@ -82,6 +85,7 @@ function createWrapper({ spaceResource = spaceMock, props = {} } = {}) {
         plugins: [
           ...defaultPlugins({
             piniaOptions: {
+              stubActions: false,
               userState: { user: { id: '1', onPremisesSamAccountName: 'marie' } as User },
               sharesState: { collaboratorShares: [spaceShare] },
               resourcesStore: { resources: [mock<Resource>({ name: 'file1', type: 'file' })] }

--- a/packages/web-pkg/tests/unit/helpers/statusIndicator.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/statusIndicator.spec.ts
@@ -28,13 +28,6 @@ describe('status indicators', () => {
   })
 
   describe('sharing indicators', () => {
-    it('should not be present if the user is not a member of the project space', () => {
-      const space = mock<SpaceResource>({ driveType: 'project', isMember: () => false })
-      const resource = mock<Resource>({ id: 'resource', shareTypes: [0, 3] })
-      const indicators = getIndicators({ space, resource, ancestorMetaData: {}, user })
-
-      expect(indicators.some(({ category }) => category === 'sharing')).toBeFalsy()
-    })
     it("should not be present in another user's personal space", () => {
       const space = mock<SpaceResource>({ driveType: 'personal', isOwner: () => false })
       const resource = mock<Resource>({ id: 'resource', shareTypes: [0, 3] })
@@ -57,7 +50,7 @@ describe('status indicators', () => {
       expect(indicators.some(({ category }) => category === 'sharing')).toBeFalsy()
     })
     it('should be present for direct collaborator and link shares', () => {
-      const space = mock<SpaceResource>({ driveType: 'project', isMember: () => true })
+      const space = mock<SpaceResource>({ driveType: 'project' })
       const resource = mock<Resource>({ id: 'resource', shareTypes: [0, 3] })
       const indicators = getIndicators({ space, resource, ancestorMetaData: {}, user })
 
@@ -73,7 +66,7 @@ describe('status indicators', () => {
         '/': mock<AncestorMetaDataValue>({ shareTypes: [0, 3] })
       }
 
-      const space = mock<SpaceResource>({ driveType: 'project', isMember: () => true })
+      const space = mock<SpaceResource>({ driveType: 'project' })
       const resource = mock<Resource>({ id: 'resource', shareTypes: [] })
       const indicators = getIndicators({ space, resource, ancestorMetaData, user })
 


### PR DESCRIPTION
We don't want to display this kind of information anymore due to performance reasons.

Also removes unnecessary `isMember` checks on project spaces since `/me/drives` only returns spaces where the current user is member of.

Preparation for https://github.com/opencloud-eu/web/issues/706