### PR TITLE
fix(admin-settings): broken update user space quota for users with sp…

### DIFF
--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -230,7 +230,6 @@ export default defineComponent({
       const updateSpace = await client.drives.updateDrive(
         editUser.drive.id,
         {
-          name: editUser.drive.name,
           quota: { total: editUser.drive.quota.total }
         },
         sharesStore.graphRoles

--- a/packages/web-client/src/graph/drives/types.ts
+++ b/packages/web-client/src/graph/drives/types.ts
@@ -1,5 +1,5 @@
 import type { ShareRole, SpaceResource } from '../../helpers'
-import type { Drive } from '../generated'
+import type { Drive, DriveUpdate } from '../generated'
 import type { GraphRequestOptions } from '../types'
 
 export interface GraphDrives {
@@ -15,7 +15,7 @@ export interface GraphDrives {
   ) => Promise<SpaceResource>
   updateDrive: (
     id: string,
-    data: Drive,
+    data: DriveUpdate,
     graphRoles: Record<string, ShareRole>,
     requestOptions?: GraphRequestOptions
   ) => Promise<SpaceResource>


### PR DESCRIPTION
…ecial characters in name

## Description
Under certain circumstances, it was not possible to change the user space quota. For example, it failed if the username contained special characters...

The error occurred because Web had always sent the username when changing the quota... In the end, it all comes down to the fact that the wrong interface was used in the client, which required a name

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/789

## How Has This Been Tested?

- local installation

## Types of changes

- [X] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
