### PR TITLE
[with-tracing] Upload tracing results of UI tests to public S3

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -183,8 +183,8 @@ function filterTracingReports(status: string) {
     reports.forEach((report) => {
       fs.renameSync(`${traceDir}/${report}`, `${failedDir}/${report}`)
     })
-  } else {
-    // clean up the tracing directory
+  } else if (!defaults.reportTracing) {
+    // clean up the tracing directory if the report tracing was not set explicitly
     fs.rmSync(traceDir, { recursive: true })
   }
 }

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -166,7 +166,11 @@ AfterAll(async () => {
   // move failed tracing reports
   const failedDir = path.dirname(config.tracingReportDir) + '/failed'
   if (fs.existsSync(failedDir)) {
-    fs.renameSync(failedDir, config.tracingReportDir)
+    fs.mkdirSync(config.tracingReportDir, { recursive: true })
+    fs.readdirSync(failedDir).forEach((file) => {
+      fs.renameSync(failedDir + '/' + file, config.tracingReportDir + '/' + file)
+    })
+    fs.rmSync(failedDir, { recursive: true })
   }
 })
 


### PR DESCRIPTION
## Description

When a PR contains `with-tracing` in the heading or a test fails, the tracing results will be uploaded to a public S3 bucket, so that they can be used for debugging.

The cleanup will be done in #838

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes https://github.com/opencloud-eu/qa/issues/24

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- passing tests with `with-tracing` in the PR header
- failed tests without `with-tracing` in the PR header

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
