### PR TITLE
🎉 Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.0.1](https://github.com/opencloud-eu/web/releases/tag/v3.0.1) - 2025-06-10
+
+### ❤️ Thanks to all contributors! ❤️
+
+@JammingBen
+
+### 🐛 Bug Fixes
+
+- fix: space member count in space header component [[#812](https://github.com/opencloud-eu/web/pull/812)]
+
 ## [3.0.0](https://github.com/opencloud-eu/web/releases/tag/v3.0.0) - 2025-06-10
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.0.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.0.1](https://github.com/opencloud-eu/web/releases/tag/v3.0.1) - 2025-06-10

### 🐛 Bug Fixes

- fix: space member count in space header component [[#812](https://github.com/opencloud-eu/web/pull/812)]