### PR TITLE
fix: exclude public links from space member count

### DIFF
--- a/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
@@ -202,7 +202,7 @@ watch(
         space.id,
         space.id,
         sharesStore.graphRoles,
-        { count: true }
+        { count: true, filter: "grantedToV2 ne ''" }
       )
       memberCount.value = count || 1
     } catch (e) {


### PR DESCRIPTION
Follow-up for https://github.com/opencloud-eu/web/pull/812.

Needs https://github.com/opencloud-eu/opencloud/pull/996 to work properly, although it doesn't destroy anything without, so it can be merged independently.