### PR TITLE
A11y tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "not OperaMobile > 0"
   ],
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@babel/core": "7.27.3",
     "@babel/polyfill": "7.12.1",
     "@babel/preset-env": "7.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   .:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.10.2
+        version: 4.10.2(playwright-core@1.52.0)
       '@babel/core':
         specifier: 7.27.3
         version: 7.27.3
@@ -1214,6 +1217,11 @@ packages:
 
   '@asamuzakjp/css-color@3.1.5':
     resolution: {integrity: sha512-w7AmVyTTiU41fNLsFDf+gA2Dwtbx2EJtn2pbJNAGSRAg50loXy1uLXA3hEpD8+eydcomTurw09tq5/AyceCaGg==}
+
+  '@axe-core/playwright@4.10.2':
+    resolution: {integrity: sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -3339,6 +3347,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.10.3:
+    resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
 
   axios@1.9.0:
     resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
@@ -6767,6 +6779,11 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       lru-cache: 10.4.3
 
+  '@axe-core/playwright@4.10.2(playwright-core@1.52.0)':
+    dependencies:
+      axe-core: 4.10.3
+      playwright-core: 1.52.0
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -9228,6 +9245,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.10.3: {}
 
   axios@1.9.0:
     dependencies:

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -79,6 +79,7 @@ Before(async function (this: World, { pickle }: ITestCaseHookParameter) {
     }
   }
   this.uniquePrefix = uuidv4().substring(0, 3)
+  this.a11yEnabled = pickle.tags.some((tag) => tag.name === '@a11y')
 })
 
 BeforeAll(async (): Promise<void> => {

--- a/tests/e2e/cucumber/environment/world.ts
+++ b/tests/e2e/cucumber/environment/world.ts
@@ -16,6 +16,7 @@ export class World extends CucumberWorld {
   spacesEnvironment: environment.SpacesEnvironment
   usersEnvironment: environment.UsersEnvironment
   uniquePrefix: string
+  a11yEnabled: boolean = false
 
   constructor(options: WorldOptions) {
     super(options)

--- a/tests/e2e/cucumber/features/a11y/smoke.feature
+++ b/tests/e2e/cucumber/features/a11y/smoke.feature
@@ -1,0 +1,89 @@
+@a11y
+Feature: Accessibility checks
+
+  Scenario: check files view wrapper accessibility
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+      | Brian |
+    And "Admin" creates following groups using API
+      | id    |
+      | sales |
+    And "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Admin" adds user to the group using API
+      | user  | group |
+      | Alice | sales |
+    And "Alice" creates the following project spaces using API
+      | name     | id       |
+      | my_space | my_space |
+    And "Alice" creates the following folder in space "my_space" using API
+      | name        |
+      | spaceFolder |
+    And "Alice" creates the following folders in personal space using API
+      | name   |
+      | parent |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile       | to              |
+      | testavatar.jpeg | testavatar.jpeg |
+    And "Alice" shares the following resource using API
+      | resource | recipient | type  | role     |
+      | parent   | Brian     | user  | Can edit |
+      | parent   | sales     | group | Can edit |
+    And "Alice" creates a public link of following resource using API
+      | resource | role     | password |
+      | parent   | Can edit | %public% |
+    
+    ## checks login page
+    When "Alice" logs in
+
+    ## check files-view-wrapper
+    # personal space
+    And "Alice" opens the "files" app
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+    And "Alice" switches to the tiles-view
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+    And "Alice" switches to the "resource-table-condensed" view mode
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+
+    # shares
+    And "Alice" navigates to the shared with me page
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+    And "Alice" navigates to the shared with others page
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+    And "Alice" navigates to the shared via link page
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+
+    # project spaces
+    And "Alice" navigates to the projects space page
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+    And "Alice" switches to the tiles-view
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+    And "Alice" navigates to the project space "my_space"
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+    And "Alice" switches to the "resource-table" view mode
+    And "Alice" check accessibility of the ".files-view-wrapper" page
+
+    # deleted files
+    # search results
+
+    ## check accesability on top bar
+    # search panel
+    # notifications
+    
+    ## left sidebar web-nav-sidebar
+    
+    ## admin-settings-view-wrapper
+    # general
+    # users
+    # groups
+    # spaces
+
+    ## account page
+
+    ## app-sidebar (right sidebar)
+
+    ## public link page
+    
+    When "Alice" logs out

--- a/tests/e2e/cucumber/steps/ui/a11.y.ts
+++ b/tests/e2e/cucumber/steps/ui/a11.y.ts
@@ -1,0 +1,11 @@
+import { Then } from '@cucumber/cucumber'
+import { World } from '../../environment'
+import { checkAccessibility } from '../../../support/utils/accessibility'
+
+Then(
+  '{string} check accessibility of the {string} page',
+  async function (this: World, stepUser: string, place: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    await checkAccessibility(page, `personal space page`, place)
+  }
+)

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -420,6 +420,15 @@ When(
 )
 
 When(
+  '{string} switches to the {string} view mode',
+  async function (this: World, stepUser: string, viewMode: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    await resourceObject.switchViewMode(viewMode)
+  }
+)
+
+When(
   '{string} sees the resources displayed as tiles',
   async function (this: World, stepUser: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })

--- a/tests/e2e/cucumber/steps/ui/session.ts
+++ b/tests/e2e/cucumber/steps/ui/session.ts
@@ -119,7 +119,7 @@ When(
   }
 )
 
-Given('using {string} server', async function (this: World, server: string): Promise<void> {
+Given('using {string} server', function (this: World, server: string): void {
   switch (server) {
     case 'LOCAL':
       config.federatedServer = false

--- a/tests/e2e/cucumber/steps/ui/session.ts
+++ b/tests/e2e/cucumber/steps/ui/session.ts
@@ -23,7 +23,7 @@ async function LogInUser(this: World, stepUser: string): Promise<void> {
       : this.usersEnvironment.getCreatedUser({ key: stepUser })
 
   await page.goto(config.baseUrl)
-  await sessionObject.login(user)
+  await sessionObject.login(user, this.a11yEnabled)
 
   if (this.feature.tags.length > 0) {
     const tags: string[] = []

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import EventEmitter from 'events'
 import { Actor } from '../../types'
 import { ActorOptions, buildBrowserContextOptions } from './shared'
+import { patchPageForA11y } from '../../utils/accessibility'
 
 export class ActorEnvironment extends EventEmitter implements Actor {
   private readonly options: ActorOptions
@@ -24,6 +25,10 @@ export class ActorEnvironment extends EventEmitter implements Actor {
 
     this.page = await this.context.newPage()
     this.tabs.push(this.page)
+
+    if (process.env.A11Y_TEST === 'true') {
+      patchPageForA11y(this.page)
+    }
 
     this.page.on('pageerror', (exception) => {
       console.log(`[UNCAUGHT EXCEPTION] "${exception}"`)

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import EventEmitter from 'events'
 import { Actor } from '../../types'
 import { ActorOptions, buildBrowserContextOptions } from './shared'
-import { patchPageForA11y } from '../../utils/accessibility'
 
 export class ActorEnvironment extends EventEmitter implements Actor {
   private readonly options: ActorOptions
@@ -25,10 +24,6 @@ export class ActorEnvironment extends EventEmitter implements Actor {
 
     this.page = await this.context.newPage()
     this.tabs.push(this.page)
-
-    if (process.env.A11Y_TEST === 'true') {
-      patchPageForA11y(this.page)
-    }
 
     this.page.on('pageerror', (exception) => {
       console.log(`[UNCAUGHT EXCEPTION] "${exception}"`)

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1641,7 +1641,7 @@ export const getDisplayedResourcesFromTrashbin = async (page: Page): Promise<str
 
 export interface switchViewModeArgs {
   page: Page
-  target: 'resource-table' | 'resource-tiles'
+  target: 'resource-table' | 'resource-tiles' | 'resource-table-condensed'
 }
 
 export const clickViewModeToggle = async (args: switchViewModeArgs): Promise<void> => {

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -215,6 +215,10 @@ export class Resource {
     await po.clickViewModeToggle({ page: this.#page, target: 'resource-tiles' })
   }
 
+  async switchViewMode(viewMode): Promise<void> {
+    await po.clickViewModeToggle({ page: this.#page, target: viewMode })
+  }
+
   async expectThatResourcesAreTiles(): Promise<void> {
     await po.expectThatResourcesAreTiles({ page: this.#page })
   }

--- a/tests/e2e/support/utils/accessibility.ts
+++ b/tests/e2e/support/utils/accessibility.ts
@@ -1,11 +1,19 @@
-import { Page, Locator } from '@playwright/test'
+import { Page } from '@playwright/test'
 import AxeBuilder from '@axe-core/playwright'
 
 const a11yRuleTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice']
-const skipA11ySelectors = ['#oc-topbar-account-logout']
 
-export async function checkAccessibility(page: Page, context: string = ''): Promise<void> {
-  const results = await new AxeBuilder({ page }).withTags(a11yRuleTags).analyze()
+export async function checkAccessibility(
+  page: Page,
+  context: string = '',
+  includeSelector?: string
+): Promise<void> {
+  let builder = new AxeBuilder({ page }).withTags(a11yRuleTags)
+  if (includeSelector) {
+    builder = builder.include(includeSelector)
+  }
+  const results = await builder.analyze()
+  let shouldFail = false
 
   if (results.violations.length > 0) {
     console.error(`♿ Accessibility violations detected${context ? ` in ${context}` : ''}:`)
@@ -17,53 +25,19 @@ export async function checkAccessibility(page: Page, context: string = ''): Prom
       violation.nodes.forEach((node, idx) => {
         console.error(`  Node ${idx + 1}: ${node.html}`)
       })
+
+      if (violation.impact === 'critical') {
+        shouldFail = true
+      }
     }
     console.log(
       `Accessibility check failed with ${results.violations.length} violation(s)${context ? ` in ${context}` : ''}.`
     )
 
-    // throw new Error(
-    //   `Accessibility check failed with ${results.violations.length} violation(s)${context ? ` in ${context}` : ''}.`
-    // )
+    if (shouldFail) {
+      throw new Error(
+        `Accessibility check failed due to critical or serious violation(s)${context ? ` in ${context}` : ''}.`
+      )
+    }
   }
-}
-
-function shouldSkipA11y(selector: string): boolean {
-  return skipA11ySelectors.some((skip) => selector.includes(skip))
-}
-
-export function patchPageForA11y(page: Page) {
-  const originalLocator = page.locator.bind(page)
-
-  page.locator = ((...args: Parameters<Page['locator']>): Locator => {
-    const locator = originalLocator(...args)
-    const selector = args[0]?.toString?.() ?? ''
-
-    const originalClick = locator.click.bind(locator)
-    locator.click = async (...clickArgs) => {
-      const result = await originalClick(...clickArgs)
-      await page.waitForTimeout(200)
-
-      if (!shouldSkipA11y(selector)) {
-        await checkAccessibility(page, `after locator.click(${selector})`)
-      }
-      return result
-    }
-
-    const originalFill = locator.fill.bind(locator)
-    locator.fill = async (...fillArgs) => {
-      const result = await originalFill(...fillArgs)
-      await checkAccessibility(page, `after locator.fill(${args[0]})`)
-      return result
-    }
-
-    const originalPress = locator.press.bind(locator)
-    locator.press = async (...pressArgs) => {
-      const result = await originalPress(...pressArgs)
-      await checkAccessibility(page, `after locator.press(${args[0]})`)
-      return result
-    }
-
-    return locator
-  }) as typeof page.locator
 }

--- a/tests/e2e/support/utils/accessibility.ts
+++ b/tests/e2e/support/utils/accessibility.ts
@@ -1,0 +1,69 @@
+import { Page, Locator } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+const a11yRuleTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice']
+const skipA11ySelectors = ['#oc-topbar-account-logout']
+
+export async function checkAccessibility(page: Page, context: string = ''): Promise<void> {
+  const results = await new AxeBuilder({ page }).withTags(a11yRuleTags).analyze()
+
+  if (results.violations.length > 0) {
+    console.error(`♿ Accessibility violations detected${context ? ` in ${context}` : ''}:`)
+    for (const violation of results.violations) {
+      console.error(`\n[${violation.id}] ${violation.help}`)
+      console.error(`  Impact: ${violation.impact}`)
+      console.error(`  Description: ${violation.description}`)
+      console.error(`  Help: ${violation.helpUrl}`)
+      violation.nodes.forEach((node, idx) => {
+        console.error(`  Node ${idx + 1}: ${node.html}`)
+      })
+    }
+    console.log(
+      `Accessibility check failed with ${results.violations.length} violation(s)${context ? ` in ${context}` : ''}.`
+    )
+
+    // throw new Error(
+    //   `Accessibility check failed with ${results.violations.length} violation(s)${context ? ` in ${context}` : ''}.`
+    // )
+  }
+}
+
+function shouldSkipA11y(selector: string): boolean {
+  return skipA11ySelectors.some((skip) => selector.includes(skip))
+}
+
+export function patchPageForA11y(page: Page) {
+  const originalLocator = page.locator.bind(page)
+
+  page.locator = ((...args: Parameters<Page['locator']>): Locator => {
+    const locator = originalLocator(...args)
+    const selector = args[0]?.toString?.() ?? ''
+
+    const originalClick = locator.click.bind(locator)
+    locator.click = async (...clickArgs) => {
+      const result = await originalClick(...clickArgs)
+      await page.waitForTimeout(200)
+
+      if (!shouldSkipA11y(selector)) {
+        await checkAccessibility(page, `after locator.click(${selector})`)
+      }
+      return result
+    }
+
+    const originalFill = locator.fill.bind(locator)
+    locator.fill = async (...fillArgs) => {
+      const result = await originalFill(...fillArgs)
+      await checkAccessibility(page, `after locator.fill(${args[0]})`)
+      return result
+    }
+
+    const originalPress = locator.press.bind(locator)
+    locator.press = async (...pressArgs) => {
+      const result = await originalPress(...pressArgs)
+      await checkAccessibility(page, `after locator.press(${args[0]})`)
+      return result
+    }
+
+    return locator
+  }) as typeof page.locator
+}


### PR DESCRIPTION
related #400 

This PR implements the checkAccessibility() function to check accessibility using e2e playwright tests with the following recommended rule tags: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice']

### Next, we need to decide on a strategy, namely:
- Will it be a separate set of tests, or will we check a11e in existing tests? I would prefer to use existing e2e tests with the ability to enable/disable a11y tests (`A11Y_TEST=true`).
- Where to use `checkAccessibility()`
   - check every click()
   - check in specific places in action.ts files where page elements are clicked directly
- Failed tests:
   - do not fail the test the first time. Just get the error logs
   - further, during the fix, we can fail tests based on violation.impact (critical — test failed, moderate — test passed)

I experimented and wrapped each click with `patchPageForA11y`
here is result of running one test with enabled/disabled `A11Y_TEST`

### running one suite without a11y:
10sec: 
```
1 scenario (1 passed)
11 steps (11 passed)
0m10.136s (executing steps: 0m07.482s)
```

### running one suite witht a11y` 17 sec: 
tests become fragile. 

<details>
<summary> Log</summary>

```
HEADLESS=true A11Y=true OC_BASE_URL=host.docker.internal:9200 pnpm test:e2e:cucumber tests/e2e/cucumber/features/smoke/tags.feature:54

> @3.0.0-alpha.1 test:e2e:cucumber /Users/v.scharf/Work/opencloud/web
> NODE_TLS_REJECT_UNAUTHORIZED=0 TS_NODE_PROJECT=./tests/e2e/cucumber/tsconfig.json cucumber-js --profile=e2e --parallel ${PARALLEL:-1} "tests/e2e/cucumber/features/smoke/tags.feature:54"

(node:558) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:597) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
Feature: Users can use web to organize tags # tests/e2e/cucumber/features/smoke/tags.feature:1

  Scenario: Tag sharing # tests/e2e/cucumber/features/smoke/tags.feature:54
(node:597) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
    Given "Admin" creates following users using API
      │ id    │
      │ Alice │
      │ Brian │
    Given "Alice" creates the following folders in personal space using API
      │ name             │
      │ folder_to_shared │
    And "Alice" creates the following files into personal space using API
      │ pathToFile                 │ content     │
      │ folder_to_shared/lorem.txt │ lorem ipsum │
    And "Alice" logs in
♿ Accessibility violations detected in after locator.fill(#oc-login-username):

[autocomplete-valid] autocomplete attribute must be used correctly
  Impact: serious
  Description: Ensure the autocomplete attribute is correct and suitable for the form field
  Help: https://dequeuniversity.com/rules/axe/4.10/autocomplete-valid?application=playwright
  Node 1: <input class="oc-input " autocapitalize="off" spellcheck="false" autocomplete="kopano-account username" placeholder="Username" id="oc-login-username" aria-invalid="false" value="Alice-120">
  Node 2: <input class="oc-input " type="password" margin="normal" autocomplete="kopano-account current-password" placeholder="Password" id="oc-login-password" aria-invalid="false">
Accessibility check failed with 1 violation(s) in after locator.fill(#oc-login-username).
♿ Accessibility violations detected in after locator.fill(#oc-login-password):

[autocomplete-valid] autocomplete attribute must be used correctly
  Impact: serious
  Description: Ensure the autocomplete attribute is correct and suitable for the form field
  Help: https://dequeuniversity.com/rules/axe/4.10/autocomplete-valid?application=playwright
  Node 1: <input class="oc-input " autocapitalize="off" spellcheck="false" autocomplete="kopano-account username" placeholder="Username" id="oc-login-username" aria-invalid="false" value="Alice-120">
  Node 2: <input class="oc-input " type="password" margin="normal" autocomplete="kopano-account current-password" placeholder="Password" id="oc-login-password" aria-invalid="false">
Accessibility check failed with 1 violation(s) in after locator.fill(#oc-login-password).
♿ Accessibility violations detected in after locator.click(button[type="submit"]):

[heading-order] Heading levels should only increase by one
  Impact: moderate
  Description: Ensure the order of headings is semantically correct
  Help: https://dequeuniversity.com/rules/axe/4.10/heading-order?application=playwright
  Node 1: <h3 class="oc-login-card-title" data-msgid="Logging you in" data-current-language="en">Logging you in</h3>

[landmark-one-main] Document should have one main landmark
  Impact: moderate
  Description: Ensure the document has a main landmark
  Help: https://dequeuniversity.com/rules/axe/4.10/landmark-one-main?application=playwright
  Node 1: <html lang="en" style="--oc-role-background: #F5FAFD; --oc-role-chrome: #20434f; --oc-role-error: #BA1A1A; --oc-role-error-container: #FFDAD6; --oc-role-inverse-on-surface: #EDF1F4; --oc-role-inverse-primary: #88D1EC; --oc-role-inverse-surface: #2C3134; --oc-role-on-background: #171C1F; --oc-role-on-chrome: #ffffff; --oc-role-on-error: #FFFFFF; --oc-role-on-error-container: #410002; --oc-role-on-primary: #19353F; --oc-role-on-primary-container: #001F28; --oc-role-on-primary-fixed: #001F28; --oc-role-on-primary-fixed-variant: #004E60; --oc-role-on-secondary: #FFFFFF; --oc-role-on-secondary-container: #071E26; --oc-role-on-secondary-fixed: #071E26; --oc-role-on-secondary-fixed-variant: #344A52; --oc-role-on-surface: #171C1F; --oc-role-on-surface-variant: #40484C; --oc-role-on-tertiary: #FFFFFF; --oc-role-on-tertiary-container: #171937; --oc-role-on-tertiary-fixed: #171937; --oc-role-on-tertiary-fixed-variant: #424465; --oc-role-outline: #70787C; --oc-role-outline-variant: #BFC8CC; --oc-role-primary: #E2BAFF; --oc-role-primary-container: #B7EAFF; --oc-role-primary-fixed: #B7EAFF; --oc-role-primary-fixed-dim: #88D1EC; --oc-role-scrim: #000000; --oc-role-secondary: #20434f; --oc-role-secondary-container: #f4e5ff; --oc-role-secondary-fixed: #CFE6F1; --oc-role-secondary-fixed-dim: #B3CAD4; --oc-role-shadow: #000000; --oc-role-surface: #FFFFFF; --oc-role-surface-bright: #F5FAFD; --oc-role-surface-container: #F1F3F4; --oc-role-surface-container-high: #E4E9EC; --oc-role-surface-container-highest: #DEE3E6; --oc-role-surface-container-low: #EFF4F7; --oc-role-surface-container-lowest: #FFFFFF; --oc-role-surface-dim: #D6DBDE; --oc-role-surface-tint: #07677F; --oc-role-surface-variant: #DBE4E8; --oc-role-tertiary: #5A5C7E; --oc-role-tertiary-container: #E0E0FF; --oc-role-tertiary-fixed: #E0E0FF; --oc-role-tertiary-fixed-dim: #C3C3EB; --oc-color-icon-archive: #fbbe54; --oc-color-icon-audio: #700460; --oc-color-icon-document: #3b44a6; --oc-color-icon-folder: #4d7eaf; --oc-color-icon-image: #ee6b3b; --oc-color-icon-medical: #0984db; --oc-color-icon-pdf: #ec0d47; --oc-color-icon-presentation: #ee6b3b; --oc-color-icon-spreadsheet: #15c286; --oc-color-icon-video: #045459; --oc-role-errorContainer: #FFDAD6; --oc-role-inverseOnSurface: #EDF1F4; --oc-role-inversePrimary: #88D1EC; --oc-role-inverseSurface: #2C3134; --oc-role-onBackground: #171C1F; --oc-role-onChrome: #ffffff; --oc-role-onError: #FFFFFF; --oc-role-onErrorContainer: #410002; --oc-role-onPrimary: #19353F; --oc-role-onPrimaryContainer: #001F28; --oc-role-onPrimaryFixed: #001F28; --oc-role-onPrimaryFixedVariant: #004E60; --oc-role-onSecondary: #FFFFFF; --oc-role-onSecondaryContainer: #071E26; --oc-role-onSecondaryFixed: #071E26; --oc-role-onSecondaryFixedVariant: #344A52; --oc-role-onSurface: #171C1F; --oc-role-onSurfaceVariant: #40484C; --oc-role-onTertiary: #FFFFFF; --oc-role-onTertiaryContainer: #171937; --oc-role-onTertiaryFixed: #171937; --oc-role-onTertiaryFixedVariant: #424465; --oc-role-outlineVariant: #BFC8CC; --oc-role-primaryContainer: #B7EAFF; --oc-role-primaryFixed: #B7EAFF; --oc-role-primaryFixedDim: #88D1EC; --oc-role-secondaryContainer: #f4e5ff; --oc-role-secondaryFixed: #CFE6F1; --oc-role-secondaryFixedDim: #B3CAD4; --oc-role-surfaceBright: #F5FAFD; --oc-role-surfaceContainer: #F1F3F4; --oc-role-surfaceContainerHigh: #E4E9EC; --oc-role-surfaceContainerHighest: #DEE3E6; --oc-role-surfaceContainerLow: #EFF4F7; --oc-role-surfaceContainerLowest: #FFFFFF; --oc-role-surfaceDim: #D6DBDE; --oc-role-surfaceTint: #07677F; --oc-role-surfaceVariant: #DBE4E8; --oc-role-tertiaryContainer: #E0E0FF; --oc-role-tertiaryFixed: #E0E0FF; --oc-role-tertiaryFixedDim: #C3C3EB;">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <h1 class="oc-invisible-sr">Oidc callback</h1>
  Node 2: <div class="oc-login-card-body"><h3 class="oc-login-card-title" data-msgid="Logging you in" data-current-language="en">Logging you in</h3> <p data-msgid="Please wait, you are being redirected." data-current-language="en">Please wait, you are being redirected.</p></div>
  Node 3: <div class="oc-login-card-footer oc-pt-rm"><p>OpenCloud – Excellent file sharing</p></div>
  Node 4: <img class="oc-login-emblem" alt="OpenCloud emblem" src="data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='2.83%202.84%2021.45%2027.82'%3e%3cpolygon%20points='13.55%2023.12%2014.72%2022.45%2014.72%2017.57%2018.92%2015.14%2018.92%2013.8%2017.75%2013.12%2013.53%2015.56%209.36%2013.16%208.19%2013.83%208.19%2015.18%2012.39%2017.6%2012.39%2022.45%2013.55%2023.12'%20fill='%23e2baff'/%3e%3cpolygon%20points='24.28%209.02%2013.56%202.84%2013.56%202.84%2013.56%202.84%202.83%209.02%202.83%2011.72%2013.56%205.53%2024.28%2011.72%2024.28%209.02'%20fill='%23e2baff'/%3e%3cpolygon%20points='24.28%2021.78%2013.56%2027.97%202.83%2021.78%202.83%2024.48%2013.56%2030.66%2013.56%2030.66%2013.56%2030.66%2024.28%2024.48%2024.28%2021.78'%20fill='%23e2baff'/%3e%3c/svg%3e">
Accessibility check failed with 3 violation(s) in after locator.click(button[type="submit"]).
    And "Alice" adds the following tags for the following resources using the sidebar panel
      │ resource                   │ tags         │
      │ folder_to_shared/lorem.txt │ tag 1, tag 2 │
♿ Accessibility violations detected in after locator.click(:is(#files-files-table, .oc-tiles-item, #files-shared-with-me-accepted-section, .files-table) [data-test-resource-name="folder_to_shared"]):

[aria-hidden-focus] ARIA hidden element must not be focusable or contain focusable elements
  Impact: serious
  Description: Ensure aria-hidden elements are not focusable nor contain focusable elements
  Help: https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright
  Node 1: <li data-key="1" aria-hidden="true" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/text-editor/personal/alice-120/folder_to_shared/lorem.txt?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%2106d5c740-c5f4-4060-989e-27c602aaf38f&amp;contextRouteName=files-spaces-generic&amp;contextRouteParams.driveAliasAndItem=personal/alice-120/folder_to_shared&amp;contextRouteQuery.fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 4 violation(s) in after locator.click(:is(#files-files-table, .oc-tiles-item, #files-shared-with-me-accepted-section, .files-table) [data-test-resource-name="folder_to_shared"]).
♿ Accessibility violations detected in after locator.click(//span[@data-test-resource-name="lorem.txt"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]):

[aria-hidden-focus] ARIA hidden element must not be focusable or contain focusable elements
  Impact: serious
  Description: Ensure aria-hidden elements are not focusable nor contain focusable elements
  Help: https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright
  Node 1: <li data-key="1" aria-hidden="true" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/text-editor/personal/alice-120/folder_to_shared/lorem.txt?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%2106d5c740-c5f4-4060-989e-27c602aaf38f&amp;contextRouteName=files-spaces-generic&amp;contextRouteParams.driveAliasAndItem=personal/alice-120/folder_to_shared&amp;contextRouteQuery.fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 4 violation(s) in after locator.click(//span[@data-test-resource-name="lorem.txt"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]).
♿ Accessibility violations detected in after locator.click(.oc-files-actions-show-details-trigger):

[aria-hidden-focus] ARIA hidden element must not be focusable or contain focusable elements
  Impact: serious
  Description: Ensure aria-hidden elements are not focusable nor contain focusable elements
  Help: https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright
  Node 1: <li data-key="1" aria-hidden="true" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-file-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/text-editor/personal/alice-120/folder_to_shared/lorem.txt?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%2106d5c740-c5f4-4060-989e-27c602aaf38f&amp;contextRouteName=files-spaces-generic&amp;contextRouteParams.driveAliasAndItem=personal/alice-120/folder_to_shared&amp;contextRouteQuery.fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 4 violation(s) in after locator.click(.oc-files-actions-show-details-trigger).
♿ Accessibility violations detected in after locator.click(#app-sidebar .is-active-root-panel .header__close):

[aria-hidden-focus] ARIA hidden element must not be focusable or contain focusable elements
  Impact: serious
  Description: Ensure aria-hidden elements are not focusable nor contain focusable elements
  Help: https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright
  Node 1: <li data-key="1" aria-hidden="true" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/text-editor/personal/alice-120/folder_to_shared/lorem.txt?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%2106d5c740-c5f4-4060-989e-27c602aaf38f&amp;contextRouteName=files-spaces-generic&amp;contextRouteParams.driveAliasAndItem=personal/alice-120/folder_to_shared&amp;contextRouteQuery.fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 4 violation(s) in after locator.click(#app-sidebar .is-active-root-panel .header__close).
    When "Alice" shares the following resource using the sidebar panel
      │ resource         │ recipient │ type │ role     │ resourceType │
      │ folder_to_shared │ Brian     │ user │ Can edit │ folder       │
♿ Accessibility violations detected in after locator.click(//span[@data-test-resource-name="folder_to_shared"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(//span[@data-test-resource-name="folder_to_shared"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]).
♿ Accessibility violations detected in after locator.click(.oc-files-actions-show-details-trigger):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(.oc-files-actions-show-details-trigger).
♿ Accessibility violations detected in after locator.click(#sidebar-panel-sharing-select):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(#sidebar-panel-sharing-select).
♿ Accessibility violations detected in after locator.click(#files-share-invite-input):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(#files-share-invite-input).
♿ Accessibility violations detected in after locator.fill(#files-share-invite-input):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.fill(#files-share-invite-input).
♿ Accessibility violations detected in after locator.click(div[data-testid="new-collaborators-form"] div[data-testid="recipient-autocomplete-item-Brian Murphy"]):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(div[data-testid="new-collaborators-form"] div[data-testid="recipient-autocomplete-item-Brian Murphy"]).
♿ Accessibility violations detected in after locator.click(#new-collaborators-form):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(#new-collaborators-form).
♿ Accessibility violations detected in after locator.click(#files-collaborators-role-button-new):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(#files-collaborators-role-button-new).
♿ Accessibility violations detected in after locator.click(#new-collaborators-form-create-button):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-download-archive-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 2: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-move-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 3: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-copy-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 4: <button type="button" aria-label="" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-files-actions-delete-trigger action-menu-item oc-py-s oc-px-m oc-width-1-1" data-testid="action-handler">
  Node 5: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(#new-collaborators-form-create-button).
♿ Accessibility violations detected in after locator.click(#app-sidebar .is-active-sub-panel .header__close):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/personal/alice-120/folder_to_shared?fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(#app-sidebar .is-active-sub-panel .header__close).
    And "Alice" logs out
    And "Brian" logs in
♿ Accessibility violations detected in after locator.fill(#oc-login-username):

[autocomplete-valid] autocomplete attribute must be used correctly
  Impact: serious
  Description: Ensure the autocomplete attribute is correct and suitable for the form field
  Help: https://dequeuniversity.com/rules/axe/4.10/autocomplete-valid?application=playwright
  Node 1: <input class="oc-input " autocapitalize="off" spellcheck="false" autocomplete="kopano-account username" placeholder="Username" id="oc-login-username" aria-invalid="false" value="Brian-120">
  Node 2: <input class="oc-input " type="password" margin="normal" autocomplete="kopano-account current-password" placeholder="Password" id="oc-login-password" aria-invalid="false">
Accessibility check failed with 1 violation(s) in after locator.fill(#oc-login-username).
♿ Accessibility violations detected in after locator.fill(#oc-login-password):

[autocomplete-valid] autocomplete attribute must be used correctly
  Impact: serious
  Description: Ensure the autocomplete attribute is correct and suitable for the form field
  Help: https://dequeuniversity.com/rules/axe/4.10/autocomplete-valid?application=playwright
  Node 1: <input class="oc-input " autocapitalize="off" spellcheck="false" autocomplete="kopano-account username" placeholder="Username" id="oc-login-username" aria-invalid="false" value="Brian-120">
  Node 2: <input class="oc-input " type="password" margin="normal" autocomplete="kopano-account current-password" placeholder="Password" id="oc-login-password" aria-invalid="false">
Accessibility check failed with 1 violation(s) in after locator.fill(#oc-login-password).
♿ Accessibility violations detected in after locator.click(button[type="submit"]):

[aria-progressbar-name] ARIA progressbar nodes must have an accessible name
  Impact: serious
  Description: Ensure every ARIA progressbar node has an accessible name
  Help: https://dequeuniversity.com/rules/axe/4.10/aria-progressbar-name?application=playwright
  Node 1: <div class="MuiCircularProgress-root jss7 MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate" role="progressbar" style="width: 24px; height: 24px;">

[autocomplete-valid] autocomplete attribute must be used correctly
  Impact: serious
  Description: Ensure the autocomplete attribute is correct and suitable for the form field
  Help: https://dequeuniversity.com/rules/axe/4.10/autocomplete-valid?application=playwright
  Node 1: <input class="oc-input " autocapitalize="off" spellcheck="false" autocomplete="kopano-account username" placeholder="Username" id="oc-login-username" aria-invalid="false" value="Brian-120">
  Node 2: <input class="oc-input " type="password" margin="normal" autocomplete="kopano-account current-password" placeholder="Password" id="oc-login-password" aria-invalid="false">
Accessibility check failed with 2 violation(s) in after locator.click(button[type="submit"]).
    And "Brian" navigates to the shared with me page
♿ Accessibility violations detected in after locator.click(//a[@data-nav-name="files-shares"]):

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw oc-p-xs oc-files-actions-hide-share-trigger raw-hover-surface">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/files/spaces/share/folder_to_shared?shareId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702&amp;fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 3 violation(s) in after locator.click(//a[@data-nav-name="files-shares"]).
    Then the following resources should contain the following tags in the files list for user "Brian"
      │ resource                   │ tags         │
      │ folder_to_shared/lorem.txt │ tag 1, tag 2 │
♿ Accessibility violations detected in after locator.click(:is(#files-files-table, .oc-tiles-item, #files-shared-with-me-accepted-section, .files-table) [data-test-resource-name="folder_to_shared"]):

[aria-hidden-focus] ARIA hidden element must not be focusable or contain focusable elements
  Impact: serious
  Description: Ensure aria-hidden elements are not focusable nor contain focusable elements
  Help: https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright
  Node 1: <li data-key="2" aria-hidden="true" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/text-editor/share/folder_to_shared/lorem.txt?shareId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702&amp;fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%2106d5c740-c5f4-4060-989e-27c602aaf38f&amp;contextRouteName=files-spaces-generic&amp;contextRouteParams.driveAliasAndItem=share/folder_to_shared&amp;contextRouteQuery.fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702&amp;contextRouteQuery.shareId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702&amp;contextRouteQuery.sort-by=name&amp;contextRouteQuery.sort-dir=asc" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 4 violation(s) in after locator.click(:is(#files-files-table, .oc-tiles-item, #files-shared-with-me-accepted-section, .files-table) [data-test-resource-name="folder_to_shared"]).
    And "Brian" logs out
♿ Accessibility violations detected in after locator.click(#_userMenuButton):

[aria-hidden-focus] ARIA hidden element must not be focusable or contain focusable elements
  Impact: serious
  Description: Ensure aria-hidden elements are not focusable nor contain focusable elements
  Help: https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright
  Node 1: <li data-key="2" aria-hidden="true" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">

[button-name] Buttons must have discernible text
  Impact: critical
  Description: Ensure buttons have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/button-name?application=playwright
  Node 1: <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw resource-table-edit-name raw-hover-surface oc-p-xs">

[link-name] Links must have discernible text
  Impact: serious
  Description: Ensure links have discernible text
  Help: https://dequeuniversity.com/rules/axe/4.10/link-name?application=playwright
  Node 1: <a href="/text-editor/share/folder_to_shared/lorem.txt?shareId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702&amp;fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%2106d5c740-c5f4-4060-989e-27c602aaf38f&amp;contextRouteName=files-spaces-generic&amp;contextRouteParams.driveAliasAndItem=share/folder_to_shared&amp;contextRouteQuery.fileId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702&amp;contextRouteQuery.shareId=37d53b7d-4808-4fa3-b630-53b3001d4ef9%248e2c902c-189e-4cb5-9b07-3aa2536d6bef%21c4ff0cb0-b2c9-4425-ad52-e8e954701702&amp;contextRouteQuery.sort-by=name&amp;contextRouteQuery.sort-dir=asc" class="oc-resource-link oc-resource-icon-link" target="_self" draggable="false" no-hover="">

[region] All page content should be contained by landmarks
  Impact: moderate
  Description: Ensure all page content is contained by landmarks
  Help: https://dequeuniversity.com/rules/axe/4.10/region?application=playwright
  Node 1: <div class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"><span>OpenCloud 3.0.0+94b79a058</span> <span>OpenCloud Web UI 3.0.0-alpha.1</span></div>
Accessibility check failed with 4 violation(s) in after locator.click(#_userMenuButton).

1 scenario (1 passed)
11 steps (11 passed)
0m17.095s (executing steps: 0m14.786s)
v.scharf@Mac web % 
```

</details>



### running one suite: 

#### without a11y
`HEADLESS=true A11Y_TEST=false pnpm test:e2e:cucumber tests/e2e/cucumber/features/smoke/`

```
14 scenarios (14 passed)
253 steps (253 passed)
2m43.404s (executing steps: 2m40.704s)
```

#### with a11y for all tests
`HEADLESS=true A11Y_TEST=true  pnpm test:e2e:cucumber tests/e2e/cucumber/features/smoke/`

```
14 scenarios (3 failed, 11 passed)
253 steps (3 failed, 32 skipped, 218 passed)
6m29.083s (executing steps: 6m26.405s)
```
 
 error: 
   ```
✖ And "Alice" logs in # file:/Users/v.scharf/Work/opencloud/web/tests/e2e/cucumber/steps/ui/session.ts:33
       page.evaluate: Execution context was destroyed, most likely because of a navigation
           at AxeBuilder.analyze (/Users/v.scharf/Work/opencloud/web/node_modules/.pnpm/@axe-core+playwright@4.10.2_playwright-core@1.52.0/node_modules/@axe-core/playwright/dist/index.mjs:201:16)
           at checkAccessibility (/Users/v.scharf/Work/opencloud/web/tests/e2e/support/utils/accessibility.ts:7:10)
           at locator.click (/Users/v.scharf/Work/opencloud/web/tests/e2e/support/utils/accessibility.ts:38:23)
```

