### PR TITLE
get hostname of S3 server from var. not secret

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -24,6 +24,7 @@ READY_RELEASE_GO = "woodpeckerci/plugin-ready-release-go:latest"
 
 WEB_PUBLISH_NPM_PACKAGES = ["babel-preset", "design-system", "eslint-config", "extension-sdk", "prettier-config", "tsconfig", "web-client", "web-pkg", "web-test-helpers"]
 WEB_PUBLISH_NPM_ORGANIZATION = "@opencloud-eu"
+CACHE_S3_SERVER = "https://s3.ci.opencloud.eu"
 
 dir = {
     "base": "/woodpecker/src/github.com/opencloud-eu/web",
@@ -153,9 +154,7 @@ minio_mc_environment = {
     "CACHE_BUCKET": {
         "from_secret": "cache_s3_bucket",
     },
-    "MC_HOST": {
-        "from_secret": "cache_s3_server",
-    },
+    "MC_HOST": CACHE_S3_SERVER,
     "AWS_ACCESS_KEY_ID": {
         "from_secret": "cache_s3_access_key",
     },
@@ -1141,9 +1140,7 @@ def genericCache(name, action, mounts, cache_path):
         "name": "%s_%s" % (action, name),
         "image": PLUGINS_S3_CACHE,
         "settings": {
-            "endpoint": {
-                "from_secret": "cache_s3_server",
-            },
+            "endpoint": CACHE_S3_SERVER,
             "rebuild": rebuild,
             "restore": restore,
             "mount": mounts,
@@ -1175,9 +1172,7 @@ def genericCachePurge(flush_path):
                     "secret_key": {
                         "from_secret": "cache_s3_secret_key",
                     },
-                    "endpoint": {
-                        "from_secret": "cache_s3_server",
-                    },
+                    "endpoint": CACHE_S3_SERVER,
                     "flush": True,
                     "flush_age": 1,
                     "flush_path": flush_path,
@@ -1290,9 +1285,7 @@ def uploadTracingResult(ctx):
             "bucket": {
                 "from_secret": "cache_public_s3_bucket",
             },
-            "endpoint": {
-                "from_secret": "cache_public_s3_server",
-            },
+            "endpoint": CACHE_S3_SERVER,
             "path_style": True,
             "source": "%s/reports/e2e/playwright/tracing/**/*" % dir["web"],
             "strip_prefix": "%s/reports/e2e/playwright/tracing" % dir["web"],


### PR DESCRIPTION
## Description

This value is not really secret and to show the URL of the tracing uploads or any other public artifacts we have to get rid of that secret as woodpecker masks all secret in the logs

## Related Issue

needed for https://github.com/opencloud-eu/qa/issues/24

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
