### PR TITLE
[full-ci] detect and delete unused steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "licenses:save": "license-checker-rseidelsohn --relativeLicensePath --out /dev/null --files ./third-party-licenses/third-party-licenses",
     "vite": "vue-demi-fix && vite",
     "check:types": "pnpm build:tokens && vue-tsc --noEmit",
-    "check:all": "pnpm check:types && pnpm lint --fix && pnpm format:write && pnpm test:unit"
+    "check:all": "pnpm check:types && pnpm lint --fix && pnpm format:write && pnpm test:unit",
+    "check:unused-steps": "TS_NODE_PROJECT=./tests/e2e/cucumber/tsconfig.json cucumber-js --profile=e2e --format usage --dry-run tests/e2e/cucumber/features/*/*.feature"
   },
   "browserslist": [
     "last 1 year",

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -215,26 +215,6 @@ Given(
 )
 
 Given(
-  '{string} creates {int} file(s) in space {string} using API',
-  async function (
-    this: World,
-    stepUser: string,
-    numberOfFiles: number,
-    space: string
-  ): Promise<void> {
-    const user = this.usersEnvironment.getCreatedUser({ key: stepUser })
-    for (let i = 1; i <= numberOfFiles; i++) {
-      await api.dav.uploadFileInsideSpaceBySpaceName({
-        user,
-        pathToFile: `testfile${i}.txt`,
-        spaceName: space,
-        content: `This is a test file${i}`
-      })
-    }
-  }
-)
-
-Given(
   '{string} creates the following folder(s) in space {string} using API',
   async function (
     this: World,
@@ -247,25 +227,6 @@ Given(
       await api.dav.createFolderInsideSpaceBySpaceName({
         user,
         folder: info.name,
-        spaceName: space
-      })
-    }
-  }
-)
-
-Given(
-  '{string} creates {int} folders(s) in space {string} using API',
-  async function (
-    this: World,
-    stepUser: string,
-    numberOfFolders: number,
-    space: string
-  ): Promise<void> {
-    const user = this.usersEnvironment.getCreatedUser({ key: stepUser })
-    for (let i = 1; i <= numberOfFolders; i++) {
-      await api.dav.createFolderInsideSpaceBySpaceName({
-        user,
-        folder: `testFolder${i}`,
         spaceName: space
       })
     }

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -156,15 +156,6 @@ When(
 )
 
 When(
-  '{string} navigates to the general management page',
-  async function (this: World, stepUser: string): Promise<void> {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const pageObject = new objects.applicationAdminSettings.page.General({ page })
-    await pageObject.navigate()
-  }
-)
-
-When(
   '{string} changes the quota of the user {string} to {string} using the sidebar panel',
   async function (this: World, stepUser: string, key: string, value: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })

--- a/tests/e2e/cucumber/steps/ui/links.ts
+++ b/tests/e2e/cucumber/steps/ui/links.ts
@@ -167,28 +167,6 @@ When(
 )
 
 Then(
-  'public link named {string} should be visible to {string}',
-  async function (this: World, linkName: string, stepUser: any): Promise<void> {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const expectedPublicLink = this.linksEnvironment.getLink({ name: linkName })
-    const linkObject = new objects.applicationFiles.Link({ page })
-    const actualPublicLink = await linkObject.getPublicLinkUrl({ linkName, space: true })
-    expect(actualPublicLink).toBe(expectedPublicLink)
-  }
-)
-
-Then(
-  'public link named {string} of the resource {string} should be visible to {string}',
-  async function (this: World, linkName: string, resource: string, stepUser: any): Promise<void> {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const expectedPublicLink = this.linksEnvironment.getLink({ name: linkName })
-    const linkObject = new objects.applicationFiles.Link({ page })
-    const actualPublicLink = await linkObject.getPublicLinkUrl({ linkName, resource })
-    expect(actualPublicLink).toBe(expectedPublicLink)
-  }
-)
-
-Then(
   /^"([^"]*)" (should|should not) be able to edit the public link named "([^"]*)"$/,
   async function (
     this: World,
@@ -220,15 +198,6 @@ When(
     const linkObject = new objects.applicationFiles.Link({ page })
     const newPermission = await linkObject.changeRole({ linkName, role, space: true })
     expect(newPermission.toLowerCase()).toBe(role.toLowerCase())
-  }
-)
-
-When(
-  '{string} opens shared-with-me page from the internal link',
-  async function (this: World, stepUser: string): Promise<void> {
-    const actor = this.actorsEnvironment.getActor({ key: stepUser })
-    const pageObject = new objects.applicationFiles.page.shares.WithMe({ page: actor.page })
-    await pageObject.openShareWithMeFromInternalLink(actor)
   }
 )
 

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -165,28 +165,6 @@ When(
   }
 )
 
-When(
-  '{string} uploads the following resource(s) in internal link named {string}',
-  async function (
-    this: World,
-    stepUser: string,
-    link: string,
-    stepTable: DataTable
-  ): Promise<void> {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const pageObject = new objects.applicationFiles.page.Public({ page })
-    const { url } = this.linksEnvironment.getLink({ name: link })
-    for (const info of stepTable.hashes()) {
-      await pageObject.uploadInternal({
-        to: info.to,
-        resources: [this.filesEnvironment.getFile({ name: info.resource })],
-        option: info.option,
-        link: url
-      })
-    }
-  }
-)
-
 Then(
   '{string} should not be able to open the old link {string}',
   async function (this: World, stepUser: string, name: string): Promise<void> {
@@ -208,14 +186,5 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.Public({ page })
     await processDelete(stepTable, pageObject, actionType)
-  }
-)
-
-Then(
-  'for {string} file {string} should be selected',
-  async function (this: World, stepUser: string, fileName: string): Promise<void> {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const resourceObject = new objects.applicationFiles.Resource({ page })
-    await resourceObject.expectFileToBeSelected({ fileName: fileName })
   }
 )

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -732,29 +732,6 @@ When(
 )
 
 Then(
-  '{string} should not see the version of the file(s)',
-  async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const resourceObject = new objects.applicationFiles.Resource({ page })
-    const fileInfo = stepTable.hashes().reduce<Record<string, File[]>>((acc, stepRow) => {
-      const { to, resource } = stepRow
-
-      if (!acc[to]) {
-        acc[to] = []
-      }
-
-      acc[to].push(this.filesEnvironment.getFile({ name: resource }))
-
-      return acc
-    }, {})
-
-    for (const folder of Object.keys(fileInfo)) {
-      await resourceObject.checkThatFileVersionIsNotAvailable({ folder, files: fileInfo[folder] })
-    }
-  }
-)
-
-Then(
   '{string} should not see the version panel for the file(s)',
   async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })

--- a/tests/e2e/cucumber/steps/ui/session.ts
+++ b/tests/e2e/cucumber/steps/ui/session.ts
@@ -40,8 +40,6 @@ async function LogInUser(this: World, stepUser: string): Promise<void> {
   await page.locator('#web-content').waitFor()
 }
 
-Given('{string} has logged in', LogInUser)
-
 When('{string} logs in', LogInUser)
 
 async function LogOutUser(this: World, stepUser: string): Promise<void> {
@@ -52,8 +50,6 @@ async function LogOutUser(this: World, stepUser: string): Promise<void> {
   canLogout && (await sessionObject.logout())
   await actor.close()
 }
-
-Given('{string} has logged out', LogOutUser)
 
 When('{string} logs out', LogOutUser)
 

--- a/tests/e2e/cucumber/steps/ui/shares.ts
+++ b/tests/e2e/cucumber/steps/ui/shares.ts
@@ -196,15 +196,6 @@ When(
 )
 
 When(
-  '{string} should not be able to open the folder/file {string}',
-  async function (this: World, stepUser: string, resource: string): Promise<void> {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const shareObject = new objects.applicationFiles.Share({ page })
-    expect(await shareObject.resourceIsNotOpenable(resource)).toBe(true)
-  }
-)
-
-When(
   /"([^"]*)" (should|should not) see a sync status for the (?:folder|file) "([^"]*)"?$/,
   async function (
     this: World,

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -69,7 +69,6 @@ const publicLinkEditRoleButton = `//span[contains(@class, "files-links-name") an
 const addPublicLinkButton = '#files-file-link-add'
 const publicLinkNameList =
   '//div[@id="oc-files-file-link"]//ul//span[contains(@class, "files-links-name")]'
-const publicLink = `//ul//h4[text()='%s']/following-sibling::div//p`
 const publicLinkCurrentRole =
   '//button[contains(@class,"link-role-dropdown-toggle")]//span[contains(@class,"link-current-role")]'
 const linkUpdateDialog = '//div[contains(@class,"oc-notification-message-title")]'
@@ -304,25 +303,6 @@ export const deleteLink = async (args: deleteLinkArgs): Promise<void> => {
   await page.locator(confirmDeleteButton).click()
   const message = await page.locator(linkUpdateDialog).textContent()
   expect(message.trim()).toBe('Link was deleted successfully')
-}
-
-export const getPublicLinkVisibility = async (
-  args: publicLinkAndItsEditButtonVisibilityArgs
-): Promise<string> => {
-  const { page, linkName, resource, space } = args
-  let shareType = 'space-share'
-  let resourceName = null
-  if (!space) {
-    shareType = 'sharing'
-    const resourcePaths = resource.split('/')
-    resourceName = resourcePaths.pop()
-    if (resourcePaths.length) {
-      await clickResource({ page: page, path: resourcePaths.join('/') })
-    }
-  }
-  await sidebar.open({ page: page, resource: resourceName })
-  await sidebar.openPanel({ page: page, name: shareType })
-  return await page.locator(util.format(publicLink, linkName)).textContent()
 }
 
 export const getLinkEditButtonVisibility = async (

--- a/tests/e2e/support/objects/app-files/link/index.ts
+++ b/tests/e2e/support/objects/app-files/link/index.ts
@@ -81,15 +81,6 @@ export class Link {
     await this.#page.goto(startUrl)
   }
 
-  getPublicLinkUrl(
-    args: Omit<po.publicLinkAndItsEditButtonVisibilityArgs, 'page'>
-  ): Promise<string> {
-    return po.getPublicLinkVisibility({
-      ...args,
-      page: this.#page
-    })
-  }
-
   async islinkEditButtonVisibile(linkName: string): Promise<boolean> {
     return await po.getLinkEditButtonVisibility({ page: this.#page, linkName })
   }

--- a/tests/e2e/support/objects/app-files/page/public.ts
+++ b/tests/e2e/support/objects/app-files/page/public.ts
@@ -66,16 +66,6 @@ export class Public {
     await this.#page.locator('body').click()
   }
 
-  async uploadInternal(
-    args: Omit<po.uploadResourceArgs, 'page'> & { link: string }
-  ): Promise<void> {
-    // link is the public link url
-    const { link } = args
-    delete args.link
-    await po.uploadResource({ ...args, page: this.#page })
-    await this.#page.goto(link)
-  }
-
   async delete(args: Omit<po.deleteResourceArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
     await po.deleteResource({ ...args, page: this.#page, isPublicLink: true })

--- a/tests/e2e/support/objects/app-files/page/shares/withMe.ts
+++ b/tests/e2e/support/objects/app-files/page/shares/withMe.ts
@@ -1,9 +1,6 @@
 import { Page } from '@playwright/test'
-import { Actor } from '../../../../../support/types'
 
 const sharesNavSelector = '//a[@data-nav-name="files-shares"]'
-const openShareWithMeButton = `//a/span[text()='Open "Shared with me"']`
-const shareWithMeNavSelector = '//a/span[text()="Shared with me"]'
 
 export class WithMe {
   #page: Page
@@ -14,14 +11,5 @@ export class WithMe {
 
   async navigate(): Promise<void> {
     await this.#page.locator(sharesNavSelector).click()
-  }
-
-  async openShareWithMeFromInternalLink(actor: Actor): Promise<void> {
-    const [newTab] = await Promise.all([
-      this.#page.waitForEvent('popup'),
-      this.#page.locator(openShareWithMeButton).click()
-    ])
-    await newTab.locator(shareWithMeNavSelector).waitFor()
-    actor.savePage(newTab)
   }
 }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -90,7 +90,6 @@ const tagInInputForm =
   '//span[contains(@class, "tags-select-tag")]//span[text()="%s"]//ancestor::span//button[contains(@class, "vs__deselect")]'
 const tagFormInput = '//*[@data-testid="tags"]//input'
 const resourcesAsTiles = '#files-view .oc-tiles'
-const fileVersionSidebar = '#oc-file-versions-sidebar'
 const versionsPanelSelect = '//*[@data-testid="sidebar-panel-versions-select"]'
 const noLinkMessage = '#web .oc-link-resolve-error-message'
 const listItemPageSelector = '//*[contains(@class,"oc-pagination-list-item-page") and text()="%s"]'
@@ -1869,27 +1868,6 @@ export const previewMediaFromSidebarPanel = async ({
   await page.locator(util.format(sideBarActionButton, 'Preview')).first().click()
 }
 
-export const checkThatFileVersionIsNotAvailable = async (
-  args: resourceVersionArgs
-): Promise<void> => {
-  const { page, files, folder } = args
-  const fileName = files.map((file) => path.basename(file.name))
-  await clickResource({ page, path: folder })
-
-  await Promise.all([
-    page.waitForResponse(
-      (resp) =>
-        resp.url().includes('dav/meta') &&
-        resp.status() === 403 &&
-        resp.request().method() === 'PROPFIND'
-    ),
-    sidebar.open({ page, resource: fileName[0] })
-  ])
-
-  await sidebar.openPanel({ page, name: 'versions' })
-  await expect(page.locator(fileVersionSidebar)).toHaveText('No versions available for this file')
-}
-
 export const checkThatFileVersionPanelIsNotAvailable = async (
   args: resourceVersionArgs
 ): Promise<void> => {
@@ -1967,21 +1945,6 @@ export const countNumberOfResourcesInThePage = async ({
 
 export const expectPageNumberNotToBeVisible = async ({ page }: { page: Page }): Promise<void> => {
   await expect(page.locator(filesPaginationNavSelector)).not.toBeVisible()
-}
-
-export interface expectFileToBeSelectedArgs {
-  page: Page
-  fileName: string
-}
-
-export const expectFileToBeSelected = async ({
-  page,
-  fileName
-}: {
-  page: Page
-  fileName: string
-}): Promise<void> => {
-  await expect(page.locator(util.format(checkBox, fileName))).toBeChecked()
 }
 
 export const createShotcut = async (args: shortcutArgs): Promise<void> => {

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -273,14 +273,6 @@ export class Resource {
     return po.createSpaceFromAll({ page: this.#page, spaceName })
   }
 
-  async checkThatFileVersionIsNotAvailable(
-    args: Omit<po.resourceVersionArgs, 'page'>
-  ): Promise<void> {
-    const startUrl = this.#page.url()
-    await po.checkThatFileVersionIsNotAvailable({ ...args, page: this.#page })
-    await this.#page.goto(startUrl)
-  }
-
   async checkThatFileVersionPanelIsNotAvailable(
     args: Omit<po.resourceVersionArgs, 'page'>
   ): Promise<void> {
@@ -307,10 +299,6 @@ export class Resource {
 
   async expectPageNumberNotToBeVisible(): Promise<void> {
     await po.expectPageNumberNotToBeVisible({ page: this.#page })
-  }
-
-  async expectFileToBeSelected(args: Omit<po.expectFileToBeSelectedArgs, 'page'>): Promise<void> {
-    await po.expectFileToBeSelected({ ...args, page: this.#page })
   }
 
   async createShotcut(args: Omit<po.shortcutArgs, 'page'>): Promise<void> {

--- a/tests/e2e/support/objects/app-files/share/index.ts
+++ b/tests/e2e/support/objects/app-files/share/index.ts
@@ -1,6 +1,6 @@
 import { Page, Locator } from '@playwright/test'
 import * as po from './actions'
-import { resourceIsNotOpenable, isAcceptedSharePresent, resourceIsSynced } from './utils'
+import { isAcceptedSharePresent, resourceIsSynced } from './utils'
 import { ICollaborator, IAccessDetails } from './collaborator'
 import { User } from '../../../types'
 export class Share {
@@ -49,10 +49,6 @@ export class Share {
   async isAcceptedSharePresent(resource: string, owner: string): Promise<boolean> {
     await this.#page.reload()
     return await isAcceptedSharePresent({ page: this.#page, resource, owner })
-  }
-
-  async resourceIsNotOpenable(resource: string): Promise<boolean> {
-    return await resourceIsNotOpenable({ page: this.#page, resource })
   }
 
   async resourceIsSynced(resource: string): Promise<boolean> {

--- a/tests/e2e/support/objects/app-files/share/utils.ts
+++ b/tests/e2e/support/objects/app-files/share/utils.ts
@@ -3,28 +3,8 @@ import util from 'util'
 
 const acceptedShareItem =
   '//*[@data-test-resource-name="%s"]/ancestor::tr//span[@data-test-user-name="%s"]'
-const itemSelector = '.files-table [data-test-resource-name="%s"]'
 const syncEnabled =
   '//*[@data-test-resource-name="%s"]//ancestor::tr//span[contains(@class, "sync-enabled")]'
-
-export const resourceIsNotOpenable = async ({
-  page,
-  resource
-}: {
-  page: Page
-  resource: string
-}): Promise<boolean> => {
-  const resourceLocator = page.locator(util.format(itemSelector, resource))
-  try {
-    await Promise.all([
-      page.waitForRequest((req) => req.method() === 'PROPFIND', { timeout: 500 }),
-      resourceLocator.click()
-    ])
-    return false
-  } catch {
-    return true
-  }
-}
 
 export const resourceIsSynced = ({
   page,


### PR DESCRIPTION
- I added the command `pnpm check:unused-steps`, which compares all steps from `feature` and `stepDefinitions` files and finds unused steps that should, of course, be deleted.

example: 
```
pnpm check:unused-steps

> @3.0.0 check:unused-steps /Users/v.scharf/Work/opencloud/web
> TS_NODE_PROJECT=./tests/e2e/cucumber/tsconfig.json cucumber-js --profile=e2e --format usage --dry-run tests/e2e/cucumber/features/*/*.feature

(node:48694) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────┬──────────────────────────────────────────────────────────────────────────────────────────┐
│ Pattern / Text                                                                                                                                       │ Duration │ Location                                                                                 │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ {string} creates the following project space(s) using API                                                                                            │ -        │ file:/Users/v.scharf/Work/opencloud/web/tests/e2e/cucumber/steps/api.ts:125              │
│   "Admin" creates the following project spaces using API                                                                                             │ -        │ tests/e2e/cucumber/features/admin-settings/spaces.feature:10                             │
│   "Admin" creates the following project spaces using API                                                                                             │ -        │ tests/e2e/cucumber/features/admin-settings/spaces.feature:126                            │
│   "Alice" creates the following project space using API                                                                                              │ -        │ tests/e2e/cucumber/features/app-provider-onlyOffice/officeSuites.feature:84              │
│   "Alice" creates the following project space using API                                                                                              │ -        │ tests/e2e/cucumber/features/app-provider/officeSuites.feature:83                         │
│   "Alice" creates the following project space using API                                                                                              │ -        │ tests/e2e/cucumber/features/navigation/urlJourneys.feature:21                            │
│   18 more                                                                                                                                            │          │                                                                                          │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ {string} creates the following file(s) in space {string} using API                                                                                   │ -        │ file:/Users/v.scharf/Work/opencloud/web/tests/e2e/cucumber/steps/api.ts:137              │
│   "Alice" creates the following file in space "Development" using API                                                                                │ -        │ tests/e2e/cucumber/features/navigation/urlJourneys.feature:24                            │
│   "Alice" creates the following file in space "team" using API                                                                                       │ -        │ tests/e2e/cucumber/features/spaces/downloadSpace.feature:21                              │
│   "Alice" creates the following file in space "team" using API                                                                                       │ -        │ tests/e2e/cucumber/features/spaces/publicLink.feature:20                                 │
│   "Alice" creates the following file in space "team" using API                                                                                       │ -        │ tests/e2e/cucumber/features/spaces/publicLink.feature:107                                │
│   "Brian" creates the following file in space "FullTextSearch" using API                                                                             │ -        │ tests/e2e/cucumber/features/search/fullTextSearch.feature:38                             │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ {string} creates {int} file(s) in space {string} using API                                                                                           │ UNUSED   │ file:/Users/v.scharf/Work/opencloud/web/tests/e2e/cucumber/steps/api.ts:148              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ {string} creates the following folder(s) in space {string} using API                                                                                 │ -        │ file:/Users/v.scharf/Work/opencloud/web/tests/e2e/cucumber/steps/api.ts:159              │
│   "Alice" creates the following folder in space "Marketing" using API                                                                                │ -        │ tests/e2e/cucumber/features/app-provider-onlyOffice/officeSuites.feature:87              │
│   "Alice" creates the following folder in space "Marketing" using API                                                                                │ -        │ tests/e2e/cucumber/features/app-provider/officeSuites.feature:86                         │
│   "Alice" creates the following folder in space "Marketing" using API                                                                                │ -        │ tests/e2e/cucumber/features/smoke/sse.feature:55                                         │
│   "Alice" creates the following folder in space "Marketing" using API                                                                                │ -        │ tests/e2e/cucumber/features/smoke/sse.feature:178                                        │
│   "Alice" creates the following folder in space "my_space" using API                                                                                 │ -        │ tests/e2e/cucumber/features/a11y/smoke.feature:21                                        │
│   4 more                                                                                                                                             │          │                                                                                          │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ {string} creates {int} folders(s) in space {string} using API                                                                                        │ UNUSED   │ file:/Users/v.scharf/Work/opencloud/web/tests/e2e/cucumber/steps/api.ts:169              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
```

- deleted unused steps