### PR TITLE
fix(design-system): default colors for some of the icons

### DIFF
--- a/packages/design-system/src/tokens/ods/color.yaml
+++ b/packages/design-system/src/tokens/ods/color.yaml
@@ -2,9 +2,9 @@
 color:
   icon:
     folder:
-      value: rgb(44, 101, 255)
+      value: rgb(77, 126, 175)
     archive:
-      value: rgb(255, 207, 1)
+      value: rgb(251, 190, 84)
     graphic:
       value: rgb(235, 201, 74)
     drawio:
@@ -14,7 +14,7 @@ color:
     ifc:
       value: rgb(208, 67, 236)
     image:
-      value: rgb(255, 111, 0)
+      value: rgb(238, 107, 59)
     jupyter:
       value: rgb(243, 119, 38)
     code:
@@ -22,21 +22,21 @@ color:
     text:
       value: '{role.onSurface}'
     spreadsheet:
-      value: rgb(0, 182, 87)
+      value: rgb(21, 194, 134)
     document:
-      value: rgb(44, 101, 255)
+      value: rgb(59, 68, 166)
     form:
       value: rgb(102, 166, 163)
     markdown:
       value: rgb(75, 100, 137)
     video:
-      value: rgb(0, 187, 219)
+      value: rgb(4, 84, 89)
     audio:
-      value: rgb(208, 67, 236)
+      value: rgb(112, 4, 96)
     presentation:
-      value: rgb(255, 64, 6)
+      value: rgb(238, 107, 59)
     pdf:
-      value: rgb(225, 5, 14)
+      value: rgb(236, 13, 71)
     root:
       value: rgb(0, 187, 219)
     medical:


### PR DESCRIPTION
## Description

I noticed that some of the default colors for icons in the design system are not our theme default. Set them in the design system tokens now (where the defaults belong) and will delete them from the theme.json in the opencloud repo as soon as we brought a pre-release of web with the new defaults to the opencloud repo.

FTR: I just copied these colors:
https://github.com/opencloud-eu/opencloud/blob/df6fb3384f2089bade6c36a11497432f635cb570/services/web/assets/themes/opencloud/theme.json#L150

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
