### PR TITLE
feat: revert material design color hacks

### DIFF
--- a/packages/design-system/src/components/OcTable/OcTable.vue
+++ b/packages/design-system/src/components/OcTable/OcTable.vue
@@ -506,15 +506,15 @@ const handleSort = (field: FieldType) => {
   }
 
   &-hover tr:not(&-footer-row, &-header-row):hover {
-    background-color: var(--oc-role-secondary-container);
+    background-color: var(--oc-role-surface-container);
   }
 
   &-highlighted {
-    background-color: var(--oc-role-surface-container) !important;
+    background-color: var(--oc-role-secondary-container) !important;
   }
 
   &-accentuated {
-    background-color: var(--oc-role-surface-container);
+    background-color: var(--oc-role-secondary-container);
   }
 
   &-disabled {

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="observerTarget"
-    class="oc-tile-card oc-card oc-card-default"
+    class="oc-tile-card oc-card"
     :data-item-id="resource.id"
     :class="{
       'oc-tile-card-selected': isResourceSelected,
@@ -196,8 +196,10 @@ if (!lazy) {
 </script>
 
 <style lang="scss">
+.oc-tile-card.oc-card {
+  background-color: var(--oc-role-surface-container);
+}
 .oc-tile-card {
-  background-color: var(--oc-role-surface-container) !important;
   box-shadow: none;
   height: 100%;
   display: flex;
@@ -267,10 +269,10 @@ if (!lazy) {
     }
   }
   &:hover {
-    background-color: var(--oc-role-secondary-container) !important;
+    background-color: var(--oc-role-surface-container-highest);
   }
   &-selected {
-    background-color: var(--oc-role-surface-container-high) !important;
+    background-color: var(--oc-role-secondary-container) !important;
     outline: 2px solid var(--oc-role-outline);
   }
 

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTile.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTile.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`OcTile component > renders default space correctly 1`] = `
-"<div class="oc-tile-card oc-card oc-card-default">
+"<div class="oc-tile-card oc-card">
   <resource-link-stub resource="[object Object]" isresourceclickable="true" class="oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1">
     <div class="oc-tile-card-selection"></div>
     <!--v-if-->
@@ -26,7 +26,7 @@ exports[`OcTile component > renders default space correctly 1`] = `
 `;
 
 exports[`OcTile component > renders disabled space correctly 1`] = `
-"<div class="oc-tile-card oc-card oc-card-default oc-tile-card-disabled">
+"<div class="oc-tile-card oc-card oc-tile-card-disabled">
   <resource-link-stub resource="[object Object]" isresourceclickable="true" class="oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1">
     <div class="oc-tile-card-selection"></div>
     <!--v-if-->

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
   </div>
   <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles">
     <li class="oc-tiles-item has-item-context-menu">
-      <div class="oc-tile-card oc-card oc-card-default" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" no-hover="" tabindex="-1"></a>
+      <div class="oc-tile-card oc-card" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" no-hover="" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">
@@ -49,7 +49,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
       </div>
     </li>
     <li class="oc-tiles-item has-item-context-menu">
-      <div class="oc-tile-card oc-card oc-card-default" data-item-id="2" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" no-hover="" tabindex="-1"></a>
+      <div class="oc-tile-card oc-card" data-item-id="2" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" no-hover="" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -175,7 +175,7 @@ export default defineComponent({
 #nav-highlighter {
   position: absolute;
   border-radius: 5px;
-  background: var(--oc-role-surface);
+  background: var(--oc-role-secondary-container);
   transition: transform 0.2s cubic-bezier(0.51, 0.06, 0.56, 1.37);
   color: var(--oc-role-on-surface);
   svg {

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
@@ -3,7 +3,7 @@
     <oc-button
       :type="handler ? 'button' : 'router-link'"
       :appearance="active ? 'filled' : 'raw-inverse'"
-      :color-role="active ? 'surface' : 'secondaryContainer'"
+      color-role="secondaryContainer"
       :class="['oc-sidebar-nav-item-link', 'oc-oc-width-1-1', { active: active }]"
       :data-nav-id="index"
       :data-nav-name="navName"
@@ -124,7 +124,7 @@ export default defineComponent({
 
   &:focus:not(.active),
   &:hover:not(.active) {
-    background: var(--oc-role-secondary-container) !important;
+    background: var(--oc-role-surface-container-highest) !important;
   }
 
   .oc-icon svg {


### PR DESCRIPTION
## Description

Reverting color hacks that deviated our design away from material design. Download new theme.json and logos and test with a docker-compose overlay:

```yaml
services:
  opencloud:
    environment:
      WEB_ASSET_THEMES_PATH: ${WEB_ASSET_THEMES_PATH:-/web/themes}
      WEB_UI_THEME_PATH: ${WEB_UI_THEME_PATH:-/themes/opencloud/theme.json}
    volumes:
      - ../web-theme/:/web/themes/opencloud/
```

Download the following files and move them to the `web-theme` folder (or whichever folder you mount into the dev stack)

[theme.json](https://github.com/user-attachments/files/21103982/theme.json)
![assets/logo-white.svg](https://github.com/user-attachments/assets/5dd2b4d2-5000-4135-a84f-6bdc22e31832)
![assets/logo.svg](https://github.com/user-attachments/assets/f6121cb6-1d34-44f2-b5d5-4741ccf16976)


## Related Issue

Pre-requisite for merging our new theme in the opencloud repo, which will ultimately close https://github.com/opencloud-eu/web/issues/402 and works towards https://github.com/opencloud-eu/web/issues/513

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
