### PR TITLE
Get rid of 'retry' dependency

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -882,7 +882,7 @@ def buildOpenCloud(enableVips = False):
                 ". ./.woodpecker.env",
                 "if $OPENCLOUD_CACHE_FOUND; then exit 0; fi",
                 "cd repo_opencloud",
-                "retry -t 3 'make node-generate-prod'",  # ToDo Get rid of 'retry' dependency as in https://github.com/opencloud-eu/opencloud/commit/c897ec321fcd6af40c3dcfc56b2b6cd195a6054f
+                "for i in $(seq 3); do make node-generate-prod && break || sleep 1; done",
             ],
         },
         {


### PR DESCRIPTION
## Description

Get rid of that small dependency. The current container has it, but if we change to an own container for nodejs we don't need to keep on maintaining that extra dependency.
Same as https://github.com/opencloud-eu/opencloud/commit/c897ec321fcd6af40c3dcfc56b2b6cd195a6054f


## Related Issue

Part of https://github.com/opencloud-eu/qa/issues/44

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
