### PR TITLE
fix(pnpm): mute pnpm cyclic workspace dependencies warning in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RELEASE := ${CURDIR}/release
 NODE_MODULES := ${CURDIR}/node_modules
 
 node_modules: package.json pnpm-lock.yaml
-	[ -n "${NO_INSTALL}" ] || pnpm install
+	[ -n "${NO_INSTALL}" ] || pnpm install --reporter=silent
 	touch ${NODE_MODULES}
 
 .PHONY: clean


### PR DESCRIPTION
## Description

pnpm-lock.yaml contained cyclic imports

```bash
❯ pnpm install     
Scope: all 24 workspace projects
 WARN  There are cyclic workspace dependencies: /Users/fschade/Developer/fschade/opencloud-web/packages/design-system, /Users/fschade/Developer/fschade/opencloud-web/packages/web-test-helpers, /Users/fschade/Developer/fschade/opencloud-web/packages/web-pkg
✔ The modules directories will be removed and reinstalled from scratch. Proceed? 
```