### PR TITLE
fix: ensure click on whitespace in search result opens file

### DIFF
--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -84,6 +84,7 @@
                   active: isPreviewElementActive(providerSearchResultValue.id)
                 }"
                 class="preview oc-flex oc-flex-middle"
+                @click="openPreview($event)"
               >
                 <component
                   :is="provider.previewSearch.component"
@@ -517,6 +518,17 @@ export default defineComponent({
     },
     hideOptionsDrop() {
       this.optionsDrop?.hide()
+    },
+    openPreview(event: MouseEvent | KeyboardEvent) {
+      if ((event.target as HTMLElement).closest('a')) {
+        return
+      }
+
+      const container = event.currentTarget as HTMLElement
+      const link = container.querySelector<HTMLAnchorElement>('.oc-resource-link')
+      if (link) {
+        window.location.href = link.href
+      }
     }
   }
 })


### PR DESCRIPTION
ensure click on whitespace in search result opens file.

Now also works for Keyboard select (ENTER)

Related to Issue #865 