### PR TITLE
[full-ci] e2e tests. fix flakiness while filling resource name for text file

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -354,6 +354,7 @@ export const createNewFileOrFolder = async (args: createResourceArgs): Promise<v
     }
     case 'txtFile': {
       await page.locator(createNewTxtFileButton).click()
+      await page.locator(resourceNameInput).selectText()
       await page.locator(resourceNameInput).fill(name)
       await Promise.all([
         page.waitForResponse((resp) => resp.status() === 201 && resp.request().method() === 'PUT'),


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->
CI is being flaky wile creating `.txt` file: https://ci.opencloud.eu/repos/3/pipeline/2357/314

```gherkin
Scenario: Upload files in personal space # tests/e2e/cucumber/features/smoke/upload.feature:14
    Given "Admin" creates following user using API
      │ id    │
      │ Alice │
    And "Alice" logs in
    And "Alice" opens the "files" app
    Given "Alice" creates the following resources
      │ resource          │ type    │ content             │
      │ new-lorem-big.txt │ txtFile │ new lorem big file  │
      │ lorem.txt         │ txtFile │ lorem file          │
      │ textfile.txt      │ txtFile │ some random content │
      │ comma,.txt        │ txtFile │ comma               │
      │ test#file.txt     │ txtFile │ some content        │
      │ test#folder       │ folder  │                     │
    ✖ failed
      locator.waitFor: Timeout 30000ms exceeded.
      Call log:
        - waiting for locator(':is(#files-files-table, .oc-tiles-item, #files-shared-with-me-accepted-section, .files-table) [data-test-resource-name="comma,.txt"]') to be visible

          at editTextDocument (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/support/objects/app-files/resource/actions.ts:433:65)
          at async createNewFileOrFolder (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/support/objects/app-files/resource/actions.ts:247:13)
          at async Module.createResources (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/support/objects/app-files/resource/actions.ts:421:5)
          at async Resource.create (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/support/objects/app-files/resource/index.ts:10:9)
          at async World.<anonymous> (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/cucumber/steps/ui/resources.ts:11:9)
```

This is also flaky in local environment because:

- we pass the file name along with extension (like `lorem.txt`) from test step
- but the resource name input field while creating a new resource already comes with the extension of chosen file type.
- this creates the file name with two extensions like `lorem.txt.txt`


https://github.com/user-attachments/assets/d33325ec-d229-498d-a248-6e5ccbc54e6c



What we have used is: `await page.locator(resourceNameInput).fill(name)` but the `.fill()` method of playwright is flaky in itself: https://github.com/microsoft/playwright/issues/36395

So as a fix, this PR adds `await page.locator(resourceNameInput).selectText()` to select all what exists in the resource input field and then only fills what comes from the test step (i.e resource name with extension) so that we can only have what is sent from the test step, which removes the creation of double file extensions.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
Locally I have tested this change for up-to 20 iterations without getting any failures.

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
