### PR TITLE
fix flaky close viewer after download

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -812,15 +812,13 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
     }
 
     case 'PREVIEW_TOPBAR':
-      await Promise.all([
-        page.locator(appBarDownloadFileButton).waitFor(),
-        page.locator(appBarContextMenu).click()
-      ])
+      const downloadButtonPromise = page.locator(appBarDownloadFileButton).waitFor()
+      await page.locator(appBarContextMenu).click()
+      await downloadButtonPromise
 
-      const [download] = await Promise.all([
-        page.waitForEvent('download'),
-        page.locator(appBarDownloadFileButton).click()
-      ])
+      const downloadPromise = page.waitForEvent('download')
+      await page.locator(appBarDownloadFileButton).click()
+      const download = await downloadPromise
       downloads.push(download)
       break
   }

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -6,11 +6,10 @@ const texEditor = '#text-editor'
 const pdfViewer = '#pdf-viewer'
 const imageViewer = '.stage'
 
-export const close = (page: Page): Promise<unknown> => {
-  return Promise.all([
-    page.waitForURL(/.*\/files\/(spaces|shares|link|search)\/.*/),
-    page.locator(closeTextEditorOrViewerButton).click()
-  ])
+export const close = async (page: Page): Promise<void> => {
+  const navigationPromise = page.waitForURL(/.*\/files\/(spaces|shares|link|search)\/.*/)
+  await page.locator(closeTextEditorOrViewerButton).click()
+  await navigationPromise
 }
 
 export const save = async (page: Page): Promise<unknown> => {

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -6,7 +6,7 @@ const texEditor = '#text-editor'
 const pdfViewer = '#pdf-viewer'
 const imageViewer = '.stage'
 
-export const close = async (page: Page): Promise<void> => {
+export const close = async (page: Page) => {
   const navigationPromise = page.waitForURL(/.*\/files\/(spaces|shares|link|search)\/.*/)
   await page.locator(closeTextEditorOrViewerButton).click()
   await navigationPromise


### PR DESCRIPTION
## Problem
The E2E tests for media viewer download and file closing were experiencing flakiness due to race conditions in Promise.all usage.

## Solution
Applied Playwright's recommended "prepare promise first" pattern:

## How to reproduce
`HEADLESS=false pnpm test:e2e:cucumber:chromium tests/e2e/cucumber/features/shares/share.feature:79`

 ```
 ✔ And "Alice" opens the following file in mediaviewer                                    # file:/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/cucumber/steps/ui/resources.ts:378
        | resource       |
        | test_video.mp4 |
    ✔ Then "Alice" is in a media-viewer                                                      # file:/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/cucumber/steps/ui/public.ts:43
    ✔ When "Alice" downloads the following resource using the preview topbar                 # file:/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/cucumber/steps/ui/resources.ts:73
        | resource       | type |
        | test_video.mp4 | file |
    ✘ And "Alice" closes the file viewer                                                     # file:/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/cucumber/steps/ui/public.ts:35
          at Module.close (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/support/objects/app-files/utils/editor.ts:8:14)
              at World.<anonymous> (/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner/tests/e2e/cucumber/steps/ui/public.ts:37:18)
```

cc @dragonchaser 