### PR TITLE
e2e-test. fix share with multiple user test

### DIFF
--- a/tests/e2e/support/objects/app-files/share/collaborator.ts
+++ b/tests/e2e/support/objects/app-files/share/collaborator.ts
@@ -110,9 +110,11 @@ export default class Collaborator {
     ])
     await collaboratorInputLocator.focus()
     await page.locator('.vs--open').waitFor()
-    await page
-      .locator(util.format(Collaborator.collaboratorDropdownItem, collaborator.displayName))
-      .click()
+    const dropdownItemLocator = page.locator(
+      util.format(Collaborator.collaboratorDropdownItem, collaborator.displayName)
+    )
+    await page.waitForTimeout(200)
+    await dropdownItemLocator.click()
   }
 
   static async sendInvitation(page: Page, collaborators: string[]): Promise<void> {


### PR DESCRIPTION
Fix flaky tests caused by right sidebar flickering when sharing with multiple users (issue not reproducible manually)

before: 

https://github.com/user-attachments/assets/8190367d-9ead-4839-accb-2d8346fc19f8

after: 

https://github.com/user-attachments/assets/d29f878d-84e2-4d15-ae48-788398821a0d


which tests were affected: 
`KEYCLOAK=true HEADLESS=false OC_BASE_URL=cloud.opencloud.test KEYCLOAK_HOST=keycloak.opencloud.test pnpm test:e2e:cucumber tests/e2e/cucumber/features/keycloak`
