### PR TITLE
feat: preserve empty folders on upload

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -171,6 +171,7 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
         // file data
         name: file.name,
         mtime: (file.data as File).lastModified / 1000,
+        isFolder: file.type === 'directory',
         // current path & space
         spaceId: unref(this.space).id,
         spaceName: unref(this.space).name,
@@ -188,6 +189,13 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
         routeName: name as string,
         routeDriveAliasAndItem: queryItemAsString(params?.driveAliasAndItem) || '',
         routeShareId: queryItemAsString(query?.shareId) || ''
+      }
+
+      if (file.type === 'directory') {
+        // folder files need their name appended to the relative folder
+        // so they can be created correctly. otherwise, only the parent directories
+        // would be created (because that's the behavior with files).
+        file.meta.relativeFolder = urlJoin(file.meta.relativeFolder, file.name)
       }
 
       filesToUpload[file.id] = file
@@ -278,7 +286,7 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
   async createDirectoryTree(
     filesToUpload: OcUppyFile[],
     uploadFolder: Resource
-  ): Promise<OcUppyFile[]> {
+  ): Promise<{ filesToUpload: OcUppyFile[]; folderFiles: OcUppyFile[] }> {
     const { webdav } = this.clientService
     const space = unref(this.space)
     const { id: currentFolderId, path: currentFolderPath } = uploadFolder
@@ -291,7 +299,16 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
     const directoryTree: Record<string, any> = {}
     const topLevelIds: Record<string, string> = {}
 
+    // folder files are manually constructed folders via the drop plugin.
+    // they should not be part of the Uppy upload queue (which only knows files)
+    // and will be created separately. they need to be filtered out later.
+    const folderFiles: OcUppyFile[] = []
+
     for (const file of filesToUpload.filter(({ meta }) => !!meta.relativeFolder)) {
+      if (file.type === 'directory') {
+        folderFiles.push(file)
+      }
+
       const folders = file.meta.relativeFolder.split('/').filter(Boolean)
       let current = directoryTree
       // first folder is always top level
@@ -365,17 +382,23 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
     await createDirectoryLevel(directoryTree)
 
     let filesToRemove: string[] = []
-    if (failedFolders.length) {
-      // remove files of folders that could not be created
+    if (failedFolders.length || folderFiles.length) {
+      // remove files of folders that could not be created and folder files
       filesToRemove = filesToUpload
-        .filter((f) => failedFolders.some((r) => f.meta.relativeFolder.startsWith(r)))
+        .filter(
+          (f) => f.meta.isFolder || failedFolders.some((r) => f.meta.relativeFolder.startsWith(r))
+        )
         .map(({ id }) => id)
+
       for (const fileId of filesToRemove) {
         this.uppy.removeFile(fileId)
       }
     }
 
-    return filesToUpload.filter(({ id }) => !filesToRemove.includes(id))
+    return {
+      filesToUpload: filesToUpload.filter(({ id }) => !filesToRemove.includes(id)),
+      folderFiles
+    }
   }
 
   /**
@@ -426,12 +449,21 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
     }
 
     this.uppyService.publish('uploadStarted')
+    let folderFiles: OcUppyFile[] = []
     if (this.directoryTreeCreateEnabled) {
-      filesToUpload = await this.createDirectoryTree(filesToUpload, uploadFolder)
+      const result = await this.createDirectoryTree(filesToUpload, uploadFolder)
+      filesToUpload = result.filesToUpload
+      folderFiles = result.folderFiles
     }
 
     if (!filesToUpload.length) {
-      this.uppyService.publish('uploadCompleted', { successful: [] })
+      const successful: OcUppyFile[] = []
+      if (folderFiles.length) {
+        // case where only empty folders have been uploaded
+        successful.push(...folderFiles)
+      }
+      this.uppyService.publish('uploadCompleted', { successful })
+      this.uppyService.removeUploadFolder(uploadId)
       return this.uppyService.clearInputs()
     }
 

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -356,7 +356,7 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
         try {
           const folder = await webdav.createFolder(space, {
             path: urlJoin(currentFolderPath, path),
-            fetchFolder: isRoot
+            fetchFolder: isRoot // FIXME: remove once we get the fileId from the server here
           })
           this.uppyService.publish('uploadSuccess', {
             ...uppyFile,

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -329,7 +329,6 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
         const uppyFile = {
           id: uuidV4(),
           name: basename(path),
-          isFolder: true,
           type: 'folder',
           meta: {
             spaceId: space.id,
@@ -342,7 +341,8 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
             uploadId,
             routeName,
             routeDriveAliasAndItem,
-            routeShareId
+            routeShareId,
+            isFolder: true
           }
         }
 

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -299,7 +299,7 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
     const directoryTree: Record<string, any> = {}
     const topLevelIds: Record<string, string> = {}
 
-    // folder files are manually constructed folders via the drop plugin.
+    // folder files are manually constructed folders.
     // they should not be part of the Uppy upload queue (which only knows files)
     // and will be created separately. they need to be filtered out later.
     const folderFiles: OcUppyFile[] = []

--- a/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
@@ -28,10 +28,19 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, onBeforeUnmount, ref } from 'vue'
+import {
+  computed,
+  defineComponent,
+  onMounted,
+  onBeforeUnmount,
+  ref,
+  unref,
+  useTemplateRef
+} from 'vue'
 import { Resource } from '@opencloud-eu/web-client'
-import { useService, ResourceIcon } from '@opencloud-eu/web-pkg'
+import { useService, ResourceIcon, convertToMinimalUppyFile } from '@opencloud-eu/web-pkg'
 import type { UppyService } from '@opencloud-eu/web-pkg'
+import { getItemsViaDirectoryPicker } from '../../../helpers/directoryPicker'
 
 export default defineComponent({
   components: { ResourceIcon },
@@ -54,6 +63,8 @@ export default defineComponent({
   },
   setup(props) {
     const uppyService = useService<UppyService>('$uppyService')
+    const input = useTemplateRef<HTMLInputElement>('input')
+
     const isRemoteUploadInProgress = ref(uppyService.isRemoteUploadInProgress())
 
     let uploadStartedSub: string
@@ -67,18 +78,44 @@ export default defineComponent({
       (isRemoteUploadInProgress.value = uppyService.isRemoteUploadInProgress())
     const onUploadCompleted = () => (isRemoteUploadInProgress.value = false)
 
+    const triggerUpload = async () => {
+      if (!props.isFolder || typeof (window as any).showDirectoryPicker !== 'function') {
+        // use native file picker for file uploads or if browser does not support the Directory API
+        unref(input).click()
+        return
+      }
+
+      try {
+        // use the Directory API so we can retrieve empty folders
+        const items = await getItemsViaDirectoryPicker((error) => uppyService.log(error))
+        const uppyFiles = convertToMinimalUppyFile('FolderUpload', items)
+        uppyService.addFiles(uppyFiles)
+      } catch (error) {
+        if (error.name !== 'AbortError') {
+          // AbortError means the user closed the picker. in any other case
+          // we assume something went wrong and we fall back to the native picker.
+          console.error('Error using DirectoryPicker, falling back to the native one:', error)
+          unref(input).click()
+        }
+      }
+    }
+
     onMounted(() => {
       uploadStartedSub = uppyService.subscribe('uploadStarted', onUploadStarted)
       uploadCompletedSub = uppyService.subscribe('uploadCompleted', onUploadCompleted)
+      uppyService.registerUploadInput(unref(input))
     })
 
     onBeforeUnmount(() => {
       uppyService.unsubscribe('uploadStarted', uploadStartedSub)
       uppyService.unsubscribe('uploadCompleted', uploadCompletedSub)
+      uppyService.removeUploadInput(unref(input))
     })
     return {
       isRemoteUploadInProgress,
-      resource
+      resource,
+      input,
+      triggerUpload
     }
   },
   computed: {
@@ -112,17 +149,6 @@ export default defineComponent({
         }
       }
       return { multiple: true }
-    }
-  },
-  mounted() {
-    this.$uppyService.registerUploadInput(this.$refs.input as HTMLInputElement)
-  },
-  beforeUnmount() {
-    this.$uppyService.removeUploadInput(this.$refs.input as HTMLInputElement)
-  },
-  methods: {
-    triggerUpload() {
-      ;(this.$refs.input as HTMLInputElement).click()
     }
   }
 })

--- a/packages/web-app-files/src/helpers/directoryPicker.ts
+++ b/packages/web-app-files/src/helpers/directoryPicker.ts
@@ -1,0 +1,54 @@
+import { urlJoin } from '@opencloud-eu/web-client'
+import { createFolderDummyFile } from '@opencloud-eu/web-pkg'
+
+/**
+ * This method uses the Directory API to retrieve items from a directory
+ * that the user selects from their file system for upload.
+ * It returns an array of File objects, including dummy files for empty folders.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker
+ */
+export const getItemsViaDirectoryPicker = async (
+  onError?: (error?: unknown) => void
+): Promise<File[]> => {
+  const dirHandle: FileSystemDirectoryHandle = await (window as any).showDirectoryPicker()
+
+  async function* getItemsFromDirectory(
+    dirHandle: FileSystemDirectoryHandle,
+    path: string
+  ): AsyncGenerator<File> {
+    let hasFiles = false
+
+    for await (const [name, handle] of (dirHandle as any).entries()) {
+      if (handle.kind === 'directory') {
+        // recurse into the directory
+        yield* getItemsFromDirectory(handle, urlJoin(path, name))
+      } else {
+        hasFiles = true
+        try {
+          const file = await handle.getFile()
+          ;(file as any).relativePath = urlJoin(path, name, { leadingSlash: true })
+          yield file
+        } catch (error) {
+          console.log(error)
+          onError?.(error)
+        }
+      }
+    }
+
+    if (!hasFiles) {
+      // empty folder, create a dummy file to represent it in the Uppy queue.
+      // note that a folder that only contains other folders is always considered empty,
+      // even if there are files located further down the hierarchy. this is because we don't
+      // have insight into the contents of the subfolders at this point.
+      yield createFolderDummyFile(path)
+    }
+  }
+
+  const items: File[] = []
+  for await (const item of getItemsFromDirectory(dirHandle, dirHandle.name)) {
+    items.push(item)
+  }
+
+  return items
+}

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -74,7 +74,7 @@ describe('HandleUpload', () => {
       mocks.opts.clientService.webdav.createFolder.mockResolvedValue(createdFolder)
 
       const uploadFolder = mock<Resource>({ id: '1', path: '/' })
-      const result = await instance.createDirectoryTree([fileToUpload], uploadFolder)
+      const { filesToUpload } = await instance.createDirectoryTree([fileToUpload], uploadFolder)
 
       expect(mocks.opts.uppyService.publish).toHaveBeenCalledWith(
         'uploadSuccess',
@@ -105,7 +105,7 @@ describe('HandleUpload', () => {
           fetchFolder: true
         }
       )
-      expect(result.length).toBe(1)
+      expect(filesToUpload.length).toBe(1)
     })
     it('filters out files whose folders could not be created', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
@@ -116,11 +116,11 @@ describe('HandleUpload', () => {
       const fileToUpload = mock<OcUppyFile>({ name: 'name', meta: { relativeFolder } })
       mocks.opts.clientService.webdav.createFolder.mockRejectedValue({})
 
-      const result = await instance.createDirectoryTree([fileToUpload], mock<Resource>())
+      const { filesToUpload } = await instance.createDirectoryTree([fileToUpload], mock<Resource>())
 
       expect(mocks.opts.uppyService.publish).toHaveBeenCalledWith('uploadError', expect.anything())
       expect(mocks.uppy.removeFile).toHaveBeenCalled()
-      expect(result.length).toBe(0)
+      expect(filesToUpload.length).toBe(0)
     })
   })
   describe('method handleUpload', () => {

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -80,7 +80,6 @@ describe('HandleUpload', () => {
         'uploadSuccess',
         expect.objectContaining({
           name: relativeFolder.split('/')[1],
-          isFolder: true,
           type: 'folder',
           meta: expect.objectContaining({
             spaceId: unref(mocks.opts.space).id,
@@ -93,7 +92,8 @@ describe('HandleUpload', () => {
             routeName: fileToUpload.meta.routeName,
             routeDriveAliasAndItem: fileToUpload.meta.routeDriveAliasAndItem,
             routeShareId: fileToUpload.meta.routeShareId,
-            fileId: createdFolder.fileId
+            fileId: createdFolder.fileId,
+            isFolder: true
           })
         })
       )

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -41,7 +41,6 @@
     "@opencloud-eu/web-client": "workspace:^",
     "@sentry/vue": "^9.0.0",
     "@uppy/core": "^4.3.1",
-    "@uppy/drop-target": "^3.0.2",
     "@uppy/tus": "^4.1.5",
     "@uppy/utils": "^6.0.6",
     "@uppy/xhr-upload": "^4.2.3",

--- a/packages/web-pkg/src/services/uppy/DropTarget/getDroppedFiles.ts
+++ b/packages/web-pkg/src/services/uppy/DropTarget/getDroppedFiles.ts
@@ -1,0 +1,107 @@
+import { urlJoin } from '@opencloud-eu/web-client'
+
+/**
+ * Methods to retrieve dropped files from a DataTransfer object.
+ * This is inspired by WICG examples and the Uppy `getDroppedFiles` function.
+ *
+ * https://wicg.github.io/entries-api/#api-directoryreader
+ * https://github.com/transloadit/uppy/blob/main/packages/%40uppy/utils/src/getDroppedFiles/README.md
+ */
+
+const convertEntryToFile = async (entry: FileSystemFileEntry): Promise<File> => {
+  const file = await new Promise((resolve, reject) => entry.file(resolve, reject))
+  const isRootFile = entry.fullPath === urlJoin(entry.name, { leadingSlash: true })
+  if (!isRootFile) {
+    // add relativePath to the file object just like Uppy does and expects it
+    ;(file as any).relativePath = entry.fullPath
+  }
+
+  return file as File
+}
+
+const getAsEntry = (item: any): ReturnType<DataTransferItem['webkitGetAsEntry']> => {
+  // `webkitGetAsEntry` might get renamed to `getAsEntry` in the future.
+  // see https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
+  return typeof item.getAsEntry === 'function' ? item.getAsEntry() : item.webkitGetAsEntry()
+}
+
+async function* readDirectory(dirEntry: FileSystemDirectoryEntry): AsyncGenerator<FileSystemEntry> {
+  const reader = dirEntry.createReader()
+  const getNextBatch = () =>
+    new Promise<FileSystemEntry[]>((resolve, reject) => {
+      reader.readEntries(resolve, reject)
+    })
+
+  let entries: FileSystemEntry[]
+  do {
+    entries = await getNextBatch()
+    for (const entry of entries) {
+      yield entry
+    }
+  } while (entries.length > 0)
+}
+
+async function* getFile(
+  entry: FileSystemEntry,
+  onEmptyFolderDetected?: (path: string) => void,
+  logDropError?: (error?: unknown) => void
+): AsyncGenerator<File> {
+  if (entry.isDirectory) {
+    let hasFiles = false // check for empty directories later
+
+    for await (const e of readDirectory(entry as FileSystemDirectoryEntry)) {
+      if (e.isDirectory) {
+        // recurse into the directory
+        yield* getFile(e, onEmptyFolderDetected, logDropError)
+      } else if (e.isFile) {
+        try {
+          hasFiles = true
+          yield convertEntryToFile(e as FileSystemFileEntry)
+        } catch (error) {
+          console.error(error)
+          logDropError?.(error)
+        }
+      }
+    }
+
+    if (!hasFiles && onEmptyFolderDetected) {
+      // note that a folder that only contains other folders is always considered empty,
+      // even if there are files located further down the hierarchy. this is because we don't
+      // have insight into the contents of the subfolders at this point.
+      onEmptyFolderDetected(entry.fullPath || entry.name)
+    }
+  } else {
+    try {
+      yield convertEntryToFile(entry as FileSystemFileEntry)
+    } catch (error) {
+      console.error(error)
+      logDropError?.(error)
+    }
+  }
+}
+
+export const getDroppedFiles = async (
+  dataTransfer: DataTransfer,
+  onEmptyFolderDetected?: (path: string) => void,
+  logDropError?: (error?: unknown) => void
+): Promise<File[]> => {
+  try {
+    const files: File[] = []
+
+    // convert DataTransfer items to FileSystemEntry objects. this needs to happen at the beginning,
+    // otherwise only the first item will be processed.
+    const items = await Promise.all(Array.from(dataTransfer.items, (item) => getAsEntry(item)))
+
+    for (let i = 0; i < items.length; i++) {
+      for await (const file of getFile(items[i], onEmptyFolderDetected, logDropError)) {
+        files.push(file)
+      }
+    }
+
+    return files
+  } catch (e) {
+    console.error(e)
+    const files = Array.from(dataTransfer.files)
+    return Promise.resolve(files)
+  }
+}

--- a/packages/web-pkg/src/services/uppy/DropTarget/getDroppedFiles.ts
+++ b/packages/web-pkg/src/services/uppy/DropTarget/getDroppedFiles.ts
@@ -65,6 +65,7 @@ async function* getFile(
     }
 
     if (!hasFiles && onEmptyFolderDetected) {
+      // empty folder, create a dummy file to represent it in the Uppy queue.
       // note that a folder that only contains other folders is always considered empty,
       // even if there are files located further down the hierarchy. this is because we don't
       // have insight into the contents of the subfolders at this point.

--- a/packages/web-pkg/src/services/uppy/DropTarget/plugin.ts
+++ b/packages/web-pkg/src/services/uppy/DropTarget/plugin.ts
@@ -3,7 +3,7 @@ import { BasePlugin } from '@uppy/core'
 import { getDroppedFiles } from './getDroppedFiles'
 import toArray from '@uppy/utils/lib/toArray'
 import { DropTargetOptions } from './types'
-import { convertToMinimalUppyFile, createFolderDummyFile } from '../utils'
+import { convertToMinimalUppyFile } from '../utils'
 
 const defaultOpts = {
   target: null,
@@ -52,15 +52,7 @@ export default class DropTarget<M extends Meta, B extends Body> extends BasePlug
       }
     }
 
-    const emptyFolders: File[] = []
-    const onEmptyFolderDetected = (path: string) => {
-      emptyFolders.push(createFolderDummyFile(path))
-    }
-
-    const files = await getDroppedFiles(event.dataTransfer, onEmptyFolderDetected, logDropError)
-
-    // add empty folders to the Uppy state so the upload plugin can handle them
-    files.push(...emptyFolders)
+    const files = await getDroppedFiles(event.dataTransfer, logDropError)
 
     if (files.length > 0) {
       this.uppy.log('[DropTarget] Files were dropped')

--- a/packages/web-pkg/src/services/uppy/DropTarget/plugin.ts
+++ b/packages/web-pkg/src/services/uppy/DropTarget/plugin.ts
@@ -1,0 +1,162 @@
+import type { Body, DefinePluginOpts, Meta, Uppy } from '@uppy/core'
+import { BasePlugin } from '@uppy/core'
+import { getDroppedFiles } from './getDroppedFiles'
+import toArray from '@uppy/utils/lib/toArray'
+import { DropTargetOptions } from './types'
+import { basename } from 'path'
+
+const defaultOpts = {
+  target: null,
+  uppyService: null
+} satisfies DropTargetOptions
+
+/**
+ * This is an adaption of the official Uppy DropTarget plugin, extended by the
+ * functionality to handle empty folders and integrated into our UppyService.
+ * https://github.com/transloadit/uppy/tree/main/packages/%40uppy/drop-target
+ */
+export default class DropTarget<M extends Meta, B extends Body> extends BasePlugin<
+  DefinePluginOpts<DropTargetOptions, keyof typeof defaultOpts>,
+  M,
+  B
+> {
+  private nodes?: Array<HTMLElement>
+  private uppyService?: DropTargetOptions['uppyService']
+
+  constructor(uppy: Uppy<M, B>, opts?: DropTargetOptions) {
+    super(uppy, { ...defaultOpts, ...opts })
+    this.type = 'acquirer'
+    this.id = this.opts.id || 'DropTarget'
+  }
+
+  addFiles = (files: Array<File>): void => {
+    const descriptors = files.map((file) => ({
+      source: this.id,
+      name: file.name,
+      type: file.type,
+      data: file,
+      meta: {
+        // path of the file relative to the ancestor directory the user selected.
+        // e.g. 'docs/Old Prague/airbnb.pdf'
+        relativePath: (file as any).relativePath || null
+      } as any
+    }))
+
+    try {
+      this.uppy.addFiles(descriptors)
+    } catch (err) {
+      this.uppy.log(err)
+    }
+  }
+
+  handleDrop = async (event: DragEvent): Promise<void> => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.setPluginState({ isDraggingOver: false })
+
+    this.uppy.iteratePlugins((plugin) => {
+      if (plugin.type === 'acquirer') {
+        // @ts-expect-error Every Plugin with .type acquirer can define handleRootDrop(event)
+        plugin.handleRootDrop?.(event)
+      }
+    })
+
+    let executedDropErrorOnce = false
+    const logDropError = (error: Error): void => {
+      this.uppy.log(error, 'error')
+
+      if (!executedDropErrorOnce) {
+        this.uppy.info(error.message, 'error')
+        executedDropErrorOnce = true
+      }
+    }
+
+    const emptyFolders: File[] = []
+    const onEmptyFolderDetected = (path: string) => {
+      // manually construct a file object for the folder that can be added to the Uppy state
+      emptyFolders.push({
+        // only use the name of the folder, not the full path
+        name: basename(path),
+
+        // fake directory mime type so it can be identified as a folder by the upload plugin
+        type: 'directory',
+
+        // set path as relativePath. this differs a bit from files where root files don't
+        // have a relativePath.
+        relativePath: path
+      } as any) // need typecast because the File object does not have a relativePath property
+    }
+
+    const files = await getDroppedFiles(event.dataTransfer, onEmptyFolderDetected, logDropError)
+
+    // add empty folders to the Uppy state so the upload plugin can handle them
+    files.push(...emptyFolders)
+
+    if (files.length > 0) {
+      this.uppy.log('[DropTarget] Files were dropped')
+      this.addFiles(files)
+    }
+
+    this.opts.onDrop?.(event)
+    this.uppyService?.publish('drop', event)
+  }
+
+  handleDragOver = (event: DragEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.setPluginState({ isDraggingOver: true })
+    this.opts.onDragOver?.(event)
+    this.uppyService?.publish('drag-over', event)
+  }
+
+  handleDragLeave = (event: DragEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.setPluginState({ isDraggingOver: false })
+    this.opts.onDragLeave?.(event)
+    this.uppyService?.publish('drag-out', event)
+  }
+
+  addListeners = (): void => {
+    const { target, uppyService } = this.opts
+    this.uppyService = uppyService
+
+    if (target instanceof Element) {
+      this.nodes = [target]
+    } else if (typeof target === 'string') {
+      this.nodes = toArray(document.querySelectorAll(target))
+    }
+
+    if (!this.nodes || this.nodes.length === 0) {
+      throw new Error(`"${target}" does not match any HTML elements`)
+    }
+
+    this.nodes.forEach((node) => {
+      node.addEventListener('dragover', this.handleDragOver, false)
+      node.addEventListener('dragleave', this.handleDragLeave, false)
+      node.addEventListener('drop', this.handleDrop, false)
+    })
+  }
+
+  removeListeners = (): void => {
+    if (this.nodes) {
+      this.nodes.forEach((node) => {
+        node.removeEventListener('dragover', this.handleDragOver, false)
+        node.removeEventListener('dragleave', this.handleDragLeave, false)
+        node.removeEventListener('drop', this.handleDrop, false)
+      })
+    }
+  }
+
+  install(): void {
+    this.setPluginState({ isDraggingOver: false })
+    this.addListeners()
+  }
+
+  uninstall(): void {
+    this.removeListeners()
+  }
+}

--- a/packages/web-pkg/src/services/uppy/DropTarget/types.ts
+++ b/packages/web-pkg/src/services/uppy/DropTarget/types.ts
@@ -1,0 +1,10 @@
+import { PluginOpts } from '@uppy/core'
+import { UppyService } from '../uppyService'
+
+export interface DropTargetOptions extends PluginOpts {
+  target?: HTMLElement | string | null
+  uppyService?: UppyService
+  onDrop?: (event: DragEvent) => void
+  onDragOver?: (event: DragEvent) => void
+  onDragLeave?: (event: DragEvent) => void
+}

--- a/packages/web-pkg/src/services/uppy/index.ts
+++ b/packages/web-pkg/src/services/uppy/index.ts
@@ -1,1 +1,2 @@
 export * from './uppyService'
+export * from './utils'

--- a/packages/web-pkg/src/services/uppy/uppyService.ts
+++ b/packages/web-pkg/src/services/uppy/uppyService.ts
@@ -4,7 +4,7 @@ import { TusOptions } from '@uppy/tus'
 import XHRUpload, { XHRUploadOptions } from '@uppy/xhr-upload'
 import { Language } from 'vue3-gettext'
 import { eventBus } from '../eventBus'
-import DropTarget from '@uppy/drop-target'
+import DropTarget from './DropTarget/plugin'
 import { Resource, urlJoin } from '@opencloud-eu/web-client'
 
 // @ts-ignore
@@ -99,7 +99,7 @@ export class UppyService {
         }
         file.meta.relativePath = this.getRelativeFilePath(file)
         // id needs to be generated after the relative path has been set.
-        file.id = generateFileID(file, this.uppy.getID())
+        file.id = this.generateUploadId(file)
         return file
       }
     })
@@ -228,21 +228,9 @@ export class UppyService {
   }
 
   useDropTarget({ targetSelector }: { targetSelector: string }) {
-    if (this.uppy.getPlugin('DropTarget')) {
-      return
+    if (!this.uppy.getPlugin('DropTarget')) {
+      this.uppy.use(DropTarget, { target: targetSelector, uppyService: this })
     }
-    this.uppy.use(DropTarget, {
-      target: targetSelector,
-      onDragOver: (event) => {
-        this.publish('drag-over', event)
-      },
-      onDragLeave: (event) => {
-        this.publish('drag-out', event)
-      },
-      onDrop: (event) => {
-        this.publish('drop', event)
-      }
-    })
   }
 
   removeDropTarget() {

--- a/packages/web-pkg/src/services/uppy/uppyService.ts
+++ b/packages/web-pkg/src/services/uppy/uppyService.ts
@@ -6,8 +6,6 @@ import { Language } from 'vue3-gettext'
 import { eventBus } from '../eventBus'
 import DropTarget from './DropTarget/plugin'
 import { Resource, urlJoin } from '@opencloud-eu/web-client'
-
-// @ts-ignore
 import generateFileID from '@uppy/utils/lib/generateFileID'
 import { Body, MinimalRequiredUppyFile } from '@uppy/utils/lib/UppyFile'
 
@@ -300,6 +298,10 @@ export class UppyService {
 
   generateUploadId(uppyFile: OcUppyFile): string {
     return generateFileID(uppyFile, this.uppy.getID())
+  }
+
+  log(message: unknown, type?: 'error' | 'warning'): void {
+    this.uppy.log(message, type)
   }
 
   addFiles(files: OcMinimalUppyFile[] | File[]) {

--- a/packages/web-pkg/src/services/uppy/utils.ts
+++ b/packages/web-pkg/src/services/uppy/utils.ts
@@ -1,0 +1,37 @@
+import { basename } from 'path'
+import { OcMinimalUppyFile } from './uppyService'
+
+/**
+ * Constructs a file-like object for a given folder path. This acts as a dummy
+ * to represent folders in the Uppy queue.
+ */
+export const createFolderDummyFile = (path: string): File => {
+  return {
+    // only use the name of the folder, not the full path
+    name: basename(path),
+
+    // fake directory mime type so it can be identified as a folder later
+    type: 'directory',
+
+    // set path as relativePath. this differs a bit from files where root files don't
+    // have a relativePath.
+    relativePath: path
+  } as any
+}
+
+/**
+ * Converts a list of files to the minimal Uppy file format.
+ * This is used to add files to the Uppy queue via addFiles() (see below).
+ */
+export const convertToMinimalUppyFile = (source: string, files: File[]): OcMinimalUppyFile[] => {
+  return files.map((file) => ({
+    source,
+    name: file.name,
+    type: file.type,
+    data: file,
+    meta: {
+      // file path relative to the directory the user selected
+      relativePath: (file as any).relativePath || null
+    } as any
+  }))
+}

--- a/packages/web-pkg/tests/unit/services/uppy/DropTarget/getDroppedFiles.spec.ts
+++ b/packages/web-pkg/tests/unit/services/uppy/DropTarget/getDroppedFiles.spec.ts
@@ -1,0 +1,120 @@
+import { getDroppedFiles } from '../../../../../src/services/uppy/DropTarget/getDroppedFiles'
+
+describe('getDroppedFiles', () => {
+  it('retrieves a single file from a given DataTransfer', async () => {
+    const expectedFileObj = new File(['Hello World'], 'foo.txt', { type: 'text/plain' })
+    const file = {
+      getAsEntry: () => ({
+        isFile: true,
+        isDirectory: false,
+        file: (resolve) => resolve(expectedFileObj)
+      })
+    } as any
+
+    const dataTransfer = { items: [file] } as any
+    const files = await getDroppedFiles(dataTransfer)
+
+    expect(files).toContain(expectedFileObj)
+  })
+
+  it('retrieves a file from inside a nested folder from a given DataTransfer', async () => {
+    const expectedFileObj = new File(['Hello World'], 'foo.txt', { type: 'text/plain' })
+    const file = {
+      isFile: true,
+      isDirectory: false,
+      file: (resolve) => resolve(expectedFileObj)
+    } as any
+
+    let folderInsideFinished = false
+    const folderInside = {
+      isFile: false,
+      isDirectory: true,
+      fullPath: '/rootFolder/folderInside',
+      createReader: () => ({
+        readEntries: (callback: (entries: any[]) => void) => {
+          callback(!folderInsideFinished ? [file] : [])
+          folderInsideFinished = true
+        }
+      })
+    }
+
+    let rootFolderFinished = false
+    const rootFolder = {
+      getAsEntry: () =>
+        ({
+          isFile: false,
+          isDirectory: true,
+          fullPath: '/rootFolder',
+          createReader: () => ({
+            readEntries: (callback: (entries: any[]) => void) => {
+              callback(!rootFolderFinished ? [folderInside] : [])
+              rootFolderFinished = true
+            }
+          })
+        }) as any
+    }
+
+    const dataTransfer = { items: [rootFolder] } as any
+    const files = await getDroppedFiles(dataTransfer)
+
+    expect(files).toContain(expectedFileObj)
+  })
+
+  it('returns empty folders', async () => {
+    const folder = {
+      getAsEntry: () =>
+        ({
+          isFile: false,
+          isDirectory: true,
+          fullPath: '/folder',
+          createReader: () => ({
+            readEntries: (callback: (entries: any[]) => void) => {
+              callback([])
+            }
+          })
+        }) as any
+    }
+
+    const dataTransfer = { items: [folder] } as any
+    const files = await getDroppedFiles(dataTransfer)
+
+    expect((files[0] as any).relativePath).toEqual('/folder')
+  })
+
+  describe('error handling', () => {
+    it('calls a callback when the conversion from entry to file fails', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const error = new Error('entry to file conversion failed')
+      const file = {
+        getAsEntry: () => ({
+          isFile: true,
+          isDirectory: false,
+          file: (resolve, reject) => reject(error)
+        })
+      } as any
+
+      const dataTransfer = { items: [file] } as any
+      const onError = vi.fn()
+      await getDroppedFiles(dataTransfer, onError)
+
+      expect(onError).toHaveBeenCalledWith(error)
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error)
+    })
+
+    it('falls back to dataTransfer.files when getAsEntry fails', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const error = new Error('getAsEntry failed')
+      const file = {
+        getAsEntry: () => {
+          throw error
+        }
+      } as any
+
+      const dataTransfer = { items: [file], files: [file] } as any
+      const files = await getDroppedFiles(dataTransfer)
+
+      expect(files).toEqual([file])
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error)
+    })
+  })
+})

--- a/packages/web-pkg/tests/unit/services/uppy/utils.spec.ts
+++ b/packages/web-pkg/tests/unit/services/uppy/utils.spec.ts
@@ -1,0 +1,35 @@
+import {
+  convertToMinimalUppyFile,
+  createFolderDummyFile
+} from '../../../../src/services/uppy/utils'
+
+describe('createFolderDummyFile', () => {
+  it('creates a dummy file for a directory', () => {
+    const dummyFile = createFolderDummyFile('/folder')
+
+    expect(dummyFile.name).toBe('folder')
+    expect(dummyFile.type).toBe('directory')
+    expect((dummyFile as any).relativePath).toBe('/folder')
+  })
+})
+
+describe('convertToMinimalUppyFile', () => {
+  it('converts a list of files to the minimal Uppy file format', () => {
+    const source = 'testSource'
+    const file = new File(['content'], 'file1.txt', { type: 'text/plain' })
+    ;(file as any).relativePath = '/folder/file1.txt'
+    const result = convertToMinimalUppyFile(source, [file])
+
+    expect(result).toEqual([
+      {
+        source,
+        name: 'file1.txt',
+        type: 'text/plain',
+        data: expect.anything(),
+        meta: {
+          relativePath: '/folder/file1.txt'
+        }
+      }
+    ])
+  })
+})

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -13,7 +13,6 @@
     "@opencloud-eu/web-pkg": "workspace:*",
     "@sentry/vue": "9.43.0",
     "@uppy/core": "4.4.7",
-    "@uppy/drop-target": "3.1.1",
     "@uppy/tus": "4.2.2",
     "@uppy/utils": "6.1.5",
     "@uppy/xhr-upload": "4.3.3",

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
@@ -35,7 +35,7 @@ describe('UploadInfo component', () => {
       const { wrapper } = getShallowWrapper()
       wrapper.vm.showInfo = true
       wrapper.vm.inPreparation = false
-      wrapper.vm.filesInProgressCount = 1
+      wrapper.vm.itemsInProgressCount = 1
       wrapper.vm.runningUploads = 1
       await nextTick()
 
@@ -81,7 +81,7 @@ describe('UploadInfo component', () => {
     it('should show that an upload is being finalized', async () => {
       const { wrapper } = getShallowWrapper()
       wrapper.vm.showInfo = true
-      wrapper.vm.filesInProgressCount = 1
+      wrapper.vm.itemsInProgressCount = 1
       wrapper.vm.runningUploads = 1
       wrapper.vm.inFinalization = true
       await nextTick()
@@ -94,7 +94,7 @@ describe('UploadInfo component', () => {
     it('should show the progress bar when an upload is in progress', async () => {
       const { wrapper } = getShallowWrapper()
       wrapper.vm.showInfo = true
-      wrapper.vm.filesInProgressCount = 1
+      wrapper.vm.itemsInProgressCount = 1
       wrapper.vm.runningUploads = 1
       await nextTick()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,9 +816,6 @@ importers:
       '@uppy/core':
         specifier: ^4.3.1
         version: 4.4.7
-      '@uppy/drop-target':
-        specifier: ^3.0.2
-        version: 3.1.1(@uppy/core@4.4.7)
       '@uppy/tus':
         specifier: ^4.1.5
         version: 4.2.2(@uppy/core@4.4.7)
@@ -962,9 +959,6 @@ importers:
       '@uppy/core':
         specifier: 4.4.7
         version: 4.4.7
-      '@uppy/drop-target':
-        specifier: 3.1.1
-        version: 3.1.1(@uppy/core@4.4.7)
       '@uppy/tus':
         specifier: 4.2.2
         version: 4.2.2(@uppy/core@4.4.7)
@@ -2997,11 +2991,6 @@ packages:
 
   '@uppy/core@4.4.7':
     resolution: {integrity: sha512-ZEdRiVnkHVITS7afBCWxQGNKOZ22DFXoDb4ZcLK2Srp5iBnxUbg1rV3sntHDNjZq7QHQAtZqHKAF8RxE6ZSNeg==}
-
-  '@uppy/drop-target@3.1.1':
-    resolution: {integrity: sha512-/2jnQ3DqfcWGjgoasLBLvwJ3fozavwSXFVULenDmPUI8YPjuxmEtOu61XnZ/OLhRnZo6Qm+kltSd+YUS0P/LNA==}
-    peerDependencies:
-      '@uppy/core': ^4.4.1
 
   '@uppy/store-default@4.2.0':
     resolution: {integrity: sha512-PieFVa8yTvRHIqsNKfpO/yaJw5Ae/hT7uT58ryw7gvCBY5bHrNWxH5N0XFe8PFHMpLpLn8v3UXGx9ib9QkB6+Q==}
@@ -8913,11 +8902,6 @@ snapshots:
       namespace-emitter: 2.0.1
       nanoid: 5.1.5
       preact: 10.26.5
-
-  '@uppy/drop-target@3.1.1(@uppy/core@4.4.7)':
-    dependencies:
-      '@uppy/core': 4.4.7
-      '@uppy/utils': 6.1.5
 
   '@uppy/store-default@4.2.0': {}
 


### PR DESCRIPTION
Introduces usage of the Directory API for uploading folders and replaces the Uppy drop target plugin by a custom one which is able to handle empty folders when uploading. Empty folders get added to the Uppy upload queue temporarily so they can be identified and processed by our `HandleUpload` plugin later down the line.

Note that uploading empty folders with non-Chromium browsers only works via drag&drop! Clicking the "Upload folder" button won't work with them because of browser limitations.

Also changes the upload overlay to only count root level files and folders. This prevents confusion where the overlay would show less items than the count. Furthermore, folders in the upload overlay are now clickable (again - I think this broke at some point).

closes https://github.com/opencloud-eu/web/issues/821