### PR TITLE
fix extension registry stable order

### DIFF
--- a/dev/docker/opencloud/csp.yaml
+++ b/dev/docker/opencloud/csp.yaml
@@ -23,6 +23,7 @@ directives:
     - 'data:'
     - 'blob:'
     - 'https://raw.githubusercontent.com/opencloud-eu/awesome-apps/'
+    - 'https://tile.openstreetmap.org/'
     # In contrast to bash and docker the default is given after the | character
     - 'https://${ONLYOFFICE_DOMAIN|host.docker.internal:9981}/'
     - 'https://${COLLABORA_DOMAIN|host.docker.internal:9980}/'

--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -71,8 +71,13 @@
               >
                 <component
                   :is="p.component"
-                  v-if="[activePanelName, oldPanelName].includes(p.name)"
+                  v-if="
+                    hasActiveRootPanel
+                      ? p.isRoot?.(panelContext)
+                      : [activePanelName, oldPanelName].includes(p.name)
+                  "
                   :class="{ 'multi-root-panel-separator oc-mt oc-pt-s': index > 0 }"
+                  class="oc-rounded"
                   v-bind="p.componentAttrs?.(panelContext) || {}"
                 />
               </div>

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
@@ -64,9 +64,7 @@ export const useFileActionsToggleHideShare = () => {
     }
 
     showErrorMessage({
-      title: hidden
-        ? $gettext('Failed to hide the share')
-        : $gettext('Failed to unhide share share'),
+      title: hidden ? $gettext('Failed to hide the share') : $gettext('Failed to unhide the share'),
       errors
     })
   }

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -62,26 +62,26 @@ const loadScriptRequireJS = <T>(moduleUri: string) => {
     )
   )
 }
-/**
- * sniffs arguments and decides if given manifest is of next or current application style.
- */
-export const buildApplication = async ({
-  app,
+
+export const loadApplication = async ({
   appName,
   applicationKey,
   applicationPath,
   applicationConfig,
-  router,
   configStore
 }: {
-  app: App
   appName?: string
   applicationKey: string
   applicationPath: string
   applicationConfig: AppConfigObject
-  router: Router
   configStore: ConfigStore
-}) => {
+}): Promise<{
+  appName?: string
+  applicationKey: string
+  applicationPath: string
+  applicationConfig: AppConfigObject
+  applicationScript: ClassicApplicationScript
+}> => {
   if (applicationStore.has(applicationKey)) {
     throw new RuntimeError('application already announced', applicationKey, applicationPath)
   }
@@ -118,8 +118,40 @@ export const buildApplication = async ({
     throw new RuntimeError('cannot load application', applicationPath, e)
   }
 
-  let application: NextApplication
+  return {
+    appName,
+    applicationKey,
+    applicationPath,
+    applicationConfig,
+    applicationScript
+  }
+}
 
+/**
+ * sniffs arguments and decides if given manifest is of next or current application style.
+ */
+export const buildApplication = ({
+  app,
+  appName,
+  applicationKey,
+  applicationPath,
+  applicationConfig,
+  applicationScript,
+  router
+}: {
+  app: App
+  appName?: string
+  applicationKey: string
+  applicationPath: string
+  applicationConfig: AppConfigObject
+  applicationScript: ClassicApplicationScript
+  router: Router
+}) => {
+  if (applicationStore.has(applicationKey)) {
+    throw new RuntimeError('application already announced', applicationKey, applicationPath)
+  }
+
+  let application: NextApplication
   try {
     /** add valuable sniffer to detect next applications, then implement next application factory */
     if (!isObject(applicationScript.appInfo) && !applicationScript.setup) {

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -223,7 +223,7 @@ export const initializeApplications = async ({
   let applicationKeys: string[] = []
   let applicationResponses: PromiseSettledResult<ApplicationResponse>[] = []
   if (appProviderApps) {
-    applicationKeys = appProviderService.appNames
+    applicationKeys = appProviderService.appNames.map((appName) => `web-app-external-${appName}`)
     applicationResponses = await Promise.allSettled(
       appProviderService.appNames.map((appName) =>
         loadApplication({


### PR DESCRIPTION
## Description

While reviewing https://github.com/opencloud-eu/web-extensions/pull/166 we found out that the order of applications during application loading is not stable. Instead of coming up with a sorting/weight concept we've decided to just maintain a stable order. This PR does that with the least possible performance impact:
- loading application scripts happens in parallel
- only building and registering the applications happens one by one, with the order defined by the config.json (this ran in parallel before, but produced a random order)
- calling the `initialize` hook on all applications happens in parallel again

## How Has This Been Tested?

Manually and with the existing unit tests.

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
