### PR TITLE
fix: resource deselect when clicking esc in a modal

### DIFF
--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -9,7 +9,7 @@
         role="dialog"
         aria-modal="true"
         aria-labelledby="oc-modal-title"
-        @keydown.esc="cancelModalAction"
+        @keydown.esc.stop="cancelModalAction"
       >
         <div class="oc-modal-title">
           <h2 id="oc-modal-title" class="oc-text-truncate" v-text="title" />


### PR DESCRIPTION
Prevents resources from getting deselected when closing modals. The ESC key should only close the modal in that case.

This also fixes an issue where the resource conflict dialog would not get focused again after closing it via ESC.

fixes https://github.com/opencloud-eu/web/issues/777