### PR TITLE
feat: change bottom drawer to less technical context menu label

### DIFF
--- a/packages/design-system/src/components/OcBottomDrawer/OcBottomDrawer.vue
+++ b/packages/design-system/src/components/OcBottomDrawer/OcBottomDrawer.vue
@@ -5,7 +5,7 @@
         v-show="show"
         class="oc-bottom-drawer-background"
         role="button"
-        :aria-label="$gettext('Close the bottom drawer')"
+        :aria-label="$gettext('Close the context menu')"
         @click="onBackgroundClicked"
       >
         <focus-trap>
@@ -17,7 +17,7 @@
                   <oc-button
                     appearance="raw"
                     class="raw-hover-surface oc-bottom-drawer-close-button"
-                    :aria-label="$gettext('Close the bottom drawer')"
+                    :aria-label="$gettext('Close the context menu')"
                     @click="close"
                   >
                     <oc-icon name="close" fill-type="fill" />

--- a/packages/design-system/src/components/OcBottomDrawer/__snapshots__/OcBottomDrawer.spec.ts.snap
+++ b/packages/design-system/src/components/OcBottomDrawer/__snapshots__/OcBottomDrawer.spec.ts.snap
@@ -4,11 +4,11 @@ exports[`OcBottomDrawer > renders when toggle is clicked 1`] = `
 "<div drawerid="button-drawer" toggle="#button-drawer-toggle" title="Bottom Drawer" closeonclick="false"><button id="button-drawer-toggle">Toggle Drawer</button>
   <div to="app.runtime.bottom.drawer">
     <transition-stub name="oc-bottom-drawer-slide" appear="false" persisted="true" css="true">
-      <div class="oc-bottom-drawer-background" role="button" aria-label="Close the bottom drawer">
+      <div class="oc-bottom-drawer-background" role="button" aria-label="Close the context menu">
         <div id="button-drawer" class="oc-bottom-drawer active">
           <div class="oc-card">
             <div class="oc-card-header">
-              <div class="oc-flex oc-flex-between oc-flex-middle"><span class="oc-text-bold">Bottom Drawer</span> <button type="button" aria-label="Close the bottom drawer" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw raw-hover-surface oc-bottom-drawer-close-button">
+              <div class="oc-flex oc-flex-between oc-flex-middle"><span class="oc-text-bold">Bottom Drawer</span> <button type="button" aria-label="Close the context menu" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-secondary oc-button-raw oc-button-secondary-raw raw-hover-surface oc-bottom-drawer-close-button">
                   <!--v-if-->
                   <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m"><svg data-testid="inline-svg-stub" src="icons/close-fill.svg" transform-source="(svg) => {
       if (__props.accessibleLabel !== &quot;&quot;) {


### PR DESCRIPTION
change `Close the bottom drawer` label to a less technical `Close the context menu`.