### PR TITLE
refactor: rename defaultExtension to defaultAppId

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/config/config.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/config.ts
@@ -18,7 +18,7 @@ const defaultOptions = {
   },
   contextHelpers: true,
   contextHelpersReadMore: true,
-  defaultExtension: 'files',
+  defaultAppId: 'files',
   disabledExtensions: [] as string[],
   disableFeedbackLink: true,
   editor: {

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -67,7 +67,7 @@ const OptionsConfigSchema = z.object({
     .optional(),
   contextHelpers: z.boolean().optional(),
   contextHelpersReadMore: z.boolean().optional(),
-  defaultExtension: z.string().optional(),
+  defaultAppId: z.string().optional(),
   disabledExtensions: z.array(z.string()).optional(),
   disableFeedbackLink: z.boolean().optional(),
   accountEditLink: z

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -638,16 +638,16 @@ export const announceDefaults = ({
 }): void => {
   // set home route
   const appIds = appsStore.appIds
-  let defaultExtensionId = configStore.options.defaultExtension
-  if (!defaultExtensionId || appIds.indexOf(defaultExtensionId) < 0) {
-    defaultExtensionId = appIds[0]
+  let defaultAppId = configStore.options.defaultAppId
+  if (!appIds.includes(defaultAppId)) {
+    defaultAppId = appIds.find((appId) => appId === 'files') || appIds[0]
   }
 
   let route: RouteRecordNormalized | RouteLocationRaw = router.getRoutes().find((r) => {
-    return r.path.startsWith(`/${defaultExtensionId}`) && r.meta?.entryPoint === true
+    return r.path.startsWith(`/${defaultAppId}`) && r.meta?.entryPoint === true
   })
   if (!route) {
-    route = getExtensionNavItems({ extensionRegistry, appId: defaultExtensionId })[0]?.route
+    route = getExtensionNavItems({ extensionRegistry, appId: defaultAppId })[0]?.route
   }
   if (route) {
     router.addRoute({


### PR DESCRIPTION
## Description

Renames the `defaultExtension` option to `defaultAppId` since that's a more appropriate name for the option. The old name comes from a time where we thought that we'd ship extensions individually, not piggyback with an app.

## Related Issue

Idea came up in https://github.com/opencloud-eu/web-extensions/pull/177

## Types of changes

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [x] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
