### PR TITLE
restore opencloud cache correctly during cron CI runs

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1628,11 +1628,8 @@ def e2eTestsOnKeycloak(ctx):
             restoreBrowsersCache() + \
             ldapService() + \
             keycloakService() + \
-            restoreBuildArtifactCache(ctx, "web-dist", "dist")
-    if ctx.build.event == "cron":
-        steps += restoreBuildArtifactCache(ctx, "opencloud", "opencloud")
-    else:
-        steps += restoreOpenCloudCache()
+            restoreBuildArtifactCache(ctx, "web-dist", "dist") + \
+            restoreOpenCloudCache()
 
     # configs to setup opencloud with keycloak and ldap
     environment = {


### PR DESCRIPTION
## Description

IMO the cache restoring process should be the same for normal CI runs and cron CI runs

## Related Issue

nightly run failed yesterday because of issues in the cache restoration: https://ci.opencloud.eu/repos/6/pipeline/3658/33

- part of https://github.com/opencloud-eu/qa/issues/41

## How Has This Been Tested?

waiting for nightly runs

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
