### PR TITLE
handle cache in CI same for cron as for other runs

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -584,12 +584,8 @@ def e2eTests(ctx):
             steps = restoreBuildArtifactCache(ctx, "pnpm", ".pnpm-store") + \
                     installPnpm() + \
                     restoreBrowsersCache() + \
-                    restoreBuildArtifactCache(ctx, "web-dist", "dist")
-
-            if ctx.build.event == "cron":
-                steps += restoreBuildArtifactCache(ctx, "opencloud", "opencloud")
-            else:
-                steps += restoreOpenCloudCache()
+                    restoreBuildArtifactCache(ctx, "web-dist", "dist") + \
+                    restoreOpenCloudCache()
 
             if "app-provider-onlyOffice" in suite:
                 environment["FAIL_ON_UNCAUGHT_CONSOLE_ERR"] = False
@@ -940,14 +936,10 @@ def checkForExistingOpenCloudCache(ctx):
     ]
 
 def cacheOpenCloudPipeline(ctx):
-    if ctx.build.event == "cron":
-        steps = getOpenCloudlatestCommitId(ctx) + \
-                buildOpenCloud() + \
-                rebuildBuildArtifactCache(ctx, "opencloud", "opencloud")
-    else:
-        steps = checkForExistingOpenCloudCache(ctx) + \
-                buildOpenCloud() + \
-                cacheOpenCloud()
+    steps = checkForExistingOpenCloudCache(ctx) + \
+            buildOpenCloud() + \
+            cacheOpenCloud()
+
     return [{
         "name": "cache-opencloud",
         "skip_clone": True,


### PR DESCRIPTION
## Description

IMO the cache restoring process should be the same for normal CI runs and cron CI runs

## Related Issue

nightly run failed yesterday because of issues in the cache restoration: https://ci.opencloud.eu/repos/6/pipeline/3726

part of https://github.com/opencloud-eu/qa/issues/41

Follow up to https://github.com/opencloud-eu/web/pull/1092

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
