### PR TITLE
run design-system-docs pipeline on cron

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -237,7 +237,7 @@ def main(ctx):
         print("Errors detected. Review messages above.")
         return []
 
-    after = pipelinesDependsOn(afterPipelines(ctx), pnpmCache(ctx))
+    after = pipelinesDependsOn(afterPipelines(ctx), pnpmCache(ctx)) + designSystemDocs(ctx)
 
     pipelines = release + before + stages + after
 
@@ -256,8 +256,7 @@ def beforePipelines(ctx):
            cacheOpenCloudPipeline(ctx) + \
            pipelinesDependsOn(buildCacheWeb(ctx), pnpmCache(ctx)) + \
            pipelinesDependsOn(pnpmlint(ctx, "lint"), pnpmCache(ctx)) + \
-           pipelinesDependsOn(pnpmlint(ctx, "format"), pnpmCache(ctx)) + \
-           designSystemDocs(ctx)
+           pipelinesDependsOn(pnpmlint(ctx, "format"), pnpmCache(ctx))
 
 def stagePipelines(ctx):
     unit_test_pipelines = unitTests(ctx)
@@ -1198,7 +1197,6 @@ def designSystemDocs(ctx):
             },
         ],
         "when": [
-            event["pull_request"],
             event["main_branch"],
         ],
         "workspace": web_workspace,


### PR DESCRIPTION
## Description

The `design-system-docs` was a dependency of other pipelines, so they did not got triggered in cron job.
But that pipeline only needs to be run on `merge`.
So move the whole thing out and adjust the trigger.

## Related Issue
pat of https://github.com/opencloud-eu/qa/issues/41

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
