### PR TITLE
e2e: flaky after closing text file

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -445,6 +445,8 @@ const createDocumentFile = async (
     page.waitForResponse((res) => res.status() === 207 && res.request().method() === 'PROPFIND'),
     editor.close(page)
   ])
+  await page.reload()
+  await page.locator(util.format(resourceNameSelector, name)).waitFor()
 }
 
 export const fillContentOfDocument = async ({


### PR DESCRIPTION
npx playwright show-trace https://s3.ci.opencloud.eu/public/web/tracing/web/15/create-and-view-resources-on-mobile-devices-alice-2025-9-2-11-16-41.zip

Sometimes the web goes into infinite loading mode after creating and closing a text file in the CI.

<img width="1276" height="616" alt="image" src="https://github.com/user-attachments/assets/56de9773-c597-477e-8795-e735a369b0e2" />

we have encountered this before. This does not reproduce locally. how fix in CI -> I reload page after closing file and wait for that file to appear in the list