### PR TITLE
fix: remove flaky resourceExists

### DIFF
--- a/tests/e2e/cucumber/features/journeys/kindergarten.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.feature
@@ -23,6 +23,10 @@ Feature: Kindergarten can use web to organize a day
     And "Alice" navigates to the personal space page
     And "Alice" creates the following resources
       | resource                             | type   |
+      | groups                               | folder |
+      | groups/Kindergarten Koalas           | folder |
+      | groups/Pre-Schools Pirates           | folder |
+      | groups/Teddy Bear Daycare            | folder |
       | groups/Kindergarten Koalas/meal plan | folder |
       | groups/Pre-Schools Pirates/meal plan | folder |
       | groups/Teddy Bear Daycare/meal plan  | folder |

--- a/tests/e2e/cucumber/features/navigation/breadcrumb.feature
+++ b/tests/e2e/cucumber/features/navigation/breadcrumb.feature
@@ -11,6 +11,7 @@ Feature: access breadcrumb
     And "Alice" logs in
     And "Alice" creates the following resources
       | resource                       | type   |
+      | parent                         | folder |
       | parent/folder%2Fwith%2FSlashes | folder |
     And "Alice" opens folder "parent/folder%2Fwith%2FSlashes"
     And "Alice" creates the following resources

--- a/tests/e2e/cucumber/features/oidc/refreshToken.feature
+++ b/tests/e2e/cucumber/features/oidc/refreshToken.feature
@@ -32,5 +32,6 @@ Feature: Token renewal using refresh token
     And "Alice" opens the "files" app
     And "Alice" creates the following resources
       | resource          | type    | content   |
+      | PARENT            | folder  |           |
       | PARENT/parent.txt | txtFile | some text |
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/search/search.feature
+++ b/tests/e2e/cucumber/features/search/search.feature
@@ -26,6 +26,8 @@ Feature: Search
     And "Alice" creates the following resources
       | resource                   | type   |
       | folder                     | folder |
+      | FolDer                     | folder |
+      | FolDer/child-one           | folder |
       | FolDer/child-one/child-two | folder |
       | strängéनेपालीName          | folder |
     And "Alice" enables the option to display the hidden file

--- a/tests/e2e/cucumber/features/shares/link.feature
+++ b/tests/e2e/cucumber/features/shares/link.feature
@@ -71,6 +71,7 @@ Feature: link
       | lorem.txt     | replace |
     And "Anonymous" creates the following resources
       | resource       | type   |
+      | myfolder       | folder |
       | myfolder/child | folder |
     And "Anonymous" uploads the following resources in public link page
       | resource | type   |

--- a/tests/e2e/cucumber/features/smoke/trashbinDelete.feature
+++ b/tests/e2e/cucumber/features/smoke/trashbinDelete.feature
@@ -15,6 +15,7 @@ Feature: Trashbin delete
     Given "Alice" creates the following resources
       | resource     | type   |
       | FOLDER       | folder |
+      | PARENT       | folder |
       | PARENT/CHILD | folder |
     And "Alice" uploads the following resources
       | resource               | to           |

--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -27,6 +27,7 @@ Feature: Upload
       | textfile.txt      | keep both |
     And "Alice" creates the following resources
       | resource           | type    | content      |
+      | PARENT             | folder  |              |
       | PARENT/parent.txt  | txtFile | some text    |
       | PARENT/example.txt | txtFile | example text |
     And "Alice" uploads the following resources via drag-n-drop

--- a/tests/e2e/cucumber/features/spaces/project.feature
+++ b/tests/e2e/cucumber/features/spaces/project.feature
@@ -146,7 +146,8 @@ Feature: spaces.personal
     And "Alice" navigates to the project space "team.1"
     And "Alice" creates the following resources
       | resource            | type    | content             |
-      | parent/textfile.txt | txtFile | some random content |
+      | parent              | folder  |                      |
+      | parent/textfile.txt | txtFile | some random content  |
     When "Alice" uploads the following resources
       | resource     | to     | option  |
       | textfile.txt | parent | replace |

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1,7 +1,7 @@
 import { Download, Locator, Page, Response, expect } from '@playwright/test'
 import util from 'util'
 import path from 'path'
-import { resourceExists, waitForResources } from './utils'
+import { waitForResources } from './utils'
 import { editor, sidebar } from '../utils'
 import { environment, utils } from '../../../../support'
 import { config } from '../../../../config'
@@ -541,15 +541,6 @@ export const createResources = async (args: createResourceArgs): Promise<void> =
   const resource = paths.pop()
 
   for (const path of paths) {
-    const resourcesExists = await resourceExists({
-      page: page,
-      name: path
-    })
-
-    if (!resourcesExists) {
-      await page.locator(addNewResourceButton).click()
-      await createNewFolder({ page, resource: path })
-    }
     await clickResource({ page, path })
   }
   await createNewFileOrFolder({ page, name: resource, type, content })

--- a/tests/e2e/support/objects/app-files/resource/utils.ts
+++ b/tests/e2e/support/objects/app-files/resource/utils.ts
@@ -1,41 +1,9 @@
-import { errors, Page, Locator } from '@playwright/test'
+import { Page, Locator } from '@playwright/test'
 import util from 'util'
 
 const resourceNameSelector = '#files-space-table [data-test-resource-name="%s"]'
 const showLinkShareButton =
   '//span[@data-test-resource-name="%s"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@data-test-indicator-type, "%s")]'
-
-/**
- * one of the few places where timeout should be used, as we also use this to detect the absence of an element
- * it is not possible to differentiate between `element not there yet` and `element not loaded yet`.
- *
- * @param page
- * @param name
- * @param timeout
- */
-export const resourceExists = async ({
-  page,
-  name,
-  timeout = 500
-}: {
-  page: Page
-  name: string
-  timeout?: number
-}): Promise<boolean> => {
-  let exist = true
-  await page
-    .locator(util.format(resourceNameSelector, name))
-    .waitFor({ timeout })
-    .catch((e) => {
-      if (!(e instanceof errors.TimeoutError)) {
-        throw e
-      }
-
-      exist = false
-    })
-
-  return exist
-}
 
 export const waitForResources = async ({
   page,


### PR DESCRIPTION
<img width="1048" height="867" alt="image" src="https://github.com/user-attachments/assets/d5b6996b-535e-4f44-8fe6-643d45aa1825" />


### Problem
Tests were sometimes interrupted due to flaky `resourceExists()` function that used timeout-based element detection.

### Solution
Restructured folder creation logic - if path contains '/' then parent folders already exist, just navigate inside. No timeouts, no try-catch, simple and stable.