### PR TITLE
feat: enable feedback link and fix button color

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/config/config.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/config.ts
@@ -20,7 +20,7 @@ const defaultOptions = {
   contextHelpersReadMore: true,
   defaultAppId: 'files',
   disabledExtensions: [] as string[],
-  disableFeedbackLink: true,
+  disableFeedbackLink: false,
   editor: {
     autosaveEnabled: true,
     autosaveInterval: 120

--- a/packages/web-runtime/src/components/Topbar/FeedbackLink.vue
+++ b/packages/web-runtime/src/components/Topbar/FeedbackLink.vue
@@ -6,7 +6,7 @@
       :href="hrefOrFallback"
       target="_blank"
       appearance="raw-inverse"
-      color-role="surface"
+      color-role="chrome"
       :aria-label="ariaLabelOrFallback"
       aria-describedby="oc-feedback-link-description"
       no-hover
@@ -41,18 +41,13 @@ export default defineComponent({
   },
   computed: {
     hrefOrFallback() {
-      return this.href || 'https://opencloud.eu'
+      return this.href || 'https://opencloud.eu/feedback-web'
     },
     ariaLabelOrFallback() {
-      return this.ariaLabel || this.$gettext('OpenCloud feedback survey')
+      return this.ariaLabel || this.$gettext('Share improvement ideas')
     },
     descriptionOrFallback() {
-      return (
-        this.description ||
-        this.$gettext(
-          "Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your OpenCloud team."
-        )
-      )
+      return this.description || this.$gettext('Share improvement ideas')
     }
   }
 })


### PR DESCRIPTION
## Description

We have a feedback survey now. This PR enables the feedback button in the topbar and sets our survey url as default. Also fixes the color of the button.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/1135

<img width="517" height="163" alt="Screenshot 2025-09-03 at 20 11 57" src="https://github.com/user-attachments/assets/2cc52d0a-c3d5-4abe-9ae4-5cbebed82d96" />


## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
