### PR TITLE
refactor: migrate grid to tailwind

### DIFF
--- a/packages/web-app-files/src/components/FilesViewWrapper.vue
+++ b/packages/web-app-files/src/components/FilesViewWrapper.vue
@@ -29,16 +29,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.files-view-wrapper {
-  grid-template-rows: max-content max-content 1fr;
-  grid-template-areas:
-    'header'
-    'upload'
-    'main';
-}
-
 #files-view {
-  grid-area: main;
   z-index: 0;
 }
 </style>

--- a/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
@@ -97,9 +97,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style lang="scss">
-.audio-data-list {
-  grid-template-columns: auto minmax(0, 1fr);
-}
-</style>

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -290,8 +290,7 @@ export default defineComponent({
 
 @layer utilities {
   .share-access-details-drop dl {
-    @apply grid gap-x-4 gap-y-1;
-    grid-template-columns: max-content auto;
+    @apply grid gap-x-4 gap-y-1 grid-cols-[max-content_auto];
   }
 
   .share-access-details-drop dt {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -57,10 +57,10 @@
         <oc-contextual-helper v-if="helpersEnabled" class="pl-1" v-bind="indirectLinkHelp" />
       </h4>
       <div
-        class="files-links-indirect-list grid [grid-template-rows:0fr] transition-all duration-250 ease-out"
+        class="files-links-indirect-list grid transition-all duration-250 ease-out"
         :class="{
-          'files-links-indirect-list-open': !indirectLinkListCollapsed,
-          'mt-4': !indirectLinkListCollapsed
+          '[grid-template-rows:1fr] mt-4': !indirectLinkListCollapsed,
+          '[grid-template-rows:0fr]': indirectLinkListCollapsed
         }"
       >
         <ul class="oc-list oc-list-divider overflow-hidden" :aria-label="$gettext('Public links')">
@@ -329,10 +329,3 @@ export default defineComponent({
   }
 })
 </script>
-<style lang="scss">
-.files-links-indirect-list {
-  &-open {
-    grid-template-rows: 1fr;
-  }
-}
-</style>

--- a/packages/web-pkg/src/components/AppTopBar.vue
+++ b/packages/web-pkg/src/components/AppTopBar.vue
@@ -1,14 +1,14 @@
 <template>
   <portal to="app.runtime.header.left">
-    <div class="oc-app-top-bar self-center flex">
+    <div class="oc-app-top-bar self-center flex col-[1/4] row-2 sm:col-2 sm:row-1">
       <div
-        class="oc-app-top-bar-inner pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex self-center items-center justify-between basis-auto sm:basis-xs md:basis-sm bg-role-chrome border border-role-on-chrome rounded-lg w-full h-10 gap-6"
+        class="pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex items-center justify-between bg-role-chrome border border-role-on-chrome rounded-lg h-10 gap-4 w-full sm:w-fit"
       >
         <div class="open-file-bar flex">
           <resource-list-item
             v-if="resource"
             id="app-top-bar-resource"
-            class="max-w-2xs md:max-w-sm"
+            class="[&_.oc-resource-name]:max-w-60 xs:[&_.oc-resource-name]:max-w-full sm:[&_.oc-resource-name]:max-w-20 md:[&_.oc-resource-name]:max-w-60"
             :is-thumbnail-displayed="false"
             :is-extension-displayed="areFileExtensionsShown"
             :path-prefix="getPathPrefix(resource)"
@@ -189,7 +189,7 @@ export default defineComponent({
 @reference '@opencloud-eu/design-system/tailwind';
 
 @layer utilities {
-  .oc-app-top-bar-inner .oc-resource-indicators .text,
+  .oc-app-top-bar .oc-resource-indicators .text,
   .app-topbar-action,
   .app-topbar-action:hover:not(:disabled),
   #app-top-bar-resource .oc-resource-name span {
@@ -202,24 +202,5 @@ export default defineComponent({
 .app-topbar-action:hover:not(:disabled) svg,
 #app-top-bar-resource svg {
   fill: var(--oc-role-on-chrome) !important;
-}
-</style>
-<style lang="scss">
-.oc-app-top-bar {
-  grid-column: 1 / 4;
-  grid-row: secondRow;
-
-  @media (min-width: $oc-breakpoint-small-default) {
-    grid-column: 2;
-    grid-row: 1;
-  }
-}
-
-.open-file-bar {
-  #app-top-bar-resource {
-    @media (min-width: $oc-breakpoint-small-default) {
-      widows: initial;
-    }
-  }
 }
 </style>

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -649,13 +649,11 @@ onBeforeUnmount(() => {
 @reference '@opencloud-eu/design-system/tailwind';
 
 @layer components {
+  .oc-tiles {
+    grid-template-columns: repeat(auto-fit, minmax(var(--oc-size-tiles-actual), 1fr));
+  }
   .oc-tiles-sort-filter-chip .oc-filter-chip-label {
     @apply text-sm;
   }
-}
-</style>
-<style lang="scss">
-.oc-tiles {
-  grid-template-columns: repeat(auto-fit, minmax(var(--oc-size-tiles-actual), 1fr));
 }
 </style>

--- a/packages/web-pkg/src/components/SearchBarFilter.vue
+++ b/packages/web-pkg/src/components/SearchBarFilter.vue
@@ -9,7 +9,7 @@
         :is-toggle-active="false"
         :filter-label="$gettext('Location filter')"
         :selected-item-names="[currentSelectionTitle]"
-        class="oc-search-bar-filter"
+        class="oc-search-bar-filter [&_button]:items-center"
         :has-active-state="false"
         raw
         close-on-click

--- a/packages/web-pkg/src/components/SideBar/Spaces/SpaceInfo.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/SpaceInfo.vue
@@ -33,10 +33,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style lang="scss">
-.space_info {
-  grid-template-columns: auto 1fr auto;
-  grid-gap: 5px;
-}
-</style>

--- a/packages/web-pkg/tests/unit/components/__snapshots__/AppTopBar.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/__snapshots__/AppTopBar.spec.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`AppTopBar > if a resource is present > renders a resource and dropdownActions (if given) and a close button 1`] = `
 "<portal to="app.runtime.header.left" dropdownactions="undefined">
-  <div class="oc-app-top-bar self-center flex">
-    <div class="oc-app-top-bar-inner pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex self-center items-center justify-between basis-auto sm:basis-xs md:basis-sm bg-role-chrome border border-role-on-chrome rounded-lg w-full h-10 gap-6">
+  <div class="oc-app-top-bar self-center flex col-[1/4] row-2 sm:col-2 sm:row-1">
+    <div class="pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex items-center justify-between bg-role-chrome border border-role-on-chrome rounded-lg h-10 gap-4 w-full sm:w-fit">
       <div class="open-file-bar flex">
-        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="max-w-2xs md:max-w-sm"></resource-list-item-stub>
+        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="[&amp;_.oc-resource-name]:max-w-60 xs:[&amp;_.oc-resource-name]:max-w-full sm:[&amp;_.oc-resource-name]:max-w-20 md:[&amp;_.oc-resource-name]:max-w-60"></resource-list-item-stub>
       </div>
       <div class="flex main-actions">
         <!--v-if-->
@@ -20,10 +20,10 @@ exports[`AppTopBar > if a resource is present > renders a resource and dropdownA
 
 exports[`AppTopBar > if a resource is present > renders a resource and dropdownActions as well as mainActions (if both are passed) and a close button 1`] = `
 "<portal to="app.runtime.header.left" dropdownactions="undefined">
-  <div class="oc-app-top-bar self-center flex">
-    <div class="oc-app-top-bar-inner pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex self-center items-center justify-between basis-auto sm:basis-xs md:basis-sm bg-role-chrome border border-role-on-chrome rounded-lg w-full h-10 gap-6">
+  <div class="oc-app-top-bar self-center flex col-[1/4] row-2 sm:col-2 sm:row-1">
+    <div class="pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex items-center justify-between bg-role-chrome border border-role-on-chrome rounded-lg h-10 gap-4 w-full sm:w-fit">
       <div class="open-file-bar flex">
-        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="max-w-2xs md:max-w-sm"></resource-list-item-stub>
+        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="[&amp;_.oc-resource-name]:max-w-60 xs:[&amp;_.oc-resource-name]:max-w-full sm:[&amp;_.oc-resource-name]:max-w-20 md:[&amp;_.oc-resource-name]:max-w-60"></resource-list-item-stub>
       </div>
       <div class="flex main-actions">
         <!--v-if-->
@@ -38,10 +38,10 @@ exports[`AppTopBar > if a resource is present > renders a resource and dropdownA
 
 exports[`AppTopBar > if a resource is present > renders a resource and mainActions (if given) and a close button 1`] = `
 "<portal to="app.runtime.header.left" dropdownactions="">
-  <div class="oc-app-top-bar self-center flex">
-    <div class="oc-app-top-bar-inner pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex self-center items-center justify-between basis-auto sm:basis-xs md:basis-sm bg-role-chrome border border-role-on-chrome rounded-lg w-full h-10 gap-6">
+  <div class="oc-app-top-bar self-center flex col-[1/4] row-2 sm:col-2 sm:row-1">
+    <div class="pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex items-center justify-between bg-role-chrome border border-role-on-chrome rounded-lg h-10 gap-4 w-full sm:w-fit">
       <div class="open-file-bar flex">
-        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="max-w-2xs md:max-w-sm"></resource-list-item-stub>
+        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="[&amp;_.oc-resource-name]:max-w-60 xs:[&amp;_.oc-resource-name]:max-w-full sm:[&amp;_.oc-resource-name]:max-w-20 md:[&amp;_.oc-resource-name]:max-w-60"></resource-list-item-stub>
       </div>
       <div class="flex main-actions">
         <!--v-if-->
@@ -56,10 +56,10 @@ exports[`AppTopBar > if a resource is present > renders a resource and mainActio
 
 exports[`AppTopBar > if a resource is present > renders a resource and no actions (if none given) and a close button 1`] = `
 "<portal to="app.runtime.header.left" dropdownactions="">
-  <div class="oc-app-top-bar self-center flex">
-    <div class="oc-app-top-bar-inner pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex self-center items-center justify-between basis-auto sm:basis-xs md:basis-sm bg-role-chrome border border-role-on-chrome rounded-lg w-full h-10 gap-6">
+  <div class="oc-app-top-bar self-center flex col-[1/4] row-2 sm:col-2 sm:row-1">
+    <div class="pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex items-center justify-between bg-role-chrome border border-role-on-chrome rounded-lg h-10 gap-4 w-full sm:w-fit">
       <div class="open-file-bar flex">
-        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="max-w-2xs md:max-w-sm"></resource-list-item-stub>
+        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="[&amp;_.oc-resource-name]:max-w-60 xs:[&amp;_.oc-resource-name]:max-w-full sm:[&amp;_.oc-resource-name]:max-w-20 md:[&amp;_.oc-resource-name]:max-w-60"></resource-list-item-stub>
       </div>
       <div class="flex main-actions">
         <!--v-if-->
@@ -74,10 +74,10 @@ exports[`AppTopBar > if a resource is present > renders a resource and no action
 
 exports[`AppTopBar > if a resource is present > renders a resource without file extension if areFileExtensionsShown is set to false 1`] = `
 "<portal to="app.runtime.header.left" dropdownactions="undefined">
-  <div class="oc-app-top-bar self-center flex">
-    <div class="oc-app-top-bar-inner pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex self-center items-center justify-between basis-auto sm:basis-xs md:basis-sm bg-role-chrome border border-role-on-chrome rounded-lg w-full h-10 gap-6">
+  <div class="oc-app-top-bar self-center flex col-[1/4] row-2 sm:col-2 sm:row-1">
+    <div class="pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex items-center justify-between bg-role-chrome border border-role-on-chrome rounded-lg h-10 gap-4 w-full sm:w-fit">
       <div class="open-file-bar flex">
-        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="false" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="max-w-2xs md:max-w-sm"></resource-list-item-stub>
+        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="false" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="[&amp;_.oc-resource-name]:max-w-60 xs:[&amp;_.oc-resource-name]:max-w-full sm:[&amp;_.oc-resource-name]:max-w-20 md:[&amp;_.oc-resource-name]:max-w-60"></resource-list-item-stub>
       </div>
       <div class="flex main-actions">
         <!--v-if-->
@@ -92,10 +92,10 @@ exports[`AppTopBar > if a resource is present > renders a resource without file 
 
 exports[`AppTopBar > if no resource is present > renders only a close button 1`] = `
 "<portal to="app.runtime.header.left" dropdownactions="">
-  <div class="oc-app-top-bar self-center flex">
-    <div class="oc-app-top-bar-inner pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex self-center items-center justify-between basis-auto sm:basis-xs md:basis-sm bg-role-chrome border border-role-on-chrome rounded-lg w-full h-10 gap-6">
+  <div class="oc-app-top-bar self-center flex col-[1/4] row-2 sm:col-2 sm:row-1">
+    <div class="pl-4 pr-1 my-2 mx-auto sm:m-0 inline-flex items-center justify-between bg-role-chrome border border-role-on-chrome rounded-lg h-10 gap-4 w-full sm:w-fit">
       <div class="open-file-bar flex">
-        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="max-w-2xs md:max-w-sm"></resource-list-item-stub>
+        <resource-list-item-stub resource="undefined" pathprefix="[Function]" ispathdisplayed="true" parentfoldername="Personal" parentfolderlinkiconadditionalattributes="[object Object]" isextensiondisplayed="true" isthumbnaildisplayed="false" isicondisplayed="true" isresourceclickable="false" id="app-top-bar-resource" class="[&amp;_.oc-resource-name]:max-w-60 xs:[&amp;_.oc-resource-name]:max-w-full sm:[&amp;_.oc-resource-name]:max-w-20 md:[&amp;_.oc-resource-name]:max-w-60"></resource-list-item-stub>
       </div>
       <div class="flex main-actions">
         <!--v-if-->

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -1,11 +1,14 @@
 <template>
   <header
     id="oc-topbar"
-    :class="{ 'open-app': contentOnLeftPortal }"
-    class="sticky grid items-center justify-center px-4 h-auto sm:h-13 sm:gap-2.5"
+    :class="[
+      { 'grid-cols-[auto_1fr_1fr]': contentOnLeftPortal },
+      { 'grid-cols-[auto_9fr_1fr]': !contentOnLeftPortal }
+    ]"
+    class="sticky grid items-center px-4 h-auto sm:h-13 sm:gap-10 grid-rows-[52px_auto]"
     :aria-label="$gettext('Top bar')"
   >
-    <div class="oc-topbar-left flex items-center flex-start gap-2.5 sm:gap-5">
+    <div class="flex items-center flex-start gap-2.5 sm:gap-5 col-1">
       <applications-menu
         v-if="appMenuExtensions.length && !isEmbedModeEnabled"
         :menu-items="appMenuExtensions"
@@ -18,10 +21,10 @@
         />
       </router-link>
     </div>
-    <div v-if="!contentOnLeftPortal" class="oc-topbar-center flex justify-end sm:justify-center">
+    <div v-if="!contentOnLeftPortal" class="flex justify-end sm:justify-center col-2">
       <custom-component-target :extension-point="topBarCenterExtensionPoint" />
     </div>
-    <div class="oc-topbar-right flex items-center justify-end gap-5">
+    <div class="flex items-center justify-end gap-5 col-3">
       <portal-target name="app.runtime.header.right" multiple />
     </div>
     <template v-if="!isEmbedModeEnabled">
@@ -211,23 +214,7 @@ export default {
 
 <style lang="scss">
 #oc-topbar {
-  grid-template-areas: 'logo center right' 'secondRow secondRow secondRow';
-  grid-template-columns: 30% 30% 40%;
-  grid-template-rows: 52px auto;
   z-index: 5;
-
-  @media (min-width: $oc-breakpoint-small-default) {
-    grid-template-columns: v-bind(logoWidth) 9fr 1fr;
-    grid-template-rows: 1;
-  }
-
-  &.open-app {
-    grid-template-columns: 30% 30% 40%;
-
-    @media (min-width: $oc-breakpoint-small-default) {
-      grid-template-columns: v-bind(logoWidth) 1fr 1fr;
-    }
-  }
 
   .oc-logo-image {
     image-rendering: auto;
@@ -235,18 +222,6 @@ export default {
     image-rendering: pixelated;
     image-rendering: -webkit-optimize-contrast;
     user-select: none;
-  }
-
-  .oc-topbar-left {
-    grid-area: logo;
-  }
-
-  .oc-topbar-center {
-    grid-area: center;
-  }
-
-  .oc-topbar-right {
-    grid-area: right;
   }
 }
 </style>


### PR DESCRIPTION
Also simplifies the topbar grid a bit and makes it work nicely on all screen resolutions (this includes the search icon not being placed in the middle of the screen).

refs https://github.com/opencloud-eu/web/issues/937