### PR TITLE
feat: add manifest generator

### DIFF
--- a/packages/extension-sdk/index.mjs
+++ b/packages/extension-sdk/index.mjs
@@ -38,7 +38,7 @@ const manifestPlugin = () => {
       if (existsSync(generatedManifestPath)) {
         this.warn(
           `${generatedManifestPath} already exists in output directory (likely from public/), skipping generation\n` +
-            `Consider using --emptyOutDir if outDir is out of project root.`
+            `Consider using --emptyOutDir if outDir is outside of project root.`
         )
         return
       }


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

You can still ship your manifest.json from public/, but instead you can also just put it next to your index.ts and have the extension-sdk insert the fingerprinted filename automatically. This way we can keep arbitrary values in the manifest.json while not disabling fingerprinting which is important for cache busting. If you do not provide any manifest.json, it's automatically generated now.

`pnpm build` creates fingerprinted assets, `pnpm build:w` creates assets without fingerprint. The latter is useful in development when serving the assets through opencloud directly, because manifest.json files are only read once on startup - if the filename is fingerprinted, opencloud needs to be restarted constantly


## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
