### PR TITLE
fix: opening image with right sidebar being opened

### DIFF
--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -407,6 +407,8 @@ export default defineComponent({
           } else {
             loadFileTask.perform()
           }
+        } else {
+          space.value = unref(unref(currentFileContext).space)
         }
       },
       { immediate: true }


### PR DESCRIPTION
Space always needs to be set, even if `noResourceLoading` is false.

fixes https://github.com/opencloud-eu/web/issues/1089