### PR TITLE
feat: remove edit space description inline button

### DIFF
--- a/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
@@ -84,22 +84,10 @@
         }"
       >
         <text-editor
-          class="markdown-container-content w-full [&_#text-editor-preview-component]:!bg-transparent"
+          class="markdown-container-content w-full"
           is-read-only
           :current-content="markdownContent"
         />
-        <div v-if="isEditReadmeVisible" class="markdown-container-edit ml-2">
-          <oc-button
-            type="router-link"
-            size="small"
-            :aria-label="$gettext('Edit description')"
-            appearance="raw"
-            class="p-1"
-            :to="editReadMeContentLink"
-          >
-            <oc-icon name="pencil" size="small" fill-type="line" />
-          </oc-button>
-        </div>
       </div>
       <div
         v-if="showMarkdownCollapse && markdownContent"
@@ -123,11 +111,9 @@ import {
   SideBarEventTopics,
   TextEditor,
   useClientService,
-  useFileActions,
   useLoadPreview,
   useResourcesStore,
   useSharesStore,
-  useSpaceActionsEditReadmeContent,
   useSpacesStore
 } from '@opencloud-eu/web-pkg'
 import SpaceContextActions from './SpaceContextActions.vue'
@@ -147,16 +133,10 @@ const { $gettext, $ngettext } = language
 const clientService = useClientService()
 const { getFileContents, getFileInfo } = clientService.webdav
 const resourcesStore = useResourcesStore()
-const { getDefaultAction } = useFileActions()
 const { loadPreview } = useLoadPreview()
 const spacesStore = useSpacesStore()
 const sharesStore = useSharesStore()
 const { imagesLoading, readmesLoading } = storeToRefs(spacesStore)
-const { actions: editReadmeContentActions } = useSpaceActionsEditReadmeContent()
-
-const isEditReadmeVisible = computed(() =>
-  unref(editReadmeContentActions)[0].isVisible({ resources: [space] })
-)
 
 const isMobileWidth = inject<Ref<boolean>>('isMobileWidth')
 
@@ -280,15 +260,6 @@ watch(
 const imageContent = ref<string>(null)
 const imageExpanded = ref(false)
 
-const editReadMeContentLink = computed(() => {
-  const action = getDefaultAction({ resources: [unref(markdownResource)], space })
-
-  if (!action.route) {
-    return null
-  }
-
-  return action.route({ space, resources: [unref(markdownResource)] })
-})
 const toggleImageExpanded = () => {
   imageExpanded.value = !unref(imageExpanded)
 }

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -86,7 +86,6 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
     <!--v-if-->
     <div class="markdown-container flex min-h-0 [&amp;.collapsed]:max-h-[150px] [&amp;.collapsed]:overflow-hidden collapsed">
       <!---->
-      <div class="markdown-container-edit ml-2"><a attrs="[object Object]" aria-label="Edit description" class="oc-button-secondary oc-button-raw oc-button-secondary-raw gap-2 justify-center text-sm min-h-3 oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default p-1"></a></div>
     </div>
     <!--v-if-->
   </div>


### PR DESCRIPTION
## Description

Removing the edit space description inline-button from the space header. It's supposed to be pretty for everyone, not only for those who can't edit the description. ;-) Also, aligning the button vertically is virtually impossible because it depends on the vertical paddings of the rendered content - which is different if some headline or block text is used.

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
