### PR TITLE
fix: authenticated requests in password protected public links

### DIFF
--- a/packages/web-pkg/src/services/client/auth.ts
+++ b/packages/web-pkg/src/services/client/auth.ts
@@ -23,7 +23,8 @@ export class Auth {
           'Basic ' + Buffer.from(['public', this.publicLinkPassword].join(':')).toString('base64')
       }),
       ...(this.accessToken &&
-        !this.publicLinkPassword && {
+        !this.publicLinkPassword &&
+        !this.publicLinkToken && {
           Authorization: 'Bearer ' + this.accessToken
         })
     }


### PR DESCRIPTION
As authenticated user in a password protected public link context, the `makeRequest` method of the `useRequest` composable should use the password for authentication instead of the Bearer token.

refs https://github.com/opencloud-eu/opencloud/issues/1517