### PR TITLE
feat: load config authenticated

### DIFF
--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -24,28 +24,7 @@ export interface AppNavigationItem {
   priority?: number
 }
 
-/**
- * ApplicationQuickAction describes an application action that is used in the runtime.
- *
- * @deprecated Quick actions should be registered as extension via the `files.quick-action` scope.
- */
-export interface ApplicationQuickAction {
-  id?: string
-  label?: (...args: unknown[]) => string | string
-  icon?: string
-  iconFillType?: IconFillType
-  handler?: (...args: unknown[]) => Promise<void> | void
-  displayed?: (...args: unknown[]) => boolean | boolean
-}
-
 export type AppConfigObject = Record<string, any>
-
-/** @deprecated */
-export interface ApplicationMenuItem {
-  enabled: () => boolean
-  priority?: number
-  openAsEditor?: boolean
-}
 
 export interface ApplicationFileExtension {
   app?: string
@@ -77,15 +56,9 @@ export interface ApplicationInformation {
   meta?: {
     fileSizeLimit?: number
   }
-  /** @deprecated */
-  isFileEditor?: boolean
   extensions?: ApplicationFileExtension[]
   defaultExtension?: string
-  /** @deprecated */
-  type?: string
   translations?: Translations
-  /** @deprecated */
-  applicationMenu?: ApplicationMenuItem
 }
 
 /**

--- a/packages/web-pkg/src/composables/piniaStores/apps.ts
+++ b/packages/web-pkg/src/composables/piniaStores/apps.ts
@@ -22,7 +22,6 @@ export const useAppsStore = defineStore('apps', () => {
     }
 
     unref(apps)[appInfo.id] = {
-      applicationMenu: appInfo.applicationMenu || { enabled: () => false },
       defaultExtension: appInfo.defaultExtension || '',
       icon: 'check_box_outline_blank',
       name: appInfo.name || appInfo.id,

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -138,12 +138,16 @@ const getEmbedConfigFromQuery = (
  */
 export const announceConfiguration = async ({
   path,
-  configStore
+  configStore,
+  token
 }: {
   path: string
   configStore: ConfigStore
+  token?: string
 }) => {
-  const request = await fetch(path, { headers: { 'X-Request-ID': uuidV4() } })
+  const request = await fetch(path, {
+    headers: { 'X-Request-ID': uuidV4(), ...(token && { Authorization: `Bearer ${token}` }) }
+  })
   if (request.status !== 200) {
     throw new Error(`config could not be loaded. HTTP status-code ${request.status}`)
   }

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -201,6 +201,12 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
         return
       }
 
+      await announceConfiguration({
+        path: configurationPath,
+        configStore,
+        token: authStore.accessToken
+      })
+
       const clientService = app.config.globalProperties.$clientService
       const previewService = app.config.globalProperties.$previewService
       const passwordPolicyService = app.config.globalProperties.passwordPolicyService

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -7,7 +7,7 @@
       <div v-if="isIE11" class="bg-role-surface-container text-center py-4">
         <p class="m-0" v-text="ieDeprecationWarning" />
       </div>
-      <top-bar :applications-list="Object.values(apps)" />
+      <top-bar />
     </div>
     <div
       id="web-content-main"
@@ -53,7 +53,6 @@ import orderBy from 'lodash-es/orderBy'
 import {
   AppLoadingSpinner,
   CustomComponentTarget,
-  useAppsStore,
   useAuthStore,
   useExtensionRegistry,
   useLocalStorage,
@@ -69,7 +68,6 @@ import { useActiveApp, useRoute, useRouteMeta, useSpacesLoading } from '@openclo
 import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, unref, watch } from 'vue'
 import { RouteLocationAsRelativeTyped, useRouter } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
-import { storeToRefs } from 'pinia'
 import { progressBarExtensionPoint } from '../extensionPoints'
 
 const MOBILE_BREAKPOINT = 640
@@ -81,9 +79,6 @@ const authStore = useAuthStore()
 const activeApp = useActiveApp()
 const extensionRegistry = useExtensionRegistry()
 const { isSideBarOpen } = useSideBar()
-
-const appsStore = useAppsStore()
-const { apps } = storeToRefs(appsStore)
 
 const extensionNavItems = computed(() =>
   getExtensionNavItems({ extensionRegistry, appId: unref(activeApp) })

--- a/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
@@ -99,9 +99,7 @@ const getWrapper = ({
       props: {
         applicationsList: [
           mock<ApplicationInformation>({
-            type: 'extension',
-            icon: '',
-            applicationMenu: undefined
+            icon: ''
           })
         ]
       },


### PR DESCRIPTION
Loads the config a second time authenticated after the user has been loaded.

The acceptance criteria from the story can not be fulfilled because we need routes to load the auth context, and we need apps for the routes. Hence it's not possible to load the apps after the authenticated config. However, this doesn't seem to be needed because the `extensions` prop of an application is defined as a `ref` and is therefore reactive. That means checks on a user-specific config can still be made.

Also removes deprecated app properties.

closes https://github.com/opencloud-eu/web/issues/1050