### PR TITLE
feat(extension-sdk): add tailwind vite plugin to vite config

### DIFF
--- a/packages/design-system/docs/gettingStarted/installation.md
+++ b/packages/design-system/docs/gettingStarted/installation.md
@@ -36,10 +36,8 @@ $ yarn add @opencloud-eu/design-system
 The design-system uses [Tailwind](https://tailwindcss.com/) for styling. However, it does not ship Tailwind, meaning it must be provided by your application. Additionally, you need to import the design-system's styles at the very beginning of your main CSS file. It's important that this file is imported before any other styles to ensure the styles and Tailwind are working correctly.
 
 ```ts
-import '@opencloud-eu/design-system/tailwind'
+import '@opencloud-eu/design-system/dist/tailwind.css'
 ```
-
-Again, this is not needed if you're using the design-system in an OpenCloud Web app because the styles are already available via the Web runtime.
 
 ### Register components
 

--- a/packages/design-system/docs/gettingStarted/tailwindMigration.md
+++ b/packages/design-system/docs/gettingStarted/tailwindMigration.md
@@ -187,7 +187,7 @@ The philosophy of Tailwind is to use utility classes as much as possible. Howeve
 
 ```html
 <style>
-  @reference '@opencloud-eu/design-system/tailwind';
+  @reference '@opencloud-eu/design-system/dist/tailwind.css';
 
   @layer components {
     .element {

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -61,6 +61,10 @@ export default defineConfig({
           {
             src: './src/styles/tailwind.css',
             dest: '.'
+          },
+          {
+            src: './src/styles/defaults.css',
+            dest: '.'
           }
         ]
       })()

--- a/packages/extension-sdk/index.mjs
+++ b/packages/extension-sdk/index.mjs
@@ -6,6 +6,7 @@ import { mergeConfig, searchForWorkspaceRoot } from 'vite'
 import { join } from 'path'
 import { cwd } from 'process'
 import { readFileSync, existsSync } from 'fs'
+import tailwindcss from '@tailwindcss/vite'
 
 import vue from '@vitejs/plugin-vue'
 
@@ -140,7 +141,8 @@ export const defineConfig = (overrides = {}) => {
             customElement: false,
             ...(isTesting && { template: { compilerOptions: { whitespace: 'preserve' } } })
           }),
-          manifestPlugin()
+          manifestPlugin(),
+          tailwindcss()
         ],
         test: {
           globals: true,

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -14,6 +14,7 @@
     "directory": "packages/extension-sdk"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.1.11",
     "@vitejs/plugin-vue": "^6.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
 
   packages/extension-sdk:
     dependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.11
+        version: 4.1.13(vite@7.1.7(@types/node@22.16.0)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.93.1)(yaml@2.8.1))
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
         version: 6.0.1(vite@7.1.7(@types/node@22.16.0)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.93.1)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))


### PR DESCRIPTION
This eliminates the need for each extension to do that on its own.

Also fixes the Tailwind import paths in the design-system docs and adds the missing css custom file.

refs https://github.com/opencloud-eu/web-extensions/issues/208