### PR TITLE
fix: prevent uploading the same file again during upload

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -363,6 +363,11 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
             ...uppyFile,
             meta: { ...uppyFile.meta, fileId: folder?.fileId }
           })
+
+          if (isRoot && this.resourcesStore.currentFolder?.id === uploadFolder.id) {
+            // update file list for top level folders when the current folder is the upload target folder
+            this.resourcesStore.upsertResource(folder)
+          }
         } catch (error) {
           if (error.statusCode !== 405) {
             console.error(error)

--- a/packages/web-pkg/src/services/uppy/uppyService.ts
+++ b/packages/web-pkg/src/services/uppy/uppyService.ts
@@ -46,7 +46,6 @@ type TusClientError = Error & { originalResponse: any }
 
 // IMPORTANT: must only contain primitive types, complex types won't be serialized properly!
 export type OcUppyMeta = {
-  retry?: boolean
   name?: string
   mtime?: number
   // current space & folder
@@ -91,8 +90,9 @@ export class UppyService {
     this.uppy = new Uppy<OcUppyMeta, OcUppyBody>({
       autoProceed: false,
       onBeforeFileAdded: (file, files) => {
-        if (file.id in files) {
-          file.meta.retry = true
+        if (file.id in files && !files[file.id].error) {
+          // file is currently being uploaded, no need to add it again
+          return false
         }
         file.meta.relativePath = this.getRelativeFilePath(file)
         // id needs to be generated after the relative path has been set.

--- a/packages/web-pkg/src/services/uppy/uppyService.ts
+++ b/packages/web-pkg/src/services/uppy/uppyService.ts
@@ -41,9 +41,6 @@ type FileWithPath = File & {
   readonly relativePath?: string
 }
 
-// FIXME: tus error types seem to be wrong in Uppy, we need the type of the tus client lib
-type TusClientError = Error & { originalResponse: any }
-
 // IMPORTANT: must only contain primitive types, complex types won't be serialized properly!
 export type OcUppyMeta = {
   name?: string
@@ -170,10 +167,10 @@ export class UppyService {
       onBeforeRequest,
       onShouldRetry: (err, retryAttempt, options, next) => {
         // status code 5xx means the upload is gone on the server side
-        if ((err as TusClientError)?.originalResponse?.getStatus() >= 500) {
+        if (err?.originalResponse?.getStatus() >= 500) {
           return false
         }
-        if ((err as TusClientError)?.originalResponse?.getStatus() === 401) {
+        if (err?.originalResponse?.getStatus() === 401) {
           return true
         }
         return next(err)

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -28,7 +28,7 @@
       <div v-if="runningUploads" class="flex items-center">
         <oc-icon v-if="uploadsPaused" name="pause" size="small" class="mr-1" />
         <oc-spinner v-else size="small" class="mr-1" />
-        <span class="text-sm text-role-on-surface-variant" v-text="remainingTime" />
+        <span class="text-sm text-role-on-surface-variant leading-7" v-text="remainingTime" />
       </div>
       <div
         v-else


### PR DESCRIPTION
Uploading the same file multiple times while the upload is still running causes issues because Uppy can not distinguish those files. Hence prevent this behavior.

Also updates the file list immediately after a top-level folder has been created during upload so the user gets direct feedback about their upload.

fixes https://github.com/opencloud-eu/web/issues/1263