### PR TITLE
fix: sidebar versions loading (performance)

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -27,7 +27,11 @@
         <oc-status-indicators :resource="resource" :indicators="shareIndicators" />
         <p class="my-0 mx-2" v-text="detailSharingInformation" />
       </div>
+      <div v-if="detailsLoading" class="flex justify-center">
+        <oc-spinner :aria-label="$gettext('Loading details')" />
+      </div>
       <dl
+        v-else
         class="details-list grid grid-cols-[auto_minmax(0,1fr)] m-0"
         :aria-label="$gettext('Overview of the information about the selected file')"
       >
@@ -179,6 +183,7 @@ const { user } = storeToRefs(userStore)
 
 const resource = inject<Ref<Resource>>('resource')
 const versions = inject<Ref<Resource[]>>('versions')
+const versionsLoading = inject<Ref<boolean>>('versionsLoading')
 const space = inject<Ref<SpaceResource>>('space')
 
 const preview = ref<string>(undefined)
@@ -187,6 +192,7 @@ const authStore = useAuthStore()
 const { publicLinkContextReady } = storeToRefs(authStore)
 
 const isPreviewLoading = computed(() => previewEnabled && unref(previewsLoading))
+const detailsLoading = computed(() => unref(versionsLoading))
 
 const sharedAncestor = computed(() => {
   return Object.values(unref(ancestorMetaData)).find(


### PR DESCRIPTION
Previously, when the current resource had changed, the sidebar would re-fetch all versions, causing the entire sidebar to get re-rendered.

I improved this in 2 ways:

* only load versions if the mdate of the current resource has changed.
* (re-)loading versions now only (re-)renders the file details list, no the entire sidebar.

fixes https://github.com/opencloud-eu/web/issues/1280