### PR TITLE
fix: normalize file and folder names to NFC when uploading

### DIFF
--- a/packages/web-pkg/src/services/uppy/uppyService.ts
+++ b/packages/web-pkg/src/services/uppy/uppyService.ts
@@ -94,7 +94,8 @@ export class UppyService {
         if (file.id in files) {
           file.meta.retry = true
         }
-        file.meta.relativePath = this.getRelativeFilePath(file)
+        file.name = file.name.normalize('NFC')
+        file.meta.relativePath = this.getRelativeFilePath(file)?.normalize('NFC')
         // id needs to be generated after the relative path has been set.
         file.id = this.generateUploadId(file)
         return file


### PR DESCRIPTION
This makes Web independent of the current OS unicode normalization and prevents duplicated files and folders when using different OS with different unicode normalizations.

fixes https://github.com/opencloud-eu/web/issues/1261