### PR TITLE
refactor: remove old archiver handling and semver

### DIFF
--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -65,7 +65,6 @@
     "prismjs": "^1.29.0",
     "qs": "^6.13.0",
     "screenfull": "^6.0.2",
-    "semver": "^7.6.3",
     "uuid": "^13.0.0",
     "vue-concurrency": "^5.0.1",
     "vue-router": "^4.2.5",

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -5,8 +5,6 @@ import {
   isLocationSpacesActive
 } from '../../../router'
 import { useIsFilesAppActive } from '../helpers'
-import path from 'path'
-import first from 'lodash-es/first'
 import { isProjectSpaceResource, isPublicSpaceResource, Resource } from '@opencloud-eu/web-client'
 import { computed, unref } from 'vue'
 import { useLoadingService } from '../../loadingService'
@@ -34,20 +32,12 @@ export const useFileActionsDownloadArchive = () => {
       resources = resources.filter((r) => r.canDownload() && !isProjectSpaceResource(r))
     }
 
-    const fileOptions = unref(archiverService.fileIdsSupported)
-      ? {
-          fileIds: resources.map((resource) => resource.fileId)
-        }
-      : {
-          dir: path.dirname(first<Resource>(resources).path) || '/',
-          files: resources.map((resource) => resource.name)
-        }
     return archiverService
       .triggerDownload({
-        ...fileOptions,
+        fileIds: resources.map((resource) => resource.fileId),
         ...(space &&
           isPublicSpaceResource(space) && {
-            publicToken: space.id as string,
+            publicToken: space.id,
             publicLinkPassword: authStore.publicLinkPassword
           })
       })
@@ -123,12 +113,6 @@ export const useFileActionsDownloadArchive = () => {
             return false
           }
           if (isProjectSpaceResource(resources[0]) && resources[0].disabled) {
-            return false
-          }
-          if (
-            !unref(archiverService.fileIdsSupported) &&
-            isLocationCommonActive(router, 'files-common-favorites')
-          ) {
             return false
           }
 

--- a/packages/web-pkg/src/utils/index.ts
+++ b/packages/web-pkg/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './dirname'
 export * from './encodePath'
 export * from './objectKeys'
+export * from './semver'
 export * from './types'

--- a/packages/web-pkg/src/utils/semver.ts
+++ b/packages/web-pkg/src/utils/semver.ts
@@ -1,0 +1,41 @@
+export const parseVersion = (tag: string) => {
+  const version = tag.startsWith('v') ? tag.slice(1) : tag
+  const [main, pre] = version.split('-')
+  const [major, minor, patch] = main.split('.').map(Number)
+  return { major, minor, patch, pre }
+}
+
+/**
+ * Compares two version strings.
+ * Returns:
+ * - negative number if a is less than b,
+ * - positive number if a is greater than b,
+ * - 0 if a and b are equal.
+ */
+export const compareVersions = (a: string, b: string) => {
+  const va = parseVersion(a)
+  const vb = parseVersion(b)
+
+  if (va.major !== vb.major) {
+    return va.major - vb.major
+  }
+  if (va.minor !== vb.minor) {
+    return va.minor - vb.minor
+  }
+  if (va.patch !== vb.patch) {
+    return va.patch - vb.patch
+  }
+
+  if (va.pre && !vb.pre) {
+    return -1
+  }
+  if (!va.pre && vb.pre) {
+    return 1
+  }
+
+  if (va.pre && vb.pre) {
+    return va.pre.localeCompare(vb.pre)
+  }
+
+  return 0
+}

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDownloadArchive.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDownloadArchive.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '@opencloud-eu/web-test-helpers'
 import { useArchiverService } from '../../../../../src/composables'
 import { ArchiverService } from '../../../../../src'
-import { ref } from 'vue'
 
 vi.mock('../../../../../src/composables/archiverService/useArchiverService')
 
@@ -63,8 +62,7 @@ function getWrapper({
 
   vi.mocked(useArchiverService).mockImplementation(() => {
     return {
-      triggerDownload: triggerDownloadMock,
-      fileIdsSupported: ref(true)
+      triggerDownload: triggerDownloadMock
     } as ArchiverService
   })
 

--- a/packages/web-pkg/tests/unit/services/archiver.spec.ts
+++ b/packages/web-pkg/tests/unit/services/archiver.spec.ts
@@ -47,7 +47,7 @@ describe('archiver', () => {
       new RuntimeError('no archiver available')
     )
   })
-  describe('with one v2 archiver capability', () => {
+  describe('with one archiver capability', () => {
     const archiverUrl = [serverUrl, 'archiver'].join('/')
     const capabilities = ref([
       {
@@ -60,10 +60,6 @@ describe('archiver', () => {
       }
     ])
 
-    it('is announcing itself as supporting fileIds', () => {
-      const archiverService = getArchiverServiceInstance(capabilities)
-      expect(unref(archiverService.fileIdsSupported)).toBe(true)
-    })
     it('fails to trigger a download if no files were given', async () => {
       const archiverService = getArchiverServiceInstance(capabilities)
       await expect(archiverService.triggerDownload({})).rejects.toThrow(
@@ -78,42 +74,6 @@ describe('archiver', () => {
       expect(window.URL.createObjectURL).toHaveBeenCalled()
       expect(url.startsWith(archiverUrl)).toBeTruthy()
       expect(url.indexOf(`id=${fileId}`)).toBeGreaterThan(-1)
-    })
-  })
-  describe('with one v1 archiver capability', () => {
-    const archiverUrl = [serverUrl, 'archiver'].join('/')
-    const capabilities = ref([
-      {
-        enabled: true,
-        version: 'v1.2.3',
-        archiver_url: archiverUrl,
-        formats: [],
-        max_num_files: '42',
-        max_size: '1073741824'
-      }
-    ])
-    it('is announcing itself as not supporting fileIds', () => {
-      const archiverService = getArchiverServiceInstance(capabilities)
-      expect(unref(archiverService.fileIdsSupported)).toBe(false)
-    })
-    it('fails to trigger a download if no files were given', async () => {
-      const archiverService = getArchiverServiceInstance(capabilities)
-      await expect(archiverService.triggerDownload({})).rejects.toThrow(
-        new RuntimeError('requested archive with empty list of resources')
-      )
-    })
-    it('returns a download url for a valid archive download trigger', async () => {
-      const archiverService = getArchiverServiceInstance(capabilities)
-      window.URL.createObjectURL = vi.fn(() => '')
-      const dir = '/some/path'
-      const fileName = 'qwer'
-      const url = await archiverService.triggerDownload({ dir, files: [fileName] })
-
-      expect(window.URL.createObjectURL).toHaveBeenCalled()
-      expect(url.startsWith(archiverUrl)).toBeTruthy()
-      expect(url.indexOf(`files[]=${fileName}`)).toBeGreaterThan(-1)
-      expect(url.indexOf(`dir=${encodeURIComponent(dir)}`)).toBeGreaterThan(-1)
-      expect(url.indexOf('downloadStartSecret=')).toBeGreaterThan(-1)
     })
   })
   describe('with multiple archiver capabilities of different versions', () => {

--- a/packages/web-pkg/tests/unit/utils/semver.spec.ts
+++ b/packages/web-pkg/tests/unit/utils/semver.spec.ts
@@ -1,0 +1,19 @@
+import { compareVersions, parseVersion } from '../../../src/utils/semver'
+
+describe('parseVersion', () => {
+  it('parses version strings correctly', () => {
+    const version = parseVersion('v1.2.3-beta')
+    expect(version).toEqual({ major: 1, minor: 2, patch: 3, pre: 'beta' })
+  })
+})
+
+describe('compareVersions', () => {
+  it.each([
+    ['v1.2.3', 'v1.2.4', -1],
+    ['v1.2.4', 'v1.2.3', 1],
+    ['v1.2.3', 'v1.2.3', 0]
+  ])('compares version strings correctly', (a, b, expected) => {
+    const result = compareVersions(a, b)
+    expect(result).toBe(expected)
+  })
+})

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -33,7 +33,6 @@
     "portal-vue": "^3.0.0",
     "promise": "^8.1.0",
     "qs": "6.14.0",
-    "semver": "7.7.2",
     "utf8": "^3.0.0",
     "uuid": "13.0.0",
     "vue-concurrency": "5.0.3",

--- a/packages/web-runtime/src/components/VersionCheck.vue
+++ b/packages/web-runtime/src/components/VersionCheck.vue
@@ -34,8 +34,12 @@
 <script setup lang="ts">
 import { ref, watch, unref } from 'vue'
 import { useGettext } from 'vue3-gettext'
-import semver from 'semver'
-import { UpdateChannel, useCapabilityStore, useUpdatesStore } from '@opencloud-eu/web-pkg'
+import {
+  UpdateChannel,
+  useCapabilityStore,
+  useUpdatesStore,
+  compareVersions
+} from '@opencloud-eu/web-pkg'
 import { storeToRefs } from 'pinia'
 
 const { $gettext } = useGettext()
@@ -58,7 +62,7 @@ watch(
       return
     }
     const newestVersion = unref(updates).channels[serverEdition].current_version
-    if (semver.gt(newestVersion, currentServerVersionSanitized)) {
+    if (compareVersions(newestVersion, currentServerVersionSanitized) > 0) {
       updateAvailable.value = true
       updateData.value = unref(updates).channels[serverEdition]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -879,9 +879,6 @@ importers:
       screenfull:
         specifier: ^6.0.2
         version: 6.0.2
-      semver:
-        specifier: ^7.6.3
-        version: 7.7.2
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -1007,9 +1004,6 @@ importers:
       qs:
         specifier: 6.14.0
         version: 6.14.0
-      semver:
-        specifier: 7.7.2
-        version: 7.7.2
       utf8:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
We only support archivers with file id support by now, hence removes the old archiver handling.

Also removes the `semver` dependency since we only use it for comparing versions, which can be done via a simple helper method. No need for a full-blown library that lacks proper type support.