### PR TITLE
feat(external): respect light/dark theme in Collabora

### DIFF
--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`The app provider extension > should be able to load an iFrame via post 
     <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
     <div><input name="access_token_ttl" type="hidden" value="123456"></div>
     <!--v-if-->
+    <!--v-if-->
   </form> <iframe name="app-iframe" class="size-full" title="&quot;example-app&quot; app content area" allowfullscreen=""></iframe>
 </div>"
 `;


### PR DESCRIPTION
And removes the light/dark theme switch within Collabora.

closes https://github.com/opencloud-eu/web/issues/705