### PR TITLE
fix(extension-sdk): handle 'require' (wrapped in single quotes) in pa…

### DIFF
--- a/packages/extension-sdk/index.mjs
+++ b/packages/extension-sdk/index.mjs
@@ -95,7 +95,7 @@ const completeAmdWrapPlugin = () => {
 
       return {
         code: code.replace(AmdWrapRE, (_, deps, params) => {
-          if (deps?.includes('"require"')) {
+          if (deps?.includes(`"require"`) || deps?.includes(`'require'`)) {
             return `define([${deps}], (function(${params}) {`
           }
 


### PR DESCRIPTION
…rameter list of amd modules

<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

I was assuming parameters were always wrapped in double quotes, but esbuild seems to use single quotes which is used to prebundle deps.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
