### PR TITLE
e2e tests. fix open shortcut

### DIFF
--- a/tests/e2e/cucumber/features/navigation/shortcut.feature
+++ b/tests/e2e/cucumber/features/navigation/shortcut.feature
@@ -41,7 +41,7 @@ Feature: Users can create shortcuts for resources and sites
     Then "Alice" is in a text-editor
     And "Alice" closes the file viewer
     And "Alice" opens the "files" app
-    Then "Alice" can open a shortcut "companyNews.url" with external url "https://opencloud.eu/news/"
+    Then "Alice" can open a shortcut "companyNews.url" with external url "https://opencloud.eu/en/blog-news"
     And "Alice" logs out
 
     # create a shortcut to the shared file


### PR DESCRIPTION
The test expected the opening of https://opencloud.eu/news, but on our website the link was changed to https://opencloud.eu/en/blog-news.  