### PR TITLE
fix: bottom drawer nesting issues

### DIFF
--- a/packages/design-system/docs/.vitepress/theme/index.ts
+++ b/packages/design-system/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import './tailwind.css'
 import DefaultTheme from 'vitepress/theme-without-fonts'
 import './../../../src/styles/layers.css'
 import { createGettext } from 'vue3-gettext'
+import { createPinia } from 'pinia'
 import * as components from './../../../src/components'
 import * as directives from './../../../src/directives'
 import './custom.scss'
@@ -12,7 +13,9 @@ export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
     const gettext = createGettext()
+    const pinia = createPinia()
     app.use(gettext)
+    app.use(pinia)
 
     app.component('LiveCodeBlock', LiveCodeBlock)
     app.component('ComponentApi', ComponentApi)

--- a/packages/design-system/docs/components/OcBottomDrawer/nesting.vue
+++ b/packages/design-system/docs/components/OcBottomDrawer/nesting.vue
@@ -31,8 +31,6 @@
     drawer-id="example-bottom-drawer-child"
     toggle="#toggle-bottom-drawer-child"
     title="Example Bottom Drawer Child"
-    :is-nested-element="true"
-    :nested-parent-ref="parent"
   >
     <oc-list class="flex flex-col p-2">
       <oc-button justify-content="left" appearance="raw" no-hover aria-expanded="false">
@@ -44,8 +42,7 @@
 </template>
 <script setup lang="ts">
 import { OcBottomDrawer } from '../../../src/components'
-import { ref, useTemplateRef } from 'vue'
+import { ref } from 'vue'
 
-const parent = useTemplateRef('parent')
 const renderChild = ref(false)
 </script>

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -110,6 +110,7 @@
     "fuse.js": "^7.0.0",
     "lodash-es": "^4.17.21",
     "luxon": "^3.5.0",
+    "pinia": "^3.0.3",
     "portal-vue": "^3.0.0",
     "tippy.js": "^6.3.7",
     "vue-inline-svg": "^4.0.0",

--- a/packages/design-system/src/components/OcBottomDrawer/OcBottomDrawer.spec.ts
+++ b/packages/design-system/src/components/OcBottomDrawer/OcBottomDrawer.spec.ts
@@ -2,6 +2,7 @@ import { defaultPlugins, mount } from '@opencloud-eu/web-test-helpers'
 import BottomDrawer from './OcBottomDrawer.vue'
 import { defineComponent, nextTick } from 'vue'
 import OcButton from '../OcButton/OcButton.vue'
+import { useBottomDrawer } from '../../composables'
 
 const selectors = {
   toggle: '#button-drawer-toggle',
@@ -42,8 +43,8 @@ describe('OcBottomDrawer', () => {
     expect(wrapper.find(selectors.drawer).exists()).toBe(true)
 
     wrapper.find(selectors.closeButton).trigger('click')
-    await new Promise((r) => setTimeout(r, 160))
-    expect(wrapper.find(selectors.drawer).exists()).toBe(false)
+    const bottomDrawerStore = useBottomDrawer()
+    expect(bottomDrawerStore.closeAllDrawers).toHaveBeenCalled()
     wrapper.unmount()
   })
 
@@ -54,8 +55,8 @@ describe('OcBottomDrawer', () => {
     expect(wrapper.find(selectors.drawer).exists()).toBe(true)
 
     await wrapper.find(selectors.background).trigger('click')
-    await new Promise((r) => setTimeout(r, 160))
-    expect(wrapper.find(selectors.drawer).exists()).toBe(false)
+    const bottomDrawerStore = useBottomDrawer()
+    expect(bottomDrawerStore.closeAllDrawers).toHaveBeenCalled()
     wrapper.unmount()
   })
 
@@ -68,8 +69,8 @@ describe('OcBottomDrawer', () => {
 
     const esc = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
     document.dispatchEvent(esc)
-    await new Promise((r) => setTimeout(r, 160))
-    expect(wrapper.find(selectors.drawer).exists()).toBe(false)
+    const bottomDrawerStore = useBottomDrawer()
+    expect(bottomDrawerStore.closeAllDrawers).toHaveBeenCalled()
     wrapper.unmount()
   })
 
@@ -81,8 +82,8 @@ describe('OcBottomDrawer', () => {
     expect(wrapper.find(selectors.drawer).exists()).toBe(true)
 
     wrapper.find(selectors.actionButton).trigger('click')
-    await new Promise((r) => setTimeout(r, 160))
-    expect(wrapper.find(selectors.drawer).exists()).toBe(false)
+    const bottomDrawerStore = useBottomDrawer()
+    expect(bottomDrawerStore.closeDrawer).toHaveBeenCalled()
     wrapper.unmount()
   })
 
@@ -94,13 +95,21 @@ describe('OcBottomDrawer', () => {
     expect(wrapper.find(selectors.drawer).exists()).toBe(true)
 
     wrapper.find(selectors.actionButton).trigger('click')
-    await new Promise((r) => setTimeout(r, 160))
-    expect(wrapper.find(selectors.drawer).exists()).toBe(true)
+    const bottomDrawerStore = useBottomDrawer()
+    expect(bottomDrawerStore.closeDrawer).not.toHaveBeenCalled()
+    expect(bottomDrawerStore.closeAllDrawers).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 })
 
 const getWrapper = (props = { closeOnClick: false }) => {
+  const plugins = [...defaultPlugins()]
+
+  const drawer = { id: '1' }
+  const bottomDrawerStore = useBottomDrawer()
+  vi.mocked(bottomDrawerStore.showDrawer).mockReturnValue(drawer)
+  bottomDrawerStore.drawers = [drawer]
+
   const RootComponent = defineComponent({
     components: { BottomDrawer, OcButton },
     props: ['props'],
@@ -135,7 +144,7 @@ const getWrapper = (props = { closeOnClick: false }) => {
         ...props
       },
       attachTo: document.body,
-      global: { renderStubDefaultSlot: true, plugins: [...defaultPlugins()] }
+      global: { renderStubDefaultSlot: true, plugins }
     })
   }
 }

--- a/packages/design-system/src/components/OcBottomDrawer/OcBottomDrawer.vue
+++ b/packages/design-system/src/components/OcBottomDrawer/OcBottomDrawer.vue
@@ -1,30 +1,31 @@
 <template>
   <component
     :is="usePortal ? 'portal' : 'div'"
-    v-if="isOpen"
+    v-if="isActive"
     :to="usePortal ? portalTarget : undefined"
   >
     <div
-      v-if="isOpen"
-      ref="bottomDrawerRef"
       class="oc-bottom-drawer-background fixed inset-0 z-[calc(var(--z-index-modal)+2)] top-0 left-0 bg-black/40 size-full"
       role="button"
       @click="onBackgroundClicked"
     >
-      <focus-trap>
+      <focus-trap :active="isCurrentlyOnTop">
         <div
           :id="drawerId"
           tabindex="0"
-          class="oc-bottom-drawer fixed inset-x-0 bg-role-surface-container-high rounded-t-sm w-full max-h-[66vh] overflow-y-auto bottom-[-100%] transition-all duration-200 [&.active]:bottom-0"
+          class="oc-bottom-drawer fixed inset-x-0 bg-role-surface-container-high rounded-t-sm w-full max-h-[66vh] overflow-y-auto transition-all duration-200 bottom-[-100%]"
+          :class="{
+            '[&.active]:bottom-0': isCurrentlyOnTop
+          }"
         >
           <oc-card class="bg-transparent" header-class="flex flex-row justify-between items-center">
             <template #header>
               <oc-button
-                v-if="isNestedElement"
+                v-if="drawers.length > 1"
                 appearance="raw"
                 class="raw-hover-surface oc-bottom-drawer-back-button"
                 :aria-label="$gettext('Open the parent context menu')"
-                @click="openParentDrawer"
+                @click="hide()"
               >
                 <oc-icon name="arrow-left" fill-type="line" />
               </oc-button>
@@ -33,7 +34,7 @@
                 appearance="raw"
                 class="raw-hover-surface oc-bottom-drawer-close-button"
                 :aria-label="$gettext('Close the context menu')"
-                @click="hide()"
+                @click="closeAllDrawers()"
               >
                 <oc-icon name="close" fill-type="line" />
               </oc-button>
@@ -49,13 +50,23 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, ref, unref, useTemplateRef } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  unref,
+  useTemplateRef,
+  watch
+} from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { FocusTrap } from 'focus-trap-vue'
 import { onKeyStroke } from '@vueuse/core'
 import OcButton from '../OcButton/OcButton.vue'
 import OcCard from '../OcCard/OcCard.vue'
-import { NestedDrop } from '../../helpers'
+import { BottomDrawer, useBottomDrawer } from '../../composables'
+import { storeToRefs } from 'pinia'
 
 export interface Props {
   /**
@@ -80,22 +91,12 @@ export interface Props {
    * @default false
    */
   usePortal?: boolean
-
   /**
    * @docs
    * The target of the portal, when in use.
    * @default app.runtime.bottom.drawer
    */
   portalTarget?: string
-  /**
-   * @docs Determines if the bottom drawer element is nested.
-   * @default false
-   */
-  isNestedElement?: boolean
-  /**
-   * @docs The parent `OcBottomDrawer` ref of the nested bottom drawer.
-   */
-  nestedParentRef?: NestedDrop | null
 }
 
 const {
@@ -104,8 +105,6 @@ const {
   closeOnClick = false,
   title = '',
   usePortal = false,
-  isNestedElement = false,
-  nestedParentRef = null,
   portalTarget = 'app.runtime.bottom.drawer'
 } = defineProps<Props>()
 
@@ -133,79 +132,62 @@ export interface Slots {
 defineSlots<Slots>()
 
 const { $gettext } = useGettext()
+const bottomDrawerStore = useBottomDrawer()
+const { showDrawer, closeDrawer, closeAllDrawers } = bottomDrawerStore
+const { drawers, currentDrawer } = storeToRefs(bottomDrawerStore)
 
-const isOpen = ref(false)
-const bottomDrawerRef = useTemplateRef<HTMLElement | null>('bottomDrawerRef')
-const bottomDrawerCardBodyRef = useTemplateRef<HTMLElement | null>('bottomDrawerCardBodyRef')
+const drawer = ref<BottomDrawer | null>(null)
+const bottomDrawerCardBodyRef = useTemplateRef('bottomDrawerCardBodyRef')
+
+const isActive = computed(() => {
+  // active means the drawer is in the stack, but not necessarily on top (visible)
+  return unref(drawers)
+    .map(({ id }) => id)
+    .includes(unref(drawer)?.id)
+})
+
+const isCurrentlyOnTop = computed(() => {
+  // the drawer that is currently shown
+  return unref(drawer)?.id && unref(currentDrawer)?.id === unref(drawer).id
+})
 
 const show = async () => {
-  if (isNestedElement) {
-    unref(nestedParentRef).getElement().classList.add('hidden')
-  }
-
-  isOpen.value = true
+  drawer.value = showDrawer()
   emit('show')
   await nextTick()
-  unref(bottomDrawerCardBodyRef).addEventListener('click', onChildClicked)
-
-  // set active class for the slide-in animation
-  const drawer = document.getElementById(drawerId)
-  drawer?.classList.add('active')
+  unref(bottomDrawerCardBodyRef)?.addEventListener('click', onChildClicked)
 }
 
-const openParentDrawer = () => {
-  hide({ hideParent: false })
-  unref(nestedParentRef).getElement().classList.remove('hidden')
-}
-
-const hide = async ({ hideParent = true } = {}) => {
-  if (isNestedElement && hideParent) {
-    unref(nestedParentRef).hide()
-  }
-
+const hide = () => {
+  closeDrawer(unref(drawer)?.id)
   unref(bottomDrawerCardBodyRef)?.removeEventListener('click', onChildClicked)
-
-  // remove active class for the slide-out animation
-  const drawer = document.getElementById(drawerId)
-  drawer?.classList.remove('active')
-  await new Promise((resolve) => setTimeout(resolve, 150)) // wait for the animation to finish
-
-  isOpen.value = false
   emit('hide')
 }
 
 const onChildClicked = (event: MouseEvent) => {
   const target = (event.target as HTMLElement).closest('a[href], button')
-
   if (!target) {
     return
   }
-
   if (target.hasAttribute('aria-expanded')) {
     target.setAttribute('aria-expanded', 'true')
     return
   }
-
-  if (!closeOnClick) {
-    return
+  if (closeOnClick) {
+    hide()
+    closeAllDrawers()
   }
-
-  if (isNestedElement) {
-    unref(nestedParentRef).hide()
-  }
-
-  hide()
 }
 
 const onBackgroundClicked = (event: MouseEvent) => {
   if (event.target === event.currentTarget) {
-    hide()
+    closeAllDrawers()
   }
 }
 
 onKeyStroke('Escape', (e) => {
   e.preventDefault()
-  hide()
+  closeAllDrawers()
 })
 
 onMounted(() => {
@@ -218,13 +200,20 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   document.querySelector(toggle).removeEventListener('click', show)
+  if (unref(drawer)) {
+    closeDrawer(unref(drawer).id)
+  }
 })
 
-const getElement = () => {
-  return unref(bottomDrawerRef)
-}
+watch(isCurrentlyOnTop, async () => {
+  if (unref(isCurrentlyOnTop)) {
+    await nextTick()
+    const drawerEl = document.getElementById(drawerId)
+    drawerEl?.classList.add('active')
+  }
+})
 
-defineExpose({ show, hide, getElement })
+defineExpose({ show, hide })
 </script>
 <style>
 @reference '@opencloud-eu/design-system/tailwind';

--- a/packages/design-system/src/components/OcDrop/OcDrop.vue
+++ b/packages/design-system/src/components/OcDrop/OcDrop.vue
@@ -6,8 +6,6 @@
     :toggle="toggle"
     :close-on-click="closeOnClick"
     :title="title"
-    :is-nested-element="isNestedElement"
-    :nested-parent-ref="nestedParentRef"
     use-portal
     @show="emit('showDrop')"
     @hide="emit('hideDrop')"
@@ -26,7 +24,7 @@
 import tippy, { hideAll, Props as TippyProps, Instance } from 'tippy.js'
 import { detectOverflow, Modifier } from '@popperjs/core'
 import { destroy, hideOnEsc } from '../../directives/OcTooltip'
-import { getTailwindPaddingClass, NestedDrop, SizeType, uniqueId } from '../../helpers'
+import { getTailwindPaddingClass, SizeType, uniqueId } from '../../helpers'
 import { computed, nextTick, onBeforeUnmount, ref, unref, useTemplateRef, watch } from 'vue'
 import { useIsMobile } from '../../composables'
 import OcBottomDrawer from '../OcBottomDrawer/OcBottomDrawer.vue'
@@ -51,10 +49,6 @@ export interface Props {
    * @default false
    */
   isNestedElement?: boolean
-  /**
-   * @docs The parent `OcDrop` ref of the nested drop.
-   */
-  nestedParentRef?: NestedDrop
   /**
    * @docs Determines the event that triggers the drop.
    * @default 'click'
@@ -139,8 +133,7 @@ const {
   target,
   toggle = '',
   title = '',
-  enforceDropOnMobile = false,
-  nestedParentRef = null
+  enforceDropOnMobile = false
 } = defineProps<Props>()
 
 const emit = defineEmits<Emits>()
@@ -169,11 +162,7 @@ const hide = () => {
   unref(tippyInstance)?.hide()
 }
 
-const getElement = () => {
-  return unref(useBottomDrawer) ? unref(bottomDrawerRef).getElement() : unref(drop)
-}
-
-defineExpose({ show, hide, getElement, tippy: tippyInstance })
+defineExpose({ show, hide, tippy: tippyInstance })
 
 const onClick = (event: Event) => {
   const isNestedDropToggle = (event.target as HTMLElement)

--- a/packages/design-system/src/composables/index.ts
+++ b/packages/design-system/src/composables/index.ts
@@ -1,2 +1,3 @@
 export * from './useIsVisible'
 export * from './useIsMobile'
+export * from './stores'

--- a/packages/design-system/src/composables/stores/bottomDrawer.ts
+++ b/packages/design-system/src/composables/stores/bottomDrawer.ts
@@ -1,0 +1,40 @@
+import { defineStore } from 'pinia'
+import { computed, ref, unref } from 'vue'
+import { uniqueId } from '../../helpers'
+
+export interface BottomDrawer {
+  id: string
+}
+
+export const useBottomDrawer = defineStore('bottomDrawers', () => {
+  const drawers = ref<BottomDrawer[]>([])
+
+  const currentDrawer = computed(() => {
+    // drawer that is currently displaying (top most)
+    return unref(drawers).length ? unref(drawers)[unref(drawers).length - 1] : null
+  })
+
+  const showDrawer = () => {
+    const drawer = { id: uniqueId() }
+    drawers.value.push(drawer)
+    return drawer
+  }
+
+  const closeDrawer = (id: string) => {
+    drawers.value = unref(drawers).filter((d) => d.id !== id)
+  }
+
+  const closeAllDrawers = () => {
+    drawers.value = []
+  }
+
+  return {
+    drawers,
+    currentDrawer,
+    showDrawer,
+    closeDrawer,
+    closeAllDrawers
+  }
+})
+
+export type BottomDrawerStore = ReturnType<typeof useBottomDrawer>

--- a/packages/design-system/src/composables/stores/index.ts
+++ b/packages/design-system/src/composables/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './bottomDrawer'

--- a/packages/design-system/src/helpers/types.ts
+++ b/packages/design-system/src/helpers/types.ts
@@ -1,4 +1,3 @@
-import { ComponentPublicInstance, Ref } from 'vue'
 import { RouteLocationRaw } from 'vue-router'
 
 export interface ContextualHelperDataListItem {
@@ -87,11 +86,3 @@ export type JustifyContentType =
   | 'space-around'
   | 'space-between'
   | 'space-evenly'
-
-export type NestedDrop = Ref<
-  ComponentPublicInstance & {
-    show: () => void
-    hide: () => void
-    getElement: () => HTMLElement
-  }
->

--- a/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
@@ -3,11 +3,7 @@
     <oc-spinner :aria-label="$gettext('Loading actions')" />
   </div>
   <div v-else>
-    <context-action-menu
-      :menu-sections="menuSections"
-      :action-options="actionOptions"
-      :drop-ref="dropRef"
-    />
+    <context-action-menu :menu-sections="menuSections" :action-options="actionOptions" />
     <input
       id="space-image-upload-input"
       ref="spaceImageInput"
@@ -48,7 +44,6 @@ import { useSpaceActionsUploadImage } from '../../composables'
 import { computed, defineComponent, PropType, Ref, ref, toRef, unref, VNodeRef } from 'vue'
 import { MenuSection } from '@opencloud-eu/web-pkg'
 import { useGettext } from 'vue3-gettext'
-import { NestedDrop } from '@opencloud-eu/design-system/helpers'
 
 export default defineComponent({
   name: 'SpaceContextActions',
@@ -61,11 +56,6 @@ export default defineComponent({
     loading: {
       type: Boolean,
       default: false
-    },
-    dropRef: {
-      type: Object as PropType<NestedDrop>,
-      required: false,
-      default: null
     }
   },
   setup(props) {

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -78,11 +78,10 @@
               @item-visible="loadPreview({ space, resource: $event })"
               @sort="handleSort"
             >
-              <template #contextMenu="{ resource, isOpen, dropRef }">
+              <template #contextMenu="{ resource, isOpen }">
                 <context-actions
                   v-if="isOpen && isResourceInSelection(resource)"
                   :action-options="{ space, resources: selectedResources }"
-                  :drop-ref="dropRef"
                 />
               </template>
 

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -106,12 +106,11 @@
                 <oc-icon name="group" fill-type="line" />
               </oc-button>
             </template>
-            <template #contextMenu="{ resource, isOpen, dropRef }">
+            <template #contextMenu="{ resource, isOpen }">
               <space-context-actions
                 v-if="isOpen && isResourceInSelection(resource)"
                 :loading="resource.graphPermissions === undefined"
                 :action-options="{ resources: [resource] as SpaceResource[] }"
-                :drop-ref="dropRef"
               />
             </template>
             <template #footer>

--- a/packages/web-pkg/src/components/ContextActions/ActionMenuDropItem.vue
+++ b/packages/web-pkg/src/components/ContextActions/ActionMenuDropItem.vue
@@ -21,7 +21,6 @@
       :drop-id="dropId"
       :toggle="`#${toggleId}`"
       :is-nested-element="true"
-      :nested-parent-ref="parentDropRef"
       mode="hover"
       class="w-3xs oc-files-context-action-drop"
       padding-size="small"
@@ -45,21 +44,15 @@
 
 <script setup lang="ts">
 import ActionMenuItem from './ActionMenuItem.vue'
-import { AppearanceType, NestedDrop, uniqueId } from '@opencloud-eu/design-system/helpers'
+import { AppearanceType, uniqueId } from '@opencloud-eu/design-system/helpers'
 import type { ActionOptions } from '../../composables'
 import { MenuSectionDrop } from './types'
 import { OcDrop } from '@opencloud-eu/design-system/components'
 
-const {
-  menuSectionDrop,
-  appearance,
-  actionOptions,
-  parentDropRef = null
-} = defineProps<{
+const { menuSectionDrop, appearance, actionOptions } = defineProps<{
   menuSectionDrop: MenuSectionDrop
   appearance: AppearanceType
   actionOptions: ActionOptions
-  parentDropRef?: NestedDrop | null
 }>()
 
 const dropId = uniqueId(`oc-files-context-actions-${menuSectionDrop.name}-drop-`)

--- a/packages/web-pkg/src/components/ContextActions/ContextActionMenu.vue
+++ b/packages/web-pkg/src/components/ContextActions/ContextActionMenu.vue
@@ -24,7 +24,6 @@
           :menu-section-drop="drop"
           :appearance="appearance"
           :action-options="actionOptions"
-          :parent-drop-ref="dropRef"
         />
       </template>
     </oc-list>
@@ -35,7 +34,7 @@
 import { defineComponent, PropType } from 'vue'
 import ActionMenuItem from './ActionMenuItem.vue'
 import { ActionOptions } from '../../composables'
-import { AppearanceType, NestedDrop } from '@opencloud-eu/design-system/helpers'
+import { AppearanceType } from '@opencloud-eu/design-system/helpers'
 import ActionMenuDropItem from './ActionMenuDropItem.vue'
 import { MenuSection } from './types'
 
@@ -54,11 +53,6 @@ export default defineComponent({
     actionOptions: {
       type: Object as PropType<ActionOptions>,
       required: true
-    },
-    dropRef: {
-      type: Object as PropType<NestedDrop>,
-      required: false,
-      default: null
     }
   },
   methods: {

--- a/packages/web-pkg/src/components/ContextActions/ContextMenuQuickAction.vue
+++ b/packages/web-pkg/src/components/ContextActions/ContextMenuQuickAction.vue
@@ -26,12 +26,7 @@
       @show-drop="isOpen = true"
       @hide-drop="isOpen = false"
     >
-      <slot
-        :drop-ref="$refs[`context-menu-drop-ref-${resourceDomSelector(item)}`]"
-        name="contextMenu"
-        :item="item"
-        :is-open="isOpen"
-      />
+      <slot name="contextMenu" :item="item" :is-open="isOpen" />
     </oc-drop>
   </oc-button>
 </template>

--- a/packages/web-pkg/src/components/FilesList/ContextActions.vue
+++ b/packages/web-pkg/src/components/FilesList/ContextActions.vue
@@ -1,9 +1,5 @@
 <template>
-  <context-action-menu
-    :menu-sections="menuSections"
-    :action-options="actionOptions"
-    :drop-ref="dropRef"
-  />
+  <context-action-menu :menu-sections="menuSections" :action-options="actionOptions" />
 </template>
 
 <script lang="ts">
@@ -36,7 +32,6 @@ import {
 import { isNil } from 'lodash-es'
 import { useGettext } from 'vue3-gettext'
 import { MenuSection } from '../ContextActions'
-import { NestedDrop } from '@opencloud-eu/design-system/helpers'
 
 export default defineComponent({
   name: 'ContextActions',
@@ -45,11 +40,6 @@ export default defineComponent({
     actionOptions: {
       type: Object as PropType<FileActionOptions>,
       required: true
-    },
-    dropRef: {
-      type: Object as PropType<NestedDrop>,
-      required: false,
-      default: null
     }
   },
   setup(props) {

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -252,8 +252,8 @@
           class="resource-table-btn-action-dropdown"
           @quick-action-clicked="showContextMenuOnBtnClick($event, item)"
         >
-          <template #contextMenu="{ isOpen, dropRef }">
-            <slot :drop-ref="dropRef" name="contextMenu" :resource="item" :is-open="isOpen" />
+          <template #contextMenu="{ isOpen }">
+            <slot name="contextMenu" :resource="item" :is-open="isOpen" />
           </template>
         </context-menu-quick-action>
       </div>

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -114,13 +114,8 @@
               class="resource-tiles-btn-action-dropdown"
               @quick-action-clicked="showContextMenuOnBtnClick($event, resource, resource.id)"
             >
-              <template #contextMenu="{ isOpen, dropRef }">
-                <slot
-                  name="contextMenu"
-                  :resource="resource"
-                  :is-open="isOpen"
-                  :drop-ref="dropRef"
-                />
+              <template #contextMenu="{ isOpen }">
+                <slot name="contextMenu" :resource="resource" :is-open="isOpen" />
               </template>
             </context-menu-quick-action>
           </template>
@@ -240,11 +235,7 @@ const emit = defineEmits<{
 defineSlots<{
   image?: (props: { resource: Resource }) => unknown
   actions?: (props: { resource: Resource }) => unknown
-  contextMenu?: (props: {
-    resource: Resource
-    isOpen: boolean
-    dropRef: HTMLElement | null
-  }) => unknown
+  contextMenu?: (props: { resource: Resource; isOpen: boolean }) => unknown
   footer?: () => unknown
   additionalResourceContent?: (props: { resource: Resource }) => unknown
 }>()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       luxon:
         specifier: ^3.5.0
         version: 3.7.2
+      pinia:
+        specifier: ^3.0.3
+        version: 3.0.3(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
       portal-vue:
         specifier: ^3.0.0
         version: 3.0.0(patch_hash=ce486dc8fb49b1e3f9b160bfede1dfeb31a492b7e1ea6dc8d10bbee39174cdcb)(vue@3.5.22(typescript@5.9.3))


### PR DESCRIPTION
Fixes several issues with the bottom drawer (especially with nested ones) and improves the general animation handling when opening/closing nested menus.

This was achieved by introducing a store that keeps track of all the registered bottom drawers. This should be a much cleaner approach than the previous one.

fixes https://github.com/opencloud-eu/web/issues/1444
fixes https://github.com/opencloud-eu/web/issues/1445
fixes https://github.com/opencloud-eu/web/issues/1451