### PR TITLE
🎉 Release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 
 ### 📦️ Dependencies
 
+- chore(deps): update dependency @codemirror/view to v6.39.4 [[#1732](https://github.com/opencloud-eu/web/pull/1732)]
+- fix(deps): update dependency vue-router to v4.6.4 [[#1743](https://github.com/opencloud-eu/web/pull/1743)]
 - fix(deps): update dependency @sentry/vue to v10.30.0 [[#1737](https://github.com/opencloud-eu/web/pull/1737)]
 - chore(deps): update node.js to v24.12.0 [[#1734](https://github.com/opencloud-eu/web/pull/1734)]
 - chore(deps): update devdependencies (non-major) [[#1742](https://github.com/opencloud-eu/web/pull/1742)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `4.3.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [4.3.0](https://github.com/opencloud-eu/web/releases/tag/v4.3.0) - 2025-12-15

### 🔒 Security

- chore(deps): bump mdast-util-to-hast to 13.2.1 (security) [[#1692](https://github.com/opencloud-eu/web/pull/1692)]
- chore: bump sub-dependencies that cause vulnerability alerts [[#1653](https://github.com/opencloud-eu/web/pull/1653)]

### ✅ Tests

- [tests-only] correct release PR condition to use build.sender [[#1736](https://github.com/opencloud-eu/web/pull/1736)]
- [tests-only] skip unit and e2e test pipelines on ready-release-go prs [[#1714](https://github.com/opencloud-eu/web/pull/1714)]
- e2e-tests. undo deleted resources [[#1580](https://github.com/opencloud-eu/web/pull/1580)]
- e2e-test. download folder on public link [[#1531](https://github.com/opencloud-eu/web/pull/1531)]
- check user avatar in the admin settings->users [[#1510](https://github.com/opencloud-eu/web/pull/1510)]

### 🐛 Bug Fixes

- fix(design-system): remove tailwind reference in bundled css [[#1728](https://github.com/opencloud-eu/web/pull/1728)]
- fix: add missing drag styling in tiles view [[#1645](https://github.com/opencloud-eu/web/pull/1645)]
- fix: embed mode click behavior [[#1641](https://github.com/opencloud-eu/web/pull/1641)]
- fix: hide calendar when env var FRONTEND_DISABLE_RADICALE is set to true [[#1660](https://github.com/opencloud-eu/web/pull/1660)]
- fix: move folder replace [[#1627](https://github.com/opencloud-eu/web/pull/1627)]
- fix: editing and loading tags for received shares [[#1650](https://github.com/opencloud-eu/web/pull/1650)]
- fix: catching errors in sse events [[#1654](https://github.com/opencloud-eu/web/pull/1654)]
- fix: missing versions when closing and re-opening sidebar [[#1602](https://github.com/opencloud-eu/web/pull/1602)]
- fix: embed actions z-index [[#1610](https://github.com/opencloud-eu/web/pull/1610)]
- fix: version downloads and remove downloadUrl dav property default [[#1559](https://github.com/opencloud-eu/web/pull/1559)]
- fix: copying created links in Safari [[#1594](https://github.com/opencloud-eu/web/pull/1594)]
- fix: prevent undo delete multiple times for same file [[#1587](https://github.com/opencloud-eu/web/pull/1587)]
- fix: initial default favicon [[#1584](https://github.com/opencloud-eu/web/pull/1584)]
- fix: add missing file list update after undo delete in space [[#1561](https://github.com/opencloud-eu/web/pull/1561)]
- bug: hide addtional calendar data, if radicale is not set up [[#1573](https://github.com/opencloud-eu/web/pull/1573)]
- fix: lazy loading indicator in condensed resource table [[#1572](https://github.com/opencloud-eu/web/pull/1572)]
- fix: endless propfind requests when opening public links authenticated [[#1534](https://github.com/opencloud-eu/web/pull/1534)]
- fix: archive download on password protected links [[#1523](https://github.com/opencloud-eu/web/pull/1523)]
- bug: allow clipboard access to collabora [[#1569](https://github.com/opencloud-eu/web/pull/1569)]
- fix: translation string typos [[#1564](https://github.com/opencloud-eu/web/pull/1564)]
- fix: remove horizontal scrollbar when opening upload menu [[#1562](https://github.com/opencloud-eu/web/pull/1562)]
- fix: account preferences page, left sidebar won't be translated on language change [[#1554](https://github.com/opencloud-eu/web/pull/1554)]
- fix: avoid flicker on CalDAV check [[#1538](https://github.com/opencloud-eu/web/pull/1538)]
- fix: private link doesn't reliably open default app [[#1527](https://github.com/opencloud-eu/web/pull/1527)]
- fix: only render drop content when opened [[#1498](https://github.com/opencloud-eu/web/pull/1498)]
- fix: space batch actions not loading in spaces table [[#1517](https://github.com/opencloud-eu/web/pull/1517)]
- fix: bottom drawer 'New'-menus appearance [[#1494](https://github.com/opencloud-eu/web/pull/1494)]
- revert: "Update Font Metadata2 (#1488)" [[#1507](https://github.com/opencloud-eu/web/pull/1507)]
- fix: adjust headline sizes across the webui [[#1504](https://github.com/opencloud-eu/web/pull/1504)]

### 📈 Enhancement

- feat: add photo roll to preview app  [[#1699](https://github.com/opencloud-eu/web/pull/1699)]
- feat: render readme.md file at the top of folder [[#1708](https://github.com/opencloud-eu/web/pull/1708)]
- feat: add inlineLabel and hasBorder props to OcTextInput and OCSelect [[#1707](https://github.com/opencloud-eu/web/pull/1707)]
- feat(preview): add support for mov video files [[#1705](https://github.com/opencloud-eu/web/pull/1705)]
- feat: add floating action button [[#1688](https://github.com/opencloud-eu/web/pull/1688)]
- feat: replace extension and gdpr icon in preference menu [[#1683](https://github.com/opencloud-eu/web/pull/1683)]
- feat: implement mail account switcher [[#1677](https://github.com/opencloud-eu/web/pull/1677)]
- feat: show empty trash bin icon at quick action if trash is empty [[#1647](https://github.com/opencloud-eu/web/pull/1647)]
- feat: share links and passwords in embed mode [[#1613](https://github.com/opencloud-eu/web/pull/1613)]
- Introduce mail app [[#1382](https://github.com/opencloud-eu/web/pull/1382)]

### 📦️ Dependencies

- chore(deps): update dependency @codemirror/view to v6.39.4 [[#1732](https://github.com/opencloud-eu/web/pull/1732)]
- fix(deps): update dependency vue-router to v4.6.4 [[#1743](https://github.com/opencloud-eu/web/pull/1743)]
- fix(deps): update dependency @sentry/vue to v10.30.0 [[#1737](https://github.com/opencloud-eu/web/pull/1737)]
- chore(deps): update node.js to v24.12.0 [[#1734](https://github.com/opencloud-eu/web/pull/1734)]
- chore(deps): update devdependencies (non-major) [[#1742](https://github.com/opencloud-eu/web/pull/1742)]
- chore(deps): update dependency @codemirror/view to v6.39.1 [[#1730](https://github.com/opencloud-eu/web/pull/1730)]
- chore(deps): update dependency dompurify to v3.3.1 [[#1721](https://github.com/opencloud-eu/web/pull/1721)]
- chore(deps): update typescript-eslint monorepo to v8.49.0 [[#1724](https://github.com/opencloud-eu/web/pull/1724)]
- chore(deps): update dependency md-editor-v3 to v6.2.1 [[#1726](https://github.com/opencloud-eu/web/pull/1726)]
- chore(deps): update dependency @codemirror/view to v6.39.1 [[#1725](https://github.com/opencloud-eu/web/pull/1725)]
- chore(deps): update devdependencies (non-major) [[#1722](https://github.com/opencloud-eu/web/pull/1722)]
- fix(deps): update uppy monorepo [[#1729](https://github.com/opencloud-eu/web/pull/1729)]
- chore(deps): update pnpm to v10.25.0 [[#1723](https://github.com/opencloud-eu/web/pull/1723)]
- chore(deps): update traefik docker tag to v3.6.4 [[#1716](https://github.com/opencloud-eu/web/pull/1716)]
- chore(deps): update devdependencies (non-major) [[#1717](https://github.com/opencloud-eu/web/pull/1717)]
- fix(deps): update dependency @sentry/vue to v10.29.0 [[#1712](https://github.com/opencloud-eu/web/pull/1712)]
- fix(deps): update dependency @sentry/vue to v10.28.0 [[#1697](https://github.com/opencloud-eu/web/pull/1697)]
- chore(deps): update dependency @panzoom/panzoom to v4.6.1 [[#1698](https://github.com/opencloud-eu/web/pull/1698)]
- chore(deps): update typescript-eslint monorepo to v8.48.1 [[#1693](https://github.com/opencloud-eu/web/pull/1693)]
- fix(deps): update uppy monorepo [[#1695](https://github.com/opencloud-eu/web/pull/1695)]
- chore(deps): update devdependencies (non-major) [[#1690](https://github.com/opencloud-eu/web/pull/1690)]
- update-playwright-1.57 [[#1709](https://github.com/opencloud-eu/web/pull/1709)]
- fix(deps): update dependency password-sheriff to v2 [[#1701](https://github.com/opencloud-eu/web/pull/1701)]
- chore(deps): update collabora/code docker tag to v25.04.7.3.1 [[#1684](https://github.com/opencloud-eu/web/pull/1684)]
- chore(deps): update dependency vite to v7.2.6 [[#1689](https://github.com/opencloud-eu/web/pull/1689)]
- chore(deps): update devdependencies (non-major) [[#1686](https://github.com/opencloud-eu/web/pull/1686)]
- chore(deps): update devdependencies (non-major) [[#1652](https://github.com/opencloud-eu/web/pull/1652)]
- chore(deps): update typescript-eslint monorepo to v8.48.0 [[#1673](https://github.com/opencloud-eu/web/pull/1673)]
- chore(deps): update dependency password-sheriff to v1.3.1 [[#1672](https://github.com/opencloud-eu/web/pull/1672)]
- chore(deps): update ghcr.io/stalwartlabs/stalwart docker tag to v0.14.1 [[#1541](https://github.com/opencloud-eu/web/pull/1541)]
- chore(deps): update dependency eslint-plugin-vue to v10.6.2 [[#1664](https://github.com/opencloud-eu/web/pull/1664)]
- fix(deps): update dependency @sentry/vue to v10.27.0 [[#1674](https://github.com/opencloud-eu/web/pull/1674)]
- chore(deps): update dependency @vueuse/core to v14.1.0 [[#1676](https://github.com/opencloud-eu/web/pull/1676)]
- fix(deps): update vue monorepo to v3.5.25 [[#1669](https://github.com/opencloud-eu/web/pull/1669)]
- fix(deps): update dependency zod to v4.1.13 [[#1667](https://github.com/opencloud-eu/web/pull/1667)]
- chore(deps): update pnpm to v10.24.0 [[#1656](https://github.com/opencloud-eu/web/pull/1656)]
- chore(deps): update dependency md-editor-v3 to v6.2.0 [[#1648](https://github.com/opencloud-eu/web/pull/1648)]
- fix(deps): update dependency @sentry/vue to v10.26.0 [[#1649](https://github.com/opencloud-eu/web/pull/1649)]
- chore(deps): update dependency glob to v13 [[#1651](https://github.com/opencloud-eu/web/pull/1651)]
- chore(deps): update dependency @cucumber/messages to v31 [[#1644](https://github.com/opencloud-eu/web/pull/1644)]
- chore(deps): update dependency @vitejs/plugin-vue to v6.0.2 [[#1632](https://github.com/opencloud-eu/web/pull/1632)]
- chore(deps): update traefik docker tag to v3.6.2 [[#1643](https://github.com/opencloud-eu/web/pull/1643)]
- chore(deps): update dependency oidc-client-ts to v3.4.1 [[#1570](https://github.com/opencloud-eu/web/pull/1570)]
- fix(deps): update dependency p-queue to v9.0.1 [[#1640](https://github.com/opencloud-eu/web/pull/1640)]
- chore(deps): update typescript-eslint monorepo to v8.47.0 [[#1633](https://github.com/opencloud-eu/web/pull/1633)]
- chore(deps): update dependency glob to v12 [[#1634](https://github.com/opencloud-eu/web/pull/1634)]
- chore(deps): update collabora/code docker tag to v25.04.7.2.1 [[#1631](https://github.com/opencloud-eu/web/pull/1631)]
- chore(deps): update devdependencies (non-major) to v4.0.10 [[#1625](https://github.com/opencloud-eu/web/pull/1625)]
- chore(deps): update dependency @codemirror/view to v6.38.8 [[#1622](https://github.com/opencloud-eu/web/pull/1622)]
- chore(deps): update dependency vue-tsc to v3.1.4 [[#1621](https://github.com/opencloud-eu/web/pull/1621)]
- chore(deps): update dependency @codemirror/view to v6.38.7 [[#1619](https://github.com/opencloud-eu/web/pull/1619)]
- chore(deps): update devdependencies (non-major) to v4.0.9 [[#1618](https://github.com/opencloud-eu/web/pull/1618)]
- chore(deps): update traefik docker tag to v3.6.1 [[#1614](https://github.com/opencloud-eu/web/pull/1614)]
- chore(deps): update pnpm to v10.22.0 [[#1607](https://github.com/opencloud-eu/web/pull/1607)]
- chore(deps): update dependency jsdom to v27.2.0 [[#1601](https://github.com/opencloud-eu/web/pull/1601)]
- chore(deps): update node.js to v24.11.1 [[#1600](https://github.com/opencloud-eu/web/pull/1600)]
- fix(deps): update dependency @sentry/vue to v10.25.0 [[#1599](https://github.com/opencloud-eu/web/pull/1599)]
- fix(deps): update dependency @sentry/vue to v10.24.0 [[#1574](https://github.com/opencloud-eu/web/pull/1574)]
- chore(deps): update typescript-eslint monorepo to v8.46.4 [[#1581](https://github.com/opencloud-eu/web/pull/1581)]
- chore(deps): update collabora/code docker tag to v25.04.7.1.1 [[#1516](https://github.com/opencloud-eu/web/pull/1516)]
- chore(deps): update devdependencies (non-major) to v4.0.8 [[#1557](https://github.com/opencloud-eu/web/pull/1557)]
- chore(deps): update traefik docker tag to v3.6.0 [[#1566](https://github.com/opencloud-eu/web/pull/1566)]
- chore(deps): update pnpm to v10.21.0 [[#1568](https://github.com/opencloud-eu/web/pull/1568)]
- chore(deps): update dependency password-sheriff to v1.3.0 [[#1560](https://github.com/opencloud-eu/web/pull/1560)]
- fix(deps): update vue monorepo to v3.5.24 [[#1558](https://github.com/opencloud-eu/web/pull/1558)]
- chore(deps): update dependency vite to v7.2.2 [[#1555](https://github.com/opencloud-eu/web/pull/1555)]
- chore(deps): update devdependencies (non-major) to v4.1.17 [[#1533](https://github.com/opencloud-eu/web/pull/1533)]
- chore(deps): update dependency axios to v1.13.2 [[#1537](https://github.com/opencloud-eu/web/pull/1537)]
- fix(deps): update vue monorepo to v3.5.23 [[#1544](https://github.com/opencloud-eu/web/pull/1544)]
- fix(deps): update dependency @sentry/vue to v10.23.0 [[#1542](https://github.com/opencloud-eu/web/pull/1542)]
- fix(deps): update dependency pinia to v3.0.4 [[#1532](https://github.com/opencloud-eu/web/pull/1532)]
- chore(deps): update dependency @pinia/testing to v1.0.3 [[#1524](https://github.com/opencloud-eu/web/pull/1524)]
- chore(deps): update dependency pinia to v3.0.4 [[#1525](https://github.com/opencloud-eu/web/pull/1525)]
- fix(deps): update dependency axios to v1.13.2 - autoclosed [[#1515](https://github.com/opencloud-eu/web/pull/1515)]
- chore(deps): update devdependencies (non-major) to v4.0.7 [[#1514](https://github.com/opencloud-eu/web/pull/1514)]
- chore(deps): update dependency eslint to v9.39.1 [[#1503](https://github.com/opencloud-eu/web/pull/1503)]
- chore(deps): update typescript-eslint monorepo to v8.46.3 [[#1502](https://github.com/opencloud-eu/web/pull/1502)]
- [full-ci] bump-opencloud-3.7.0. run all tests [[#1500](https://github.com/opencloud-eu/web/pull/1500)]
- chore(deps): update dependency md-editor-v3 to v6.1.1 [[#1493](https://github.com/opencloud-eu/web/pull/1493)]
- fix(deps): update dependency @uppy/utils to v7.1.3 [[#1496](https://github.com/opencloud-eu/web/pull/1496)]