### PR TITLE
[stable-4.2] check user avatar in the admin settings->users (#1510)

### DIFF
--- a/tests/e2e/cucumber/features/user-settings/profilePhoto.feature
+++ b/tests/e2e/cucumber/features/user-settings/profilePhoto.feature
@@ -12,6 +12,12 @@ Feature: profile photo
     When "Alice" uploads the profile image "testavatar.jpeg"
     Then "Alice" should have a profile picture
 
+    And "Admin" logs in
+    And "Admin" opens the "admin-settings" app
+    When "Admin" navigates to the users management page
+    Then "Admin" sees profile photo of the user "Alice"
+    And "Admin" logs out
+
     When "Alice" changes the profile image "testavatar.png"
     Then "Alice" should have a profile picture
 

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -552,3 +552,13 @@ When(
     await spacesObject.select({ key: value })
   }
 )
+
+Then(
+  '{string} sees profile photo of the user {string}',
+  async function (this: World, stepUser: string, key: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const usersObject = new objects.applicationAdminSettings.Users({ page })
+    const userProfilePicture = usersObject.getUserProfilePicture({ key })
+    await expect(userProfilePicture).toHaveAttribute('src', /.+/)
+  }
+)

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { Page, Locator } from '@playwright/test'
 import util from 'util'
 import { UsersEnvironment } from '../../../environment'
 
@@ -34,6 +34,7 @@ const userNameInput = '#create-user-input-user-name'
 const displayNameInput = '#create-user-input-display-name'
 const emailInput = '#create-user-input-email'
 const passwordInput = '#create-user-input-password'
+const userAvatarImg = `[data-item-id="%s"] .oc-avatar .avatarImg`
 
 export interface UserInterface {
   displayName: string
@@ -424,4 +425,9 @@ export const waitForEditPanelToBeVisible = async (args: { page: Page }): Promise
 const getGroupId = (group: string): string => {
   const usersEnvironment = new UsersEnvironment()
   return usersEnvironment.getCreatedGroupByDisplayName(group).uuid
+}
+
+export const getUserProfilePicture = (args: { page: Page; uuid: string }): Locator => {
+  const { page, uuid } = args
+  return page.locator(util.format(userAvatarImg, uuid))
 }

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { Page, Locator } from '@playwright/test'
 import { UsersEnvironment } from '../../../environment'
 import * as po from './actions'
 
@@ -185,5 +185,9 @@ export class Users {
 
   async waitForEditPanelToBeVisible(): Promise<void> {
     await po.waitForEditPanelToBeVisible({ page: this.#page })
+  }
+
+  getUserProfilePicture({ key }: { key: string }): Locator {
+    return po.getUserProfilePicture({ page: this.#page, uuid: this.getUUID({ key }) })
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [check user avatar in the admin settings->users (#1510)](https://github.com/opencloud-eu/web/pull/1510)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)