### PR TITLE
[stable-4.2] fix: space batch actions not loading in spaces table

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -672,7 +672,7 @@ export default defineComponent({
 
     const toggleSelection = (resourceId: string) => {
       resourcesStore.toggleSelection(resourceId)
-      emitSelect(resourcesStore.selectedIds)
+      emitSelect([...resourcesStore.selectedIds])
     }
 
     const getResourceLink = (resource: Resource) => {

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -496,10 +496,8 @@ const toggleTile = (data: [Resource, MouseEvent | KeyboardEvent], event?: MouseE
 }
 
 const toggleSelection = (resource: Resource) => {
-  const selected = !isResourceSelected(resource)
-    ? [...selectedIds, resource.id]
-    : selectedIds.filter((id) => id !== resource.id)
-  emit('update:selectedIds', selected)
+  resourcesStore.toggleSelection(resource.id)
+  emit('update:selectedIds', [...resourcesStore.selectedIds])
 }
 
 const getResourceCheckboxLabel = (resource: Resource) => {

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -8,6 +8,7 @@ import { useCanBeOpenedWithSecureView } from '../../../../src/composables/resour
 import { displayPositionedDropdown } from '../../../../src/helpers/contextMenuDropdown'
 import { OcFilterChip } from '@opencloud-eu/design-system/components'
 import { ResourceIndicator } from '../../../../src/helpers/statusIndicators'
+import { useResourcesStore } from '../../../../src'
 
 vi.mock('../../../../src/helpers/contextMenuDropdown')
 vi.mock('../../../../src/composables/viewMode', async (importOriginal) => ({
@@ -120,6 +121,8 @@ describe('ResourceTiles component', () => {
         preventDefault: vi.fn()
       } as unknown as MouseEvent
 
+      const resourcesStore = useResourcesStore()
+      resourcesStore.selectedIds = [resources[0].id]
       await resourceTile.vm.$emit('click', mockMouseEvent)
       expect(wrapper.emitted('update:selectedIds')).toBeTruthy()
       expect(wrapper.emitted('update:selectedIds')[0][0]).toEqual([resources[0].id])


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [fix: space batch actions not loading in spaces table](https://github.com/opencloud-eu/web/pull/1517)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)