### PR TITLE
fix: archive download on password protected links

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -13,13 +13,14 @@ import { FileAction, FileActionOptions } from '../types'
 import { useGettext } from 'vue3-gettext'
 import { useArchiverService } from '../../archiverService'
 import { formatFileSize } from '../../../helpers/filesize'
-import { useMessages } from '../../piniaStores'
+import { useAuthStore, useMessages } from '../../piniaStores'
 
 export const useFileActionsDownloadArchive = () => {
   const { showErrorMessage } = useMessages()
   const router = useRouter()
   const archiverService = useArchiverService()
   const { $ngettext, $gettext, current } = useGettext()
+  const authStore = useAuthStore()
   const isFilesAppActive = useIsFilesAppActive()
 
   const handler = ({ space, resources }: FileActionOptions) => {
@@ -34,7 +35,8 @@ export const useFileActionsDownloadArchive = () => {
         fileIds: resources.map((resource) => resource.fileId),
         ...(space &&
           isPublicSpaceResource(space) && {
-            publicToken: space.id
+            publicToken: space.id,
+            publicLinkPassword: authStore.publicLinkPassword
           })
       })
       .catch((e) => {


### PR DESCRIPTION
Undo the change from https://github.com/opencloud-eu/web/commit/c7072a70ad872b0679480bba0f089f8fc5079b8f for password protected links for now, until we ditch client-side signing.

refs https://github.com/opencloud-eu/opencloud/issues/1712