### PR TITLE
[stable-4.2] fix: private link doesn't reliably open default app

### DIFF
--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -75,6 +75,7 @@
 import {
   FolderView,
   ResourceTable,
+  SortField,
   useCapabilityStore,
   useConfigStore,
   useFileActions,
@@ -93,8 +94,6 @@ import { useSelectedResources } from '@opencloud-eu/web-pkg'
 import { RouteLocationNamedRaw } from 'vue-router'
 import { CreateTargetRouteOptions } from '@opencloud-eu/web-pkg'
 import { createFileRouteOptions } from '@opencloud-eu/web-pkg'
-import { useResourcesViewDefaults } from '../../composables'
-import { folderViewsSharedWithMeExtensionPoint } from '../../extensionPoints'
 
 export default defineComponent({
   components: {
@@ -161,6 +160,18 @@ export default defineComponent({
       type: Number,
       default: 0
     },
+    viewMode: {
+      type: String,
+      required: true
+    },
+    viewSize: {
+      type: Number,
+      required: true
+    },
+    sortFields: {
+      type: Object as PropType<SortField[]>,
+      required: true
+    },
 
     /**
      * This is only relevant for CERN and can be ignored in any other cases.
@@ -171,16 +182,12 @@ export default defineComponent({
       default: null
     }
   },
-  setup() {
+  setup(props) {
     const capabilityStore = useCapabilityStore()
     const configStore = useConfigStore()
     const { getMatchingSpace } = useGetMatchingSpace()
 
-    const { viewMode, viewSize, sortFields } = useResourcesViewDefaults({
-      folderViewExtensionPoint: folderViewsSharedWithMeExtensionPoint
-    })
-
-    const { loadPreview } = useLoadPreview(viewMode)
+    const { loadPreview } = useLoadPreview(computed(() => props.viewMode))
 
     const { triggerDefaultAction } = useFileActions()
     const { actions: hideShareActions } = useFileActionsToggleHideShare()
@@ -214,10 +221,7 @@ export default defineComponent({
       updateResourceField,
       isExternalShare,
       ShareTypes,
-      loadPreview,
-      viewMode,
-      viewSize,
-      sortFields
+      loadPreview
     }
   },
 

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -79,6 +79,9 @@
             areHiddenFilesShown ? $gettext('No hidden shares') : $gettext('No shares')
           "
           :grouping-settings="groupingSettings"
+          :view-mode="viewMode"
+          :view-size="viewSize"
+          :sort-fields="sortFields"
         />
       </template>
     </files-view-wrapper>

--- a/tests/e2e/cucumber/features/navigation/shortcut.feature
+++ b/tests/e2e/cucumber/features/navigation/shortcut.feature
@@ -50,9 +50,8 @@ Feature: Users can create shortcuts for resources and sites
       | resource       | name | type |
       | testavatar.jpg | logo | file |
     And "Brian" opens a shortcut "logo.url"
-    # issue #1360
-    # Then "Brian" is in a media-viewer
-    # And "Brian" closes the file viewer
+    Then "Brian" is in a media-viewer
+    And "Brian" closes the file viewer
 
     # create a shortcut to the public link
     When "Brian" opens the "files" app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [fix: private link doesn't reliably open default app](https://github.com/opencloud-eu/web/pull/1527)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)