### PR TITLE
fix: endless propfind requests when opening public links authenticated

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -215,7 +215,6 @@ export const useSpacesStore = defineStore('spaces', () => {
       ])
 
       addSpaces([...personalSpaces, ...projectSpaces])
-      spacesInitialized.value = true
     } finally {
       spacesLoading.value = false
     }

--- a/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
+++ b/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
@@ -9,6 +9,7 @@ import { useClientService } from '../clientService'
 import { urlJoin } from '@opencloud-eu/web-client'
 import { useSpacesStore } from '../piniaStores'
 import { DavProperty } from '@opencloud-eu/web-client/webdav'
+import { useTask } from 'vue-concurrency'
 
 export const useGetResourceContext = () => {
   const clientService = useClientService()
@@ -25,7 +26,7 @@ export const useGetResourceContext = () => {
     )
   }
 
-  const loadFileInfoById = (fileId: string) => {
+  const loadFileInfoById = (fileId: string, signal?: AbortSignal) => {
     const davProperties = [
       DavProperty.FileId,
       DavProperty.FileParent,
@@ -34,32 +35,32 @@ export const useGetResourceContext = () => {
     ]
 
     const tmpSpace = buildSpace({ id: fileId, name: '' })
-    return clientService.webdav.getFileInfo(tmpSpace, { fileId }, { davProperties })
+    return clientService.webdav.getFileInfo(tmpSpace, { fileId }, { davProperties, signal })
   }
 
   // get context for a resource when only having its id. be careful, this might be very expensive!
-  const getResourceContext = async (id: string) => {
+  const resourceContextTask = useTask(function* (signal, id) {
     let path: string
     let resource: Resource
     let space = getMatchingSpaceByFileId(id)
 
     if (space) {
-      path = await clientService.webdav.getPathForFileId(id)
-      resource = await clientService.webdav.getFileInfo(space, { path })
+      path = yield clientService.webdav.getPathForFileId(id, { signal })
+      resource = yield clientService.webdav.getFileInfo(space, { path }, { signal })
       return { space, resource, path }
     }
 
     // no matching space found => the file doesn't lie in own spaces => it's a share.
     // do PROPFINDs on parents until root of accepted share is found in `mountpoint` spaces
-    await spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
+    yield spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated, signal })
 
     let mountPoint = getMatchingMountPoint(id)
-    resource = await loadFileInfoById(id)
+    resource = yield loadFileInfoById(id, signal)
     const sharePathSegments = mountPoint ? [] : [unref(resource).name]
     let tmpResource = unref(resource)
 
     while (!mountPoint) {
-      tmpResource = await loadFileInfoById(tmpResource.parentFolderId)
+      tmpResource = yield loadFileInfoById(tmpResource.parentFolderId, signal)
       mountPoint = getMatchingMountPoint(tmpResource.id)
       if (!mountPoint) {
         sharePathSegments.unshift(tmpResource.name)
@@ -76,6 +77,11 @@ export const useGetResourceContext = () => {
 
     path = urlJoin(...sharePathSegments)
     return { space, resource, path }
+  }).restartable()
+
+  // get context for a resource when only having its id. be careful, this might be very expensive!
+  const getResourceContext = (id: string) => {
+    return resourceContextTask.perform(id)
   }
 
   return {

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -200,7 +200,6 @@ describe('spaces', () => {
           )
           expect(instance.spaces.length).toBe(2)
           expect(instance.spacesLoading).toBeFalsy()
-          expect(instance.spacesInitialized).toBeTruthy()
         }
       })
     })


### PR DESCRIPTION
This issue was introduced by the authenticated config loading because it delayed the space loading. This change makes sure both things happen in parallel. I only needed to extract `spacesInitialized` so it can be set outside of `loadSpaces`.

Additionally, changes the `getResourceContext` method to a task so it gets cancelled on unmount, reducing the likelihood of such an endless loop even more.

fixes https://github.com/opencloud-eu/web/issues/1512