### PR TITLE
fix: mail i18n resource name

### DIFF
--- a/packages/web-app-mail/l10n/.tx/config
+++ b/packages/web-app-mail/l10n/.tx/config
@@ -1,10 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:opencloud-eu:p:opencloud-eu:r:web-app-mail]
+[o:opencloud-eu:p:opencloud-eu:r:web-mail]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
-resource_name = web-app-mail
+resource_name = web-mail
 source_file = template.pot
 source_lang = en
 type = PO


### PR DESCRIPTION
Fixes the transifex resource name for the mail app.

I also fixed the resource name of the existing resource on transifex manually.