### PR TITLE
[stable-4.2] chore: disable echarts in markdown editor followup (#1548)

### DIFF
--- a/packages/web-pkg/src/components/TextEditor/TextEditor.vue
+++ b/packages/web-pkg/src/components/TextEditor/TextEditor.vue
@@ -28,6 +28,7 @@
       no-mermaid
       no-prettier
       no-highlight
+      no-echarts
       :on-upload-img="onUploadImg"
       :language="languages[language.current] || 'en-US'"
       :theme="theme"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [chore: disable echarts in markdown editor followup (#1548)](https://github.com/opencloud-eu/web/pull/1548)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)