### PR TITLE
bug: hide addtional calendar data, if radicale is not set up

### DIFF
--- a/packages/web-runtime/src/pages/account/accountCalendar.vue
+++ b/packages/web-runtime/src/pages/account/accountCalendar.vue
@@ -24,64 +24,66 @@
           <span v-text="$gettext('here')" />
         </oc-button>
       </span>
-      <p
-        class="text-sm mt-0 mb-4"
-        v-text="
-          $gettext(
-            'Here, you can access your personal calendar for integration with third-party apps like Thunderbird, Apple Calendar, and others.'
-          )
-        "
-      />
-      <account-table
-        :fields="[
-          $gettext('CalDAV information name'),
-          $gettext('CalCAV information value'),
-          $gettext('CalCAV information actions')
-        ]"
-      >
-        <oc-table-tr>
-          <oc-table-td>{{ $gettext('CalDAV URL') }}</oc-table-td>
-          <oc-table-td>
-            <span class="truncate">{{ configStore.serverUrl }}</span>
-          </oc-table-td>
-          <oc-table-td>
-            <oc-button
-              appearance="raw"
-              data-testid="copy-caldav-url"
-              size="small"
-              no-hover
-              @click="copyCalDavUrlToClipboard"
-            >
-              <oc-icon :name="copyCalDavUrlIcon" size="small" />
-              <span class="ml-0.5">{{ $gettext('Copy CalDAV URL') }}</span>
-            </oc-button>
-          </oc-table-td>
-        </oc-table-tr>
-        <oc-table-tr>
-          <oc-table-td>{{ $gettext('Username') }}</oc-table-td>
-          <oc-table-td>
-            <span>{{ user.onPremisesSamAccountName }}</span>
-          </oc-table-td>
-          <oc-table-td>
-            <oc-button
-              appearance="raw"
-              data-testid="copy-caldav-username"
-              size="small"
-              no-hover
-              @click="copyCalDavUsernameToClipboard"
-            >
-              <oc-icon :name="copyCalDavUsernameIcon" size="small" />
-              <span class="ml-0.5">{{ $gettext('Copy CalDAV username') }}</span>
-            </oc-button>
-          </oc-table-td>
-        </oc-table-tr>
-        <oc-table-tr>
-          <oc-table-td>{{ $gettext('Password') }}</oc-table-td>
-          <oc-table-td colspan="2">
-            {{ $gettext('An app token needs to be generated and then can be used.') }}
-          </oc-table-td>
-        </oc-table-tr>
-      </account-table>
+      <template v-else>
+        <p
+          class="text-sm mt-0 mb-4"
+          v-text="
+            $gettext(
+              'Here, you can access your personal calendar for integration with third-party apps like Thunderbird, Apple Calendar, and others.'
+            )
+          "
+        />
+        <account-table
+          :fields="[
+            $gettext('CalDAV information name'),
+            $gettext('CalCAV information value'),
+            $gettext('CalCAV information actions')
+          ]"
+        >
+          <oc-table-tr>
+            <oc-table-td>{{ $gettext('CalDAV URL') }}</oc-table-td>
+            <oc-table-td>
+              <span class="truncate">{{ configStore.serverUrl }}</span>
+            </oc-table-td>
+            <oc-table-td>
+              <oc-button
+                appearance="raw"
+                data-testid="copy-caldav-url"
+                size="small"
+                no-hover
+                @click="copyCalDavUrlToClipboard"
+              >
+                <oc-icon :name="copyCalDavUrlIcon" size="small" />
+                <span class="ml-0.5">{{ $gettext('Copy CalDAV URL') }}</span>
+              </oc-button>
+            </oc-table-td>
+          </oc-table-tr>
+          <oc-table-tr>
+            <oc-table-td>{{ $gettext('Username') }}</oc-table-td>
+            <oc-table-td>
+              <span>{{ user.onPremisesSamAccountName }}</span>
+            </oc-table-td>
+            <oc-table-td>
+              <oc-button
+                appearance="raw"
+                data-testid="copy-caldav-username"
+                size="small"
+                no-hover
+                @click="copyCalDavUsernameToClipboard"
+              >
+                <oc-icon :name="copyCalDavUsernameIcon" size="small" />
+                <span class="ml-0.5">{{ $gettext('Copy CalDAV username') }}</span>
+              </oc-button>
+            </oc-table-td>
+          </oc-table-tr>
+          <oc-table-tr>
+            <oc-table-td>{{ $gettext('Password') }}</oc-table-td>
+            <oc-table-td colspan="2">
+              {{ $gettext('An app token needs to be generated and then can be used.') }}
+            </oc-table-td>
+          </oc-table-tr>
+        </account-table>
+      </template>
     </template>
   </div>
 </template>


### PR DESCRIPTION
## Description

This PR hides calendar setup details on the user preferences calendar page if Radicale is not configured/running. This avoids confusion among users who try to connect a third party calendar app although Radicale not running.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
