### PR TITLE
[stable-4.2] fix: archive download on password protected links

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -13,13 +13,14 @@ import { FileAction, FileActionOptions } from '../types'
 import { useGettext } from 'vue3-gettext'
 import { useArchiverService } from '../../archiverService'
 import { formatFileSize } from '../../../helpers/filesize'
-import { useMessages } from '../../piniaStores'
+import { useAuthStore, useMessages } from '../../piniaStores'
 
 export const useFileActionsDownloadArchive = () => {
   const { showErrorMessage } = useMessages()
   const router = useRouter()
   const archiverService = useArchiverService()
   const { $ngettext, $gettext, current } = useGettext()
+  const authStore = useAuthStore()
   const isFilesAppActive = useIsFilesAppActive()
 
   const handler = ({ space, resources }: FileActionOptions) => {
@@ -34,7 +35,8 @@ export const useFileActionsDownloadArchive = () => {
         fileIds: resources.map((resource) => resource.fileId),
         ...(space &&
           isPublicSpaceResource(space) && {
-            publicToken: space.id
+            publicToken: space.id,
+            publicLinkPassword: authStore.publicLinkPassword
           })
       })
       .catch((e) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [fix: archive download on password protected links](https://github.com/opencloud-eu/web/pull/1523)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)