### PR TITLE
e2e-tests. undo deleted resources

### DIFF
--- a/tests/e2e/cucumber/features/file-action/delete.feature
+++ b/tests/e2e/cucumber/features/file-action/delete.feature
@@ -54,3 +54,54 @@ Feature: Delete
       | resource         |
       | textfile.txt |
     And "Alice" logs out
+
+  
+  Scenario: quick restore deleted files
+    Given "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following folder in personal space using API
+      | name      |
+      | my-folder |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile      | to                   |
+      | testavatar.jpg | testavatar.jpg       |
+      | simple.pdf     | my-folder/simple.pdf |
+    And "Alice" creates the following project spaces using API
+      | name    | id      |
+      | mySpace | mySpace |
+    And "Alice" creates the following folder in space "mySpace" using API
+      | name        |
+      | spaceFolder |
+    And "Alice" creates the following file in space "mySpace" using API
+      | name          | content      |
+      | spaceFile.txt | test content |
+    
+    When "Alice" logs in
+    And "Alice" deletes and immediately undoes the following resource using "undo button"
+      | resource       |
+      | testavatar.jpg |
+    And "Alice" deletes and immediately undoes the following resources using "keyboard"
+      | resource       |
+      | testavatar.jpg |
+      | my-folder      |
+    And following resources should be displayed in the files list for user "Alice"
+      | resource       |
+      | testavatar.jpg |
+      | my-folder      |
+
+    And "Alice" navigates to the project space "mySpace"
+    And "Alice" deletes and immediately undoes the following resources using "undo button"
+      | resource       |
+      | spaceFile.txt  |
+      | spaceFolder    |
+
+    And "Alice" deletes and immediately undoes the following resources using "keyboard"
+      | resource      |
+      | spaceFile.txt |
+      | spaceFolder   |
+    And following resources should be displayed in the files list for user "Alice"
+      | resource       |
+      | spaceFile.txt  |
+      | spaceFolder    |
+    And "Alice" logs out

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -1122,3 +1122,25 @@ When(
     await resourceObject.openResourcePanel(panel as PanelType, resource)
   }
 )
+
+When(
+  '{string} deletes and immediately undoes the following resource(s) using {string}',
+  async function (
+    this: World,
+    stepUser: string,
+    method: 'keyboard' | 'undo button',
+    stepTable: DataTable
+  ): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    const resources = stepTable.hashes().map((row) => ({
+      name: row.resource
+    }))
+
+    await resourceObject.deleteAndUndoResource({
+      method,
+      resourcesWithInfo: resources,
+      via: 'BATCH_ACTION'
+    })
+  }
+)

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -66,7 +66,6 @@ export class Resource {
     const startUrl = this.#page.url()
     const downloads = await po.downloadResources({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
-
     return downloads
   }
 
@@ -416,5 +415,20 @@ export class Resource {
 
   async openResourcePanel(panel: PanelType, resource: string): Promise<void> {
     await po.openResourcePanel({ page: this.#page, resource, panel })
+  }
+
+  async deleteAndUndoResource(args: {
+    method: 'keyboard' | 'undo button'
+    resourcesWithInfo: po.resourceArgs[]
+    via: po.ActionViaType
+    folder?: string
+  }): Promise<void> {
+    await po.deleteAndUndo({
+      page: this.#page,
+      method: args.method,
+      resourcesWithInfo: args.resourcesWithInfo,
+      via: args.via,
+      folder: args.folder
+    })
   }
 }


### PR DESCRIPTION
test for feature #1357

- undo deleted files in the personal and project spaces
- by pressing `undo` button or `cmd+z`
- check restoring single file, multiple files

Notice: 
@JammingBen seems like bug

steps:
- delete file
- restore by press `undo` button
- press cmd+z

Actual: 
<img width="691" height="356" alt="image" src="https://github.com/user-attachments/assets/001baceb-2721-4813-813a-d8dd259681c0" />

web tries to restore file again but fails when `keep both` is selected
<img width="1506" height="835" alt="image" src="https://github.com/user-attachments/assets/d229a532-64ec-4522-a5ef-7568744f8809" />


