### PR TITLE
[stable-4.2] fix: lazy loading indicator in condensed resource table

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -1457,7 +1457,7 @@ export default defineComponent({
     max-width: calc(100% - 4 * var(--spacing));
   }
   .oc-table.condensed > tbody > tr {
-    @apply h-0;
+    @apply h-8;
   }
 }
 </style>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [fix: lazy loading indicator in condensed resource table](https://github.com/opencloud-eu/web/pull/1572)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)