### PR TITLE
fix: prevent undo delete multiple times for same file

### DIFF
--- a/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
+++ b/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
@@ -86,6 +86,7 @@ export const useFileActionsDeleteResources = () => {
     const undoAction = unref(undoActions)[0]
     const undoAvailable = undoAction.isVisible({ space, resources: deletedFiles })
 
+    let keyActionId: string | undefined
     const message = showMessage({
       title,
       timeout: messageTimeout,
@@ -95,12 +96,15 @@ export const useFileActionsDeleteResources = () => {
         resources: deletedFiles,
         callback: () => {
           removeMessage(message)
+          if (keyActionId) {
+            removeKeyAction(keyActionId)
+          }
         }
       }
     })
 
     if (undoAvailable) {
-      const keyActionId = bindKeyAction({ primary: Key.Z, modifier: Modifier.Ctrl }, () => {
+      keyActionId = bindKeyAction({ primary: Key.Z, modifier: Modifier.Ctrl }, () => {
         removeKeyAction(keyActionId)
         return undoAction.handler({
           space,


### PR DESCRIPTION
This could happen when undoing a delete via the notification and then clicking ctrl/cmd + z.

Fixes what has been reported in PR https://github.com/opencloud-eu/web/pull/1580.