### PR TITLE
feat: share links and passwords in embed mode

### DIFF
--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -270,7 +270,7 @@ const onConfirm = async (options: { copyPassword?: boolean } = {}) => {
     const result = await createLinkHandler()
     const succeeded = result.filter(({ status }) => status === 'fulfilled')
     if (succeeded.length) {
-      // **DEPRECATED**: Always emit the share url for backwards compatibility
+      /** @deprecated Always emit the share url for backwards compatibility */
       postMessage<string[]>(
         'opencloud-embed:share',
         (succeeded as PromiseFulfilledResult<LinkShare>[]).map(({ value }) => value.webUrl)


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

Change the "copy link and password" action in CreateLinkModal in embed mode to actually pass link(s) and password(s) to the parent application.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes #1592
This is not the expected outcome, but I think it's the better solution. The ticket suggest to remove the button, I think it's better to pass the password with the url to the parent application. That way the parent application can insert the password with the link into a chat message or an email.
Yes, second channel would be better - but let's be honest, being forced to use a password in the default configuration is annoying enough for most users (me included).

## How Has This Been Tested?

- using it in a roundcube plugin I'm working on :) 
- easiest way to test this is to replace `postMessage<Array<{ url: string; password?: string }>>` with `console.log` and open OpenCloud with `?embed=true`

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
