### PR TITLE
[stable-4.2] fix: embed actions z-index

### DIFF
--- a/packages/design-system/src/components/OcNotifications/OcNotifications.vue
+++ b/packages/design-system/src/components/OcNotifications/OcNotifications.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="oc-notification z-1040 mb-2 w-md max-w-full"
+    class="oc-notification z-1040 w-md max-w-full"
     :class="{
       fixed: position !== 'default',
       'top-2 left-2': position === 'top-left',

--- a/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
+++ b/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    class="relative z-[calc(var(--z-index-modal)+2)] w-full flex flex-wrap items-center justify-between my-2 text-role-on-chrome gap-2"
+    class="relative w-full flex flex-wrap items-center justify-between my-2 text-role-on-chrome gap-2"
   >
     <oc-text-input
       v-if="chooseFileName"

--- a/packages/web-runtime/src/components/MessageBar.vue
+++ b/packages/web-runtime/src/components/MessageBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <oc-notifications>
+  <oc-notifications :class="{ 'mb-2': limitedMessages.length }">
     <oc-notification-message
       v-for="item in limitedMessages"
       :key="item.id"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [fix: embed actions z-index](https://github.com/opencloud-eu/web/pull/1610)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)