### PR TITLE
[stable-4.2] fix: missing versions when closing and re-opening sidebar

### DIFF
--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -338,6 +338,7 @@ export default defineComponent({
         }
 
         if (!props.isOpen) {
+          currentResourceMtime.value = undefined
           versions.value = []
           return
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [fix: missing versions when closing and re-opening sidebar](https://github.com/opencloud-eu/web/pull/1602)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)