### PR TITLE
[stable-4.2] chore: bump sub-dependencies that cause vulnerability alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ejs": "3.1.10",
     "eslint": "9.39.0",
     "franc-min": "^6.2.0",
-    "glob": "11.0.3",
+    "glob": "13.0.0",
     "happy-dom": "20.0.10",
     "jsdom": "^27.0.0",
     "license-checker-rseidelsohn": "4.4.2",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -123,7 +123,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "@vitejs/plugin-vue": "6.0.1",
     "clean-publish": "^6.0.0",
-    "glob": "^11.0.0",
+    "glob": "^13.0.0",
     "markdown-it-container": "^4.0.0",
     "postcss": "^8.5.2",
     "process": "^0.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       glob:
-        specifier: 11.0.3
-        version: 11.0.3
+        specifier: 13.0.0
+        version: 13.0.0
       happy-dom:
         specifier: 20.0.10
         version: 20.0.10
@@ -264,8 +264,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.1
       glob:
-        specifier: ^11.0.0
-        version: 11.0.3
+        specifier: ^13.0.0
+        version: 13.0.0
       markdown-it-container:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4396,6 +4396,10 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  glob@13.0.0:
+    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
+    engines: {node: 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -5126,8 +5130,8 @@ packages:
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
   minimatch@3.0.8:
@@ -10491,9 +10495,15 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.0.3
+      minimatch: 10.1.1
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+
+  glob@13.0.0:
+    dependencies:
+      minimatch: 10.1.1
+      minipass: 7.1.2
       path-scurry: 2.0.0
 
   glob@7.2.3:
@@ -11218,7 +11228,7 @@ snapshots:
 
   minimalistic-crypto-utils@1.0.1: {}
 
-  minimatch@10.0.3:
+  minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [Merge pull request #1653 from opencloud-eu/chore/glob-security-bumps](https://github.com/opencloud-eu/web/pull/1653)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)