### PR TITLE
[stable-4.2] fix: catching errors in sse events

### DIFF
--- a/packages/web-runtime/src/container/sse/helpers.ts
+++ b/packages/web-runtime/src/container/sse/helpers.ts
@@ -1,12 +1,12 @@
 import { eventSchema, SseEventWrapperOptions } from './types'
 
-export const sseEventWrapper = (options: SseEventWrapperOptions) => {
+export const sseEventWrapper = async (options: SseEventWrapperOptions) => {
   const { topic, msg, method, ...sseEventOptions } = options
   try {
     const sseData = eventSchema.parse(JSON.parse(msg.data))
     console.debug(`SSE event '${topic}'`, sseData)
 
-    return method({ ...sseEventOptions, sseData })
+    await method({ ...sseEventOptions, sseData })
   } catch (e) {
     console.error(`Unable to process sse event ${topic}`, e)
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [Merge pull request #1654 from opencloud-eu/fix/sse-event-errors-catch](https://github.com/opencloud-eu/web/pull/1654)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)