### PR TITLE
[stable-4.2] fix: editing and loading tags for received shares

### DIFF
--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -197,7 +197,8 @@ export function buildResource(
     canEditTags: function () {
       return (
         this.permissions.indexOf(DavPermission.Updateable) >= 0 ||
-        this.permissions.indexOf(DavPermission.FileUpdateable) >= 0
+        this.permissions.indexOf(DavPermission.FileUpdateable) >= 0 ||
+        this.permissions.indexOf(DavPermission.FolderCreateable) >= 0
       )
     },
     isMounted: function () {

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -162,7 +162,7 @@ export function buildIncomingShareResource({
     canUpload: () => sharePermissions.includes(GraphSharePermission.createUpload),
     canCreate: () => sharePermissions.includes(GraphSharePermission.createChildren),
     canBeDeleted: () => sharePermissions.includes(GraphSharePermission.deleteStandard),
-    canEditTags: () => sharePermissions.includes(GraphSharePermission.createChildren),
+    canEditTags: () => sharePermissions.includes(GraphSharePermission.createUpload),
     isMounted: () => false,
     isReceivedShare: () => true,
     canShare: () => false,

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -63,7 +63,8 @@ import {
   isLinkShare,
   isShareSpaceResource,
   isIncomingShareResource,
-  isPersonalSpaceResource
+  isPersonalSpaceResource,
+  isOutgoingShareResource
 } from '@opencloud-eu/web-client'
 import { storeToRefs } from 'pinia'
 import { useTask } from 'vue-concurrency'
@@ -407,7 +408,7 @@ export default defineComponent({
           }
         }
 
-        if (!unref(isShareLocation)) {
+        if (!isOutgoingShareResource(resource) && !isIncomingShareResource(resource)) {
           loadedResource.value = resource
           sharesLoading.value = false
           return


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [Merge pull request #1650 from opencloud-eu/fix/share-tag-edit](https://github.com/opencloud-eu/web/pull/1650)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)