### PR TITLE
[stable-4.2] chore(deps): update dependency md-editor-v3 to v6.2.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,7 +872,7 @@ importers:
         version: 8.11.1
       md-editor-v3:
         specifier: ^6.0.1
-        version: 6.1.0(vue@3.5.22(typescript@5.9.3))
+        version: 6.2.0(vue@3.5.22(typescript@5.9.3))
       oidc-client-ts:
         specifier: ^2.4.0 || ^3.0.0
         version: 3.3.0
@@ -2408,8 +2408,8 @@ packages:
   '@lezer/json@1.0.3':
     resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
 
-  '@lezer/lr@1.4.2':
-    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+  '@lezer/lr@1.4.3':
+    resolution: {integrity: sha512-yenN5SqAxAPv/qMnpWW0AT7l+SxVrgG+u0tNsRQWqbrz66HIl8DnEbBObvy21J5K7+I1v7gsAnlE2VQ5yYVSeA==}
 
   '@lezer/markdown@1.5.1':
     resolution: {integrity: sha512-F3ZFnIfNAOy/jPSk6Q0e3bs7e9grfK/n5zerkKoc5COH6Guy3Zb0vrJwXzdck79K16goBhYBRAvhf+ksqe0cMg==}
@@ -5050,8 +5050,8 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  md-editor-v3@6.1.0:
-    resolution: {integrity: sha512-8/3cNyAt2CfMhu3PiQZqpOmCKmBXa7uJzWHnATVwkv61TOgUBuho4IFQPougmM4J7qZhZ0sldXQHDVf1BjABxg==}
+  md-editor-v3@6.2.0:
+    resolution: {integrity: sha512-fAwky56Lc6r/aQzC9R9S/eefG1UL2hLT2tuINfe9PlR3yLQowcbhItTCcs+VDk9gEXFaj8rbxHC+q52LpVVdwQ==}
     peerDependencies:
       vue: ^3.5.3
 
@@ -7569,7 +7569,7 @@ snapshots:
       '@codemirror/language': 6.11.3
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@codemirror/lang-cpp@6.0.3':
     dependencies:
@@ -7630,7 +7630,7 @@ snapshots:
       '@codemirror/language': 6.11.3
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@codemirror/lang-liquid@6.3.0':
     dependencies:
@@ -7641,7 +7641,7 @@ snapshots:
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@codemirror/lang-markdown@6.4.0':
     dependencies:
@@ -7689,7 +7689,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@codemirror/lang-vue@0.1.3':
     dependencies:
@@ -7698,14 +7698,14 @@ snapshots:
       '@codemirror/language': 6.11.3
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@codemirror/lang-wast@6.0.2':
     dependencies:
       '@codemirror/language': 6.11.3
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@codemirror/lang-xml@6.1.0':
     dependencies:
@@ -7723,7 +7723,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
       '@lezer/yaml': 1.0.3
 
   '@codemirror/language-data@6.5.1':
@@ -7757,7 +7757,7 @@ snapshots:
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
       style-mod: 4.1.3
 
   '@codemirror/legacy-modes@6.5.2':
@@ -8250,19 +8250,19 @@ snapshots:
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/css@1.3.0':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/go@1.0.1':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/highlight@1.2.2':
     dependencies:
@@ -8272,27 +8272,27 @@ snapshots:
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/java@1.1.3':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/javascript@1.5.4':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/json@1.0.3':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
-  '@lezer/lr@1.4.2':
+  '@lezer/lr@1.4.3':
     dependencies:
       '@lezer/common': 1.3.0
 
@@ -8305,37 +8305,37 @@ snapshots:
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/python@1.1.18':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/rust@1.0.2':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/sass@1.1.0':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/xml@1.0.6':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@lezer/yaml@1.0.3':
     dependencies:
       '@lezer/common': 1.3.0
       '@lezer/highlight': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.3
 
   '@marijn/find-cluster-break@1.0.2': {}
 
@@ -11116,7 +11116,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  md-editor-v3@6.1.0(vue@3.5.22(typescript@5.9.3)):
+  md-editor-v3@6.2.0(vue@3.5.22(typescript@5.9.3)):
     dependencies:
       '@codemirror/autocomplete': 6.19.0
       '@codemirror/commands': 6.9.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [Merge pull request #1648 from opencloud-eu/renovate/md-editor-v3-6.x-lockfile](https://github.com/opencloud-eu/web/pull/1648)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)