### PR TITLE
[stable-4.2] fix: move folder replace

### DIFF
--- a/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
+++ b/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
@@ -196,12 +196,19 @@ export class ResourceTransfer extends ConflictDialog {
       return false
     }
 
-    if (targetFolder.path === unref(this.currentFolder)?.path) {
+    const currentFolderPath = unref(this.currentFolder)?.path
+    if (!currentFolderPath || targetFolder.path === currentFolderPath) {
       return false
     }
 
     const folderName = basename(resource.path)
     const newPath = join(targetFolder.path, folderName)
+
+    if (currentFolderPath.split('/').length < newPath.split('/').length) {
+      // this edge case is only possible when moving folders upwards in the hierarchy
+      return false
+    }
+
     return targetFolderResources.some((resource) => resource.path === newPath)
   }
 }

--- a/packages/web-pkg/tests/unit/helpers/resource/conflictHandling/resourcesTransfer.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/resource/conflictHandling/resourcesTransfer.spec.ts
@@ -132,7 +132,7 @@ describe('resourcesTransfer', () => {
 
     expect(resourcesTransfer.resolveFileExists).toHaveBeenCalled()
   })
-  it('should show error message if trying to overwrite parent', async () => {
+  it('should show error message if trying to overwrite parent', () => {
     const targetFolderItems = [
       {
         id: 'a',
@@ -146,17 +146,17 @@ describe('resourcesTransfer', () => {
       resourcesToMove,
       targetSpace,
       resourcesToMove[0],
-      computed(() => mock<Resource>()),
+      computed(() => mock<Resource>({ path: '/' })),
       clientServiceMock,
       vi.fn(),
       vi.fn()
     )
-    const namingClash = await resourcesTransfer.isOverwritingParentFolder(
+    const namingClash = resourcesTransfer.isOverwritingParentFolder(
       resourcesToMove[0],
       targetFolder,
       targetFolderItems
     )
-    const noNamingClash = await resourcesTransfer.isOverwritingParentFolder(
+    const noNamingClash = resourcesTransfer.isOverwritingParentFolder(
       resourcesToMove[1],
       targetFolder,
       targetFolderItems


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [Merge pull request #1627 from opencloud-eu/fix/move-folder-replace](https://github.com/opencloud-eu/web/pull/1627)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)