### PR TITLE
replace ci images. Save webkit in cache

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -625,8 +625,6 @@ def e2eTests(ctx):
             else:
                 command = "cd tests/e2e && bash run-e2e.sh "
 
-            command = "cd tests/e2e && bash run-e2e.sh "
-
             if "suites" in matrix:
                 command += "--suites %s" % ",".join(params["suites"])
             elif "features" in matrix:


### PR DESCRIPTION
- `OC_CI_GOLANG` replaces `OC_UBUNTU` and `OC_CI_ALPINE`
-  We downloaded `webkit` before each test. Now I install the `webkit` and save it in the cache, and before starting the tests, I only install the container dependency for `webkit` `pnpm playwright install-deps webkit` https://playwright.dev/docs/browsers#install-system-dependencies