### PR TITLE
[tests-only] skip unit and e2e test pipelines on ready-release-go prs

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -239,6 +239,9 @@ event = {
 def main(ctx):
     if ctx.build.event == "cron" and ctx.build.sender == "translation-sync":
         return translation_sync(ctx)
+    is_release_pr = (ctx.build.event == "pull_request" and ctx.build.event == "openclouders" and "🎉 release" in ctx.build.title.lower())
+    if is_release_pr:
+        return licenseCheck()
 
     release = readyReleaseGo()
 


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description
This PR updates the pipeline logic to skip all stagePipelines steps (E2E tests and unit tests) for release PRs generated by the `ready-release-go` plugin. I have targetted the PR's title for this logic as all of the Release PRs start with  `🎉 Release` and also targetted the sender of the PR which is always `openclouders` for release PRs.

The release PRs now only runs licenseCheck pipeline. See:
https://ci.opencloud.rocks/repos/6/pipeline/353

Here's the CI build for this same PR in which  `🎉 Release` was included in the title:
https://ci.opencloud.rocks/repos/6/pipeline/236
## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Part of: https://github.com/opencloud-eu/qa/issues/47

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- :robot: 

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
