### PR TITLE
[tests-only] correct release PR condition to use build.sender

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -239,7 +239,7 @@ event = {
 def main(ctx):
     if ctx.build.event == "cron" and ctx.build.sender == "translation-sync":
         return translation_sync(ctx)
-    is_release_pr = (ctx.build.event == "pull_request" and ctx.build.event == "openclouders" and "🎉 release" in ctx.build.title.lower())
+    is_release_pr = (ctx.build.event == "pull_request" and ctx.build.sender == "openclouders" and "🎉 release" in ctx.build.title.lower())
     if is_release_pr:
         return licenseCheck()
 


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

This PR corrects the logic that detects release pull requests by checking `ctx.build.sender`.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Part of: https://github.com/opencloud-eu/qa/issues/47

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
