### PR TITLE
ci: add empty CI config to docs

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1117,7 +1117,7 @@ def designSystemDocs(ctx):
                     "pnpm --filter 'design-system' docs:build",
                     "cp -R packages/design-system/docs/.vitepress/dist docs",
                     # add empty woodpecker config to not run CI on push to the docs branch
-                    "touch docs/.woodpecker.star",
+                    'echo "def main(ctx): return []" > docs/.woodpecker.star',
                 ],
             },
             {


### PR DESCRIPTION
## Description
Add empty ci config to docs to disable CI trigger on push to the docs branch.
Similar to https://github.com/opencloud-eu/web/pull/1751

#1751 didn't work on new push because the unmatched files were removed while publishing (push to the docs branch).
See https://github.com/opencloud-eu/web/commit/e63e2c5809dcee847908b51d060ac33b728e54b5#diff-0d2cb487e7e8bfe77cea5a2347a1987e5c8864b49ffdc1a75543dba849928a74
and https://ci.opencloud.rocks/repos/6/pipeline/544/54
```
+ rsync -r --exclude .git --delete /woodpecker/web/docs/ /tmp/drone-gh-pages811202574
```

## Related Issue
- Fixes https://ci.opencloud.rocks/repos/6/pipeline/548

## How Has This Been Tested?
- test environment:

## Types of changes

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
