### PR TITLE
ci: add empty CI config to docs

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1117,7 +1117,7 @@ def designSystemDocs(ctx):
                     "pnpm --filter 'design-system' docs:build",
                     "cp -R packages/design-system/docs/.vitepress/dist docs",
                     # add empty woodpecker config to not run CI on push to the docs branch
-                    'echo "def main(ctx): return []" > docs/.woodpecker.star',
+                    "touch docs/.woodpecker.star",
                 ],
             },
             {


### PR DESCRIPTION
## Description
Follow up on https://github.com/opencloud-eu/web/pull/1757

Copilot suggestion didn't work :smiling_face_with_tear: : https://github.com/opencloud-eu/web/pull/1757#discussion_r2621787440
So, fall back to using my own code.

<img width="906" height="333" alt="Screenshot from 2025-12-16 17-33-45" src="https://github.com/user-attachments/assets/d0452de7-2c55-46c7-bd62-24bc1f8587c5" />



## Related Issue

## How Has This Been Tested?
- test environment:

## Types of changes

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
