### PR TITLE
chore(design-system): externalize pinia

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -110,13 +110,15 @@
     "fuse.js": "^7.0.0",
     "lodash-es": "^4.17.21",
     "luxon": "^3.5.0",
-    "pinia": "^3.0.3",
     "portal-vue": "^3.0.0",
     "tippy.js": "^6.3.7",
     "vue-inline-svg": "^4.0.0",
     "vue-router": "^4.2.5",
     "vue-select": "^4.0.0-beta.6",
     "vue3-gettext": "^2.4.0"
+  },
+  "peerDependencies": {
+    "pinia": "^3.0.3"
   },
   "devDependencies": {
     "@opencloud-eu/web-test-helpers": "workspace:*",

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -51,7 +51,8 @@ export default defineConfig({
         ),
         '**/tests',
         '**/*.spec.ts',
-        'vue'
+        'vue',
+        'pinia'
       ],
       output: {
         globals: {


### PR DESCRIPTION
Externalizes pinia and marks it as peer dependency to ensure the design-system always uses the host application's pinia instance.