### PR TITLE
ci: use dummy ci config in docs branch

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1116,8 +1116,10 @@ def designSystemDocs(ctx):
                     "corepack enable pnpm",
                     "pnpm --filter 'design-system' docs:build",
                     "cp -R packages/design-system/docs/.vitepress/dist docs",
-                    # add empty woodpecker config to not run CI on push to the docs branch
-                    "touch docs/.woodpecker.star",
+                    # add dummy woodpecker config to disable CI on push to the docs branch
+                    "printf 'def main(ctx):\n    return [{\n        \"name\":\"dummy-pipeline\",\n" +
+                    "        \"steps\":[{\"name\":\"dummy-step\",\"image\":\"alpine:latest\"}],\n" +
+                    "        \"when\":[{\"branch\":[\"main\"]}],\n    }]\n' > docs/.woodpecker.star",
                 ],
             },
             {


### PR DESCRIPTION
## Description
Add dummy ci workflow to disable CI on push to the docs branch. The created workflow doesn't run, it's just to pass the config conversion.

Previous attempts didn't work:
1. return empty workflow: https://github.com/opencloud-eu/web/pull/1757
    ```
    Invalid or missing steps section
    ```
2. empty config: https://github.com/opencloud-eu/web/pull/1758
    ```
    could not load config from forge: failed to fetch config via http (500) response: Failed to get convert
    ```

## Related Issue


## How Has This Been Tested?
- test environment: Tested and working :heavy_check_mark: 

## Types of changes
- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
