### PR TITLE
fix: resource delete action visibility

### DIFF
--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -254,6 +254,7 @@ export function buildDeletedResource(resource: WebDavResponseResource): TrashRes
     isMounted: () => false,
     isReceivedShare: () => false,
     hasPreview: () => false,
+    isShareRoot: () => false,
     getDomSelector: () => extractDomSelector(id)
   }
 }

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -166,6 +166,7 @@ export function buildIncomingShareResource({
     isMounted: () => false,
     isReceivedShare: () => true,
     canShare: () => false,
+    isShareRoot: () => true,
     getDomSelector: () => extractDomSelector(driveItem.id)
   }
 
@@ -225,6 +226,7 @@ export function buildOutgoingShareResource({
     canBeDeleted: () => true,
     canEditTags: () => true,
     isMounted: () => false,
+    isShareRoot: () => false,
     isReceivedShare: () => true,
     canShare: () => true,
     getDomSelector: () => extractDomSelector(driveItem.id)

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDelete.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDelete.ts
@@ -1,81 +1,39 @@
-import { useFileActionsDeleteResources, useIsAppActive } from '../helpers'
+import { useFileActionsDeleteResources } from '../helpers'
 import {
-  isLocationPublicActive,
-  isLocationSpacesActive,
-  isLocationTrashActive,
-  isLocationCommonActive
-} from '../../../router'
-import { isProjectSpaceResource } from '@opencloud-eu/web-client'
-import { useRouter } from '../../router'
+  isIncomingShareResource,
+  isProjectSpaceResource,
+  isSpaceResource,
+  isTrashResource
+} from '@opencloud-eu/web-client'
 import { useGettext } from 'vue3-gettext'
-import { FileAction, FileActionOptions } from '../types'
-import { computed, unref } from 'vue'
+import { FileAction } from '../types'
+import { computed } from 'vue'
 import { useUserStore, useCapabilityStore } from '../../piniaStores'
 
 export const useFileActionsDelete = () => {
   const userStore = useUserStore()
   const capabilityStore = useCapabilityStore()
-  const router = useRouter()
-  const isAppActive = useIsAppActive()
   const { displayDialog, filesList_delete } = useFileActionsDeleteResources()
 
   const { $gettext } = useGettext()
-
-  const handler = ({
-    space,
-    resources,
-    deletePermanent
-  }: FileActionOptions & { deletePermanent: boolean }) => {
-    if (isLocationCommonActive(router, 'files-common-search')) {
-      resources = resources.filter(
-        (r) => r.canBeDeleted() && !r.isShareRoot() && !isProjectSpaceResource(r)
-      )
-    }
-    if (deletePermanent) {
-      displayDialog(space, resources)
-      return
-    }
-
-    filesList_delete(resources)
-  }
 
   const actions = computed((): FileAction[] => [
     {
       name: 'delete',
       icon: 'delete-bin-5',
       label: () => $gettext('Delete'),
-      handler: ({ space, resources }) => handler({ space, resources, deletePermanent: false }),
-      isVisible: ({ space, resources }) => {
-        if (
-          !isLocationSpacesActive(router, 'files-spaces-generic') &&
-          !isLocationPublicActive(router, 'files-public-link') &&
-          !isLocationCommonActive(router, 'files-common-search') &&
-          !unref(isAppActive)
-        ) {
-          return false
-        }
-
-        if (resources.length === 0) {
-          return false
-        }
-
-        if (
-          isLocationSpacesActive(router, 'files-spaces-generic') &&
-          space?.driveType === 'share' &&
-          resources[0].path === '/'
-        ) {
-          return false
-        }
-
-        if (isLocationCommonActive(router, 'files-common-search')) {
-          return resources.some(
-            (r) => r.canBeDeleted() && !r.isShareRoot() && !isProjectSpaceResource(r)
-          )
-        }
-
-        return !resources.some((resource) => {
-          return !resource.canBeDeleted() || isProjectSpaceResource(resource)
-        })
+      handler: ({ resources }) => {
+        filesList_delete(resources)
+      },
+      isVisible: ({ resources }) => {
+        return resources.every(
+          (r) =>
+            r.canBeDeleted() &&
+            !isSpaceResource(r) &&
+            !isIncomingShareResource(r) &&
+            !isTrashResource(r) &&
+            !r.isShareRoot() // shared root folders on the search result page
+        )
       },
       isDisabled: ({ resources }) => {
         return resources.length === 1 && resources[0].locked
@@ -88,11 +46,10 @@ export const useFileActionsDelete = () => {
       name: 'delete-permanent',
       icon: 'delete-bin-5',
       label: () => $gettext('Delete'),
-      handler: ({ space, resources }) => handler({ space, resources, deletePermanent: true }),
+      handler: ({ space, resources }) => {
+        displayDialog(space, resources)
+      },
       isVisible: ({ space, resources }) => {
-        if (!isLocationTrashActive(router, 'files-trash-generic')) {
-          return false
-        }
         if (!capabilityStore.filesPermanentDeletion) {
           return false
         }
@@ -104,7 +61,7 @@ export const useFileActionsDelete = () => {
           return false
         }
 
-        return resources.length > 0
+        return resources.every(isTrashResource)
       },
       class: 'oc-files-actions-delete-permanent-trigger'
     }


### PR DESCRIPTION
Fixes the visibility of the delete actions of the `useFileActionsDelete` composable outside of the files app. To achieve this, I removed all the route-specific logic in favor of resource-specific checks.

Note that this leads to a slightly different behavior on the search result page: When selecting e.g. 5 resources and one of them is not deletable for some reason, the delete action will not be displayed as a batch action.

fixes https://github.com/opencloud-eu/web/issues/1806