### PR TITLE
fix: context menu for shares on search result page

### DIFF
--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -97,7 +97,6 @@
           :sort-by="sortBy"
           :sort-dir="sortDir"
           :fields-displayed="['name', 'size', 'tags', 'mdate']"
-          :resource-dom-selector="resourceDomSelector"
           :sort-fields="sortFields.filter((field) => field.name === 'name')"
           :view-mode="viewMode"
           :view-size="viewSize"
@@ -192,7 +191,6 @@ import {
   useKeyboardFileMouseActions,
   useKeyboardFileActions
 } from '../../composables/keyboardActions'
-import { extractDomSelector } from '@opencloud-eu/web-client'
 import { storeToRefs } from 'pinia'
 import { folderViewsSearchExtensionPoint } from '../../extensionPoints'
 
@@ -393,14 +391,6 @@ const breadcrumbs = computed(() => {
     }
   ]
 })
-
-const resourceDomSelector = ({ id, remoteItemId }: Resource) => {
-  let selectorStr = id.toString()
-  if (remoteItemId) {
-    selectorStr += remoteItemId
-  }
-  return extractDomSelector(selectorStr)
-}
 
 const itemCount = computed(() => {
   return unref(totalResourcesCount).files + unref(totalResourcesCount).folders


### PR DESCRIPTION
Fixes the broken context menu for incoming shares on the search result page.

The issue was an invalid resource dom selector. We can just use the default one from the resource table component.

fixes https://github.com/opencloud-eu/web/issues/1833