### PR TITLE
fix: text editor app entry for light users

### DIFF
--- a/packages/web-app-text-editor/src/index.ts
+++ b/packages/web-app-text-editor/src/index.ts
@@ -8,6 +8,7 @@ import {
   AppWrapperRoute,
   defineWebApplication,
   useOpenEmptyEditor,
+  useSpacesStore,
   useUserStore
 } from '@opencloud-eu/web-pkg'
 import { computed } from 'vue'
@@ -18,6 +19,7 @@ export default defineWebApplication({
     const { $gettext } = useGettext()
     const userStore = useUserStore()
     const { openEmptyEditor } = useOpenEmptyEditor()
+    const spacesStore = useSpacesStore()
 
     const appId = 'text-editor'
 
@@ -123,8 +125,7 @@ export default defineWebApplication({
 
     const menuItems = computed<AppMenuItemExtension[]>(() => {
       const items: AppMenuItemExtension[] = []
-
-      if (userStore.user) {
+      if (userStore.user && spacesStore.personalSpace) {
         items.push({
           id: `app.${appInfo.id}.menuItem`,
           type: 'appMenuItem',


### PR DESCRIPTION
Hide the text editor entry in the app drawer for light users since they don't have a personal space (meaning no default location for the file to be created).

fixes https://github.com/opencloud-eu/web/issues/1799