### PR TITLE
fix: prevent sort options in trash overview from disappearing

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
@@ -1,4 +1,4 @@
-import { isSpaceResource, SpaceResource } from '@opencloud-eu/web-client'
+import { isSpaceResource, isTrashResource, SpaceResource } from '@opencloud-eu/web-client'
 import { computed } from 'vue'
 import { useClientService } from '../../clientService'
 import { useGettext } from 'vue3-gettext'
@@ -22,16 +22,18 @@ export const useFileActionsEmptyTrashBin = () => {
   const { dispatchModal } = useModals()
   const resourcesStore = useResourcesStore()
   const spacesStore = useSpacesStore()
-
   const loadingService = useLoadingService()
 
   const emptyTrashBin = async ({ space }: { space: SpaceResource }) => {
     try {
       await clientService.webdav.clearTrashBin(space)
       showMessage({ title: $gettext('All deleted files were removed') })
-      resourcesStore.clearResources()
       resourcesStore.resetSelection()
       spacesStore.updateSpaceField({ id: space.id, field: 'hasTrashedItems', value: false })
+      if (resourcesStore.resources.some(isTrashResource)) {
+        // trash resources mean we're inside a trash bin, hence we clear all resources
+        resourcesStore.clearResources()
+      }
     } catch (error) {
       console.error(error)
       showErrorMessage({

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsEmptyTrashBin.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsEmptyTrashBin.spec.ts
@@ -15,7 +15,12 @@ import {
   RouteLocation
 } from '@opencloud-eu/web-test-helpers'
 import { unref } from 'vue'
-import { ProjectSpaceResource, SpaceResource } from '@opencloud-eu/web-client'
+import {
+  ProjectSpaceResource,
+  Resource,
+  SpaceResource,
+  TrashResource
+} from '@opencloud-eu/web-client'
 
 describe('emptyTrashBin', () => {
   describe('isVisible property', () => {
@@ -92,10 +97,22 @@ describe('emptyTrashBin', () => {
 
           expect(showMessage).toHaveBeenCalledTimes(1)
 
-          expect(clearResources).toHaveBeenCalledTimes(1)
+          expect(clearResources).not.toHaveBeenCalled()
           expect(resetSelection).toHaveBeenCalledTimes(1)
 
           expect(updateSpaceField).toHaveBeenCalledTimes(1)
+        }
+      })
+    })
+
+    it('should clear resources when trash resources are present in the file list', () => {
+      getWrapper({
+        resources: [mock<TrashResource>({ ddate: 'date' })],
+        setup: async ({ emptyTrashBin }, { space }) => {
+          await emptyTrashBin({ space })
+
+          const { clearResources } = useResourcesStore()
+          expect(clearResources).toHaveBeenCalledTimes(1)
         }
       })
     })
@@ -128,11 +145,13 @@ function getWrapper({
   invalidLocation = false,
   resolveClearTrashBin = true,
   driveType = 'personal',
+  resources = [],
   setup
 }: {
   invalidLocation?: boolean
   resolveClearTrashBin?: boolean
   driveType?: string
+  resources?: Resource[]
   setup: (
     instance: ReturnType<typeof useFileActionsEmptyTrashBin>,
     {
@@ -165,7 +184,8 @@ function getWrapper({
       },
       {
         mocks,
-        provide: mocks
+        provide: mocks,
+        pluginOptions: { piniaOptions: { resourcesStore: { resources } } }
       }
     )
   }


### PR DESCRIPTION
Prevents the sort options in the trash overview from disappearing after emptying a trash bin. This happened because we always cleared the file list afterwards, which should only happen when the user is inside a trash bin (not on the overview).

fixes https://github.com/opencloud-eu/web/issues/1391