### PR TITLE
fix: fallback icon for folders with extension

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceIcon.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceIcon.vue
@@ -52,7 +52,7 @@ const defaultSpaceIconDisabled: IconType = {
   color: 'var(--oc-role-secondary)'
 }
 
-const defaultFallbackIcon: IconType = {
+const defaultFileIcon: IconType = {
   name: 'resource-type-file',
   color: 'var(--oc-role-on-surface)'
 }
@@ -67,10 +67,7 @@ const { resource, size = 'large' } = defineProps<{
 const iconMappingInjection = inject<ResourceIconMapping>(resourceIconMappingInjectionKey)
 
 const hasFolderIcon = computed(() => {
-  if (!!resource.extension) {
-    return false
-  }
-  return resource.type === 'folder' || resource.isFolder
+  return unref(icon)?.name === defaultFolderIcon.name
 })
 
 const hasSpaceIcon = computed(() => {
@@ -79,6 +76,13 @@ const hasSpaceIcon = computed(() => {
 
 const hasDisabledSpaceIcon = computed(() => {
   return isProjectSpaceResource(resource) && resource.disabled === true
+})
+
+const fallbackIcon = computed(() => {
+  if (resource.type === 'folder' || resource.isFolder) {
+    return defaultFolderIcon
+  }
+  return defaultFileIcon
 })
 
 const hasPersonalSpaceIcon = computed(() => {
@@ -101,18 +105,15 @@ const icon = computed((): IconType => {
   if (unref(hasSpaceIcon)) {
     return defaultSpaceIcon
   }
-  if (unref(hasFolderIcon)) {
-    return defaultFolderIcon
-  }
 
-  const icon =
+  const typeIconOrUndefined =
     defaultFileIconMapping[unref(extension)] ||
     iconMappingInjection?.mimeType[unref(mimeType)] ||
     iconMappingInjection?.extension[unref(extension)]
 
   return {
-    ...defaultFallbackIcon,
-    ...icon
+    ...unref(fallbackIcon),
+    ...typeIconOrUndefined
   }
 })
 </script>


### PR DESCRIPTION
## Description

Folders can have an extension now... still, the fallback icon should always be the folder icon. Fixing that with this PR.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/1888

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
