### PR TITLE
fix: don't show parent folder doesn't exist error, on 412 server error

### DIFF
--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -694,8 +694,6 @@ export default defineComponent({
       switch (errorObject.responseCode) {
         case 507:
           return this.$gettext('Quota exceeded')
-        case 412:
-          return this.$gettext('Parent folder does not exist')
         default:
           return errorObject.errorMessage
             ? this.$gettext(errorObject.errorMessage)


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

Showing the error message "Paren't folder doesnt exist" on 412 server error while uploading a file is misleading, there are also other cases why 412 might be present. 

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Works towards https://github.com/opencloud-eu/web/issues/1893

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
