### PR TITLE
chore: don't allow back slash in resource names

### DIFF
--- a/packages/web-pkg/src/composables/actions/helpers/useIsResourceNameValid.ts
+++ b/packages/web-pkg/src/composables/actions/helpers/useIsResourceNameValid.ts
@@ -21,6 +21,10 @@ export const useIsResourceNameValid = () => {
       return { isValid: false, error: $gettext('The name cannot contain "/"') }
     }
 
+    if (/[\\]/.test(newName)) {
+      return { isValid: false, error: $gettext('The name cannot contain "\\"') }
+    }
+
     if (newName === '.') {
       return { isValid: false, error: $gettext('The name cannot be equal to "."') }
     }

--- a/packages/web-pkg/tests/unit/composables/actions/helpers/useIsResourceNameValid.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/helpers/useIsResourceNameValid.spec.ts
@@ -67,6 +67,11 @@ describe('useIsResourceNameValid', () => {
       },
       {
         currentName: 'currentName',
+        newName: 'new\\name',
+        message: 'The name cannot contain "\\"'
+      },
+      {
+        currentName: 'currentName',
         newName: '.',
         message: 'The name cannot be equal to "."'
       },


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

Since Windows and our desktop client can't handle backslashes in resource names, we need to avoid creating files and renaming them containing '\\'.


## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
