### PR TITLE
fix: error message on 425 error when creating space from resource

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
@@ -66,10 +66,11 @@ export const useFileActionsCreateSpaceFromResource = () => {
       showMessage({ title: $gettext('Space was created successfully') })
     } catch (error) {
       console.error(error)
-      showErrorMessage({
-        title: $gettext('Creating space failed…'),
-        errors: [error]
-      })
+      const title =
+        error.statusCode === 425
+          ? $gettext('Some files could not be copied')
+          : $gettext('Creating space failed…')
+      showErrorMessage({ title, errors: [error] })
     }
   }
   const handler = ({ resources, space }: FileActionOptions) => {


### PR DESCRIPTION


When a 425 error happens when creating a space from a folder, we now show a proper error message that some files could not be copied.

fixes https://github.com/opencloud-eu/web/issues/1860