### PR TITLE
fix(web-runtime): cache embed query params across config reloads

### DIFF
--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -92,6 +92,10 @@ import { bytesToHex } from '@noble/hashes/utils.js'
 // which strips the original query string before the second config load).
 let cachedEmbedConfig: RawConfig['options']['embed'] | undefined
 
+export const _resetEmbedConfigCache = () => {
+  cachedEmbedConfig = undefined
+}
+
 const getEmbedConfigFromQuery = (
   doesEmbedEnabledOptionExists: boolean
 ): RawConfig['options']['embed'] => {

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -14,7 +14,8 @@ import {
   announceCustomScripts,
   announceCustomStyles,
   announceConfiguration,
-  announceUpdates
+  announceUpdates,
+  _resetEmbedConfigCache
 } from '../../../src/container/bootstrap'
 import { buildApplication, loadApplication } from '../../../src/container/application'
 import { createTestingPinia, mockAxiosResolve } from '@opencloud-eu/web-test-helpers'
@@ -152,6 +153,7 @@ describe('announceCustomStyles', () => {
 describe('announceConfiguration', () => {
   beforeEach(() => {
     createTestingPinia({ stubActions: false })
+    _resetEmbedConfigCache()
   })
 
   it('should not enable embed mode when it is not set', async () => {

--- a/tests/e2e/cucumber/features/embed/embedMode.feature
+++ b/tests/e2e/cucumber/features/embed/embedMode.feature
@@ -1,0 +1,14 @@
+Feature: Embed mode with delegated authentication
+
+  As an integrator embedding the web UI in an iframe
+  I want embed mode to survive the internal auth redirect
+  So that embed query params are not silently lost after authentication
+
+
+  Scenario: embed mode stays active after delegated authentication
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+    When "Alice" opens the app in embed mode with delegated authentication
+    Then "Alice" should see the embed mode actions
+    And "Alice" should not see the full web UI

--- a/tests/e2e/cucumber/steps/ui/embed.ts
+++ b/tests/e2e/cucumber/steps/ui/embed.ts
@@ -1,0 +1,77 @@
+import { When, Then } from '@cucumber/cucumber'
+import { World } from '../../environment'
+import { config } from '../../../config'
+import { expect } from '@playwright/test'
+import { TokenEnvironmentFactory } from '../../../support/environment/token'
+
+When(
+  '{string} opens the app in embed mode with delegated authentication',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = await this.actorsEnvironment.createActor({
+      key: stepUser,
+      namespace: this.actorsEnvironment.generateNamespace(this.feature.name, stepUser)
+    })
+
+    const user = this.usersEnvironment.getCreatedUser({ key: stepUser })
+
+    const tokenEnvironment = TokenEnvironmentFactory(config.keycloak ? 'keycloak' : null)
+    const { accessToken } = tokenEnvironment.getToken({ user })
+
+    const appUrl = `${config.baseUrl}?embed=true&embed-delegate-authentication=true`
+
+    // Serve a test harness page at the same origin so postMessage works
+    // with the default targetOrigin. The harness embeds the app in an
+    // iframe and replies to the delegated-auth token request.
+    await page.route('**/embed-test-harness', (route) => {
+      route.fulfill({
+        contentType: 'text/html',
+        body: `<!DOCTYPE html>
+<html>
+<body>
+<iframe id="embed-frame" src="${appUrl}" style="width:100%;height:100vh;border:none;"></iframe>
+<script>
+  window.addEventListener('message', function(event) {
+    if (event.data && event.data.name === 'opencloud-embed:request-token') {
+      var iframe = document.getElementById('embed-frame');
+      iframe.contentWindow.postMessage({
+        name: 'opencloud-embed:update-token',
+        data: { access_token: '${accessToken}' }
+      }, '*');
+    }
+  });
+</script>
+</body>
+</html>`
+      })
+    })
+
+    await page.goto(`${config.baseUrl}/embed-test-harness`)
+
+    // Wait for the embedded app to fully load
+    const frame = page.frameLocator('#embed-frame')
+    await frame.locator('#web-content').waitFor({ timeout: 30000 })
+  }
+)
+
+Then(
+  '{string} should see the embed mode actions',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const frame = page.frameLocator('#embed-frame')
+
+    await expect(frame.locator('[data-testid="button-cancel"]')).toBeVisible({ timeout: 15000 })
+    await expect(frame.locator('[data-testid="button-select"]')).toBeVisible()
+  }
+)
+
+Then(
+  '{string} should not see the full web UI',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const frame = page.frameLocator('#embed-frame')
+
+    // In embed mode the user menu and app switcher should be hidden
+    await expect(frame.locator('#_userMenuButton')).not.toBeVisible()
+    await expect(frame.locator('#_appSwitcherButton')).not.toBeVisible()
+  }
+)


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

announceConfiguration is called twice: once during bootstrap and again when userContextReady fires. By the second call the delegated-auth callback has navigated away from the initial /?embed=true&… URL, so getQueryParam('embed') returns null and embed mode is silently disabled.

Cache the derived embed config on the first call and return the snapshot on subsequent invocations.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

It's hard to setup a reproduction environment for this and also it's very late ... let's talk about it tomorrow

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
