### PR TITLE
[full-ci] chore: bump opencloud for tests to v5.1.0-rc

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,3 +1,3 @@
 # The version of OpenCloud to use in pipelines
-OPENCLOUD_COMMITID=9eac47dab4dc0273cd99f36b851e39b3990340dc
+OPENCLOUD_COMMITID=2fdb87291e1af899d29e3bed14dec61a3f740356
 OPENCLOUD_BRANCH=main


### PR DESCRIPTION
## Description

Bumps the opencloud commit id to the state that will very likely be released as opencloud-rolling v5.1.0 so that we can verify with all tests.

## Related Issue

Works towards https://github.com/opencloud-eu/opencloud/issues/2326

## Types of changes

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
