### PR TITLE
fix: prevent 'New'-button flicker when navigating

### DIFF
--- a/packages/web-runtime/src/components/AppFloatingActionButton.vue
+++ b/packages/web-runtime/src/components/AppFloatingActionButton.vue
@@ -1,60 +1,77 @@
 <template>
-  <div
-    v-for="floatingActionButton in floatingActionButtonExtensions"
-    :key="floatingActionButton.id"
-  >
-    <template v-if="floatingActionButton.isActive()">
-      <div v-if="!isMobile" class="py-2 px-2">
-        <oc-button
-          :id="getButtonId(floatingActionButton.id)"
-          :disabled="floatingActionButton.isDisabled?.()"
-          appearance="filled"
-          class="oc-app-floating-action-button w-full"
-          @click="floatingActionButton.handler?.()"
-        >
-          <oc-icon :name="floatingActionButton.icon" />
-          <span v-text="floatingActionButton.label()" />
-        </oc-button>
-        <component
-          :is="floatingActionButton.dropComponent"
-          v-if="floatingActionButton.dropComponent"
-          :toggle="`#${getButtonId(floatingActionButton.id)}`"
-        />
-      </div>
-      <template v-else-if="!floatingActionButton.isDisabled?.()">
-        <oc-floating-action-button
-          :button-id="getButtonId(floatingActionButton.id)"
-          class="oc-app-floating-action-button"
-          mode="action"
-          :handler="floatingActionButton.handler"
-        />
-        <component
-          :is="floatingActionButton.dropComponent"
-          v-if="floatingActionButton.dropComponent"
-          :toggle="`#${getButtonId(floatingActionButton.id)}`"
-        />
-      </template>
+  <template v-if="floatingActionButton">
+    <div v-if="!isMobile" class="py-2 px-2">
+      <oc-button
+        :id="getButtonId(floatingActionButton.id)"
+        :disabled="isDisabled"
+        appearance="filled"
+        class="oc-app-floating-action-button w-full"
+        @click="floatingActionButton.handler?.()"
+      >
+        <oc-icon :name="floatingActionButton.icon" />
+        <span v-text="floatingActionButton.label()" />
+      </oc-button>
+      <component
+        :is="floatingActionButton.dropComponent"
+        v-if="floatingActionButton.dropComponent"
+        :toggle="`#${getButtonId(floatingActionButton.id)}`"
+      />
+    </div>
+    <template v-else-if="!isDisabled">
+      <oc-floating-action-button
+        :button-id="getButtonId(floatingActionButton.id)"
+        class="oc-app-floating-action-button"
+        mode="action"
+        :handler="floatingActionButton.handler"
+      />
+      <component
+        :is="floatingActionButton.dropComponent"
+        v-if="floatingActionButton.dropComponent"
+        :toggle="`#${getButtonId(floatingActionButton.id)}`"
+      />
     </template>
-  </div>
+  </template>
 </template>
 
 <script setup lang="ts">
-import { computed, unref } from 'vue'
+import { computed, onBeforeUnmount, ref, unref, watchEffect } from 'vue'
 import { FloatingActionButtonExtension, useExtensionRegistry } from '@opencloud-eu/web-pkg'
 import { useIsMobile } from '@opencloud-eu/design-system/composables'
 
 const { requestExtensions } = useExtensionRegistry()
 const { isMobile } = useIsMobile()
 
-const floatingActionButtonExtensions = computed(() => {
+const isDisabled = ref(false)
+
+const floatingActionButton = computed(() => {
   return requestExtensions<FloatingActionButtonExtension>({
     id: 'global.floating-action-button',
     extensionType: 'floatingActionButton'
-  })
+  }).find(({ isActive }) => isActive())
 })
 
 const getButtonId = (extensionId: string): string => {
   const prefix = unref(isMobile) ? 'mobile-' : ''
   return `${prefix}app-floating-action-button-${extensionId.replace(/\./g, '-')}`
 }
+
+let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+// use a timeout to avoid flickering of the button in case the isDisabled state changes rapidly
+watchEffect(() => {
+  const disabled = unref(floatingActionButton)?.isDisabled?.() ?? false
+  if (timeoutId) {
+    clearTimeout(timeoutId)
+  }
+  timeoutId = setTimeout(() => {
+    isDisabled.value = disabled
+    timeoutId = null
+  }, 50)
+})
+
+onBeforeUnmount(() => {
+  if (timeoutId) {
+    clearTimeout(timeoutId)
+  }
+})
 </script>

--- a/packages/web-runtime/tests/unit/components/SidebarNav/SidebarNav.spec.ts
+++ b/packages/web-runtime/tests/unit/components/SidebarNav/SidebarNav.spec.ts
@@ -1,3 +1,4 @@
+import { useExtensionRegistry } from '@opencloud-eu/web-pkg'
 import SidebarNav from '../../../../src/components/SidebarNav/SidebarNav.vue'
 import sidebarNavItemFixtures from '../../../__fixtures__/sidebarNavItems'
 import { defaultComponentMocks, defaultPlugins, mount } from '@opencloud-eu/web-test-helpers'
@@ -17,8 +18,23 @@ describe('OcSidebarNav', () => {
   })
 })
 
-function getWrapper({ closed = false, checkForUpdates = true, slots = {} } = {}) {
+function getWrapper({ closed = false, slots = {} } = {}) {
   const mocks = defaultComponentMocks()
+
+  const plugins = defaultPlugins({
+    piniaOptions: {
+      capabilityState: {
+        capabilities: {
+          core: {
+            status: { productversion: '3.5.0' }
+          }
+        }
+      }
+    }
+  })
+
+  const { requestExtensions } = useExtensionRegistry()
+  vi.mocked(requestExtensions).mockReturnValue([])
 
   return {
     wrapper: mount(SidebarNav, {
@@ -29,19 +45,7 @@ function getWrapper({ closed = false, checkForUpdates = true, slots = {} } = {})
       },
       global: {
         renderStubDefaultSlot: true,
-        plugins: [
-          ...defaultPlugins({
-            piniaOptions: {
-              capabilityState: {
-                capabilities: {
-                  core: {
-                    status: { productversion: '3.5.0' }
-                  }
-                }
-              }
-            }
-          })
-        ],
+        plugins,
         mocks,
         provide: mocks,
         stubs: { SidebarNavItem: true }

--- a/packages/web-runtime/tests/unit/components/SidebarNav/__snapshots__/SidebarNav.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/components/SidebarNav/__snapshots__/SidebarNav.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`OcSidebarNav > renders navItems into a list 1`] = `
 "<div id="web-nav-sidebar" class="bg-role-surface-container z-40 flex flex-col rounded-l-xl overflow-hidden transition-all duration-350 ease-[cubic-bezier(0.34,0.11,0,1.12)] max-w-[230px] min-w-[230px]" closed="false">
   <nav class="oc-sidebar-nav mb-4 mt-2 px-1" aria-label="Sidebar navigation menu">
+    <!--v-if-->
     <div id="nav-highlighter" class="absolute ml-2 bg-role-secondary-container text-role-on-secondary-container rounded-sm transition-transform duration-200 ease-[cubic-bezier(0.51, 0.06, 0.56, 1.37)]" aria-hidden="true"></div>
     <ul class="oc-list relative">
       <sidebar-nav-item-stub icon="folder" name="Personal" active="true" target="[object Object]" filltype="fill" collapsed="false"></sidebar-nav-item-stub>


### PR DESCRIPTION
Also makes sure to render only one FAB (as we discussed recently in chat), since it doesn't make sense to have multiple FABs displaying.

fixes https://github.com/opencloud-eu/web/issues/2019