### PR TITLE
[full-ci] test: fix ocm invite token parsing

### DIFF
--- a/tests/e2e/support/objects/federation/actions.ts
+++ b/tests/e2e/support/objects/federation/actions.ts
@@ -30,13 +30,12 @@ export const generateInvitation = async (args: { page: Page; user: string }): Pr
     }),
     page.locator(generateInvitationActionConfirmButton).click()
   ])
+  await expect(page.locator(util.format(invitationToken, inviteCode))).toBeVisible()
 
   const serverHostname = new URL(config.baseUrl).host
-
-  // Generate the invitation code by Base64 encoding "token@openCloudUrl"
-  inviteCode = btoa(inviteCode + '@' + serverHostname)
-  await expect(page.locator(util.format(invitationToken, inviteCode))).toBeVisible()
-  federatedInvitationCode.set(user, { code: inviteCode })
+  // Invitation token format: "token@server-host"
+  const inviteToken = `${inviteCode}@${serverHostname}`
+  federatedInvitationCode.set(user, { code: inviteToken })
 }
 
 export const acceptInvitation = async (args: { page: Page; sharer: string }): Promise<void> => {


### PR DESCRIPTION
## Description
Now the ocm ivite token appears in uuidv4 format (without encoding) while creating and `uuidv4@hostname` format while accepting the invite.

Old | <img width="592" height="268" alt="Screenshot from 2026-03-02 10-44-48" src="https://github.com/user-attachments/assets/479b6395-4128-46d5-bcc2-2f6dee8cd758" /> | <img width="653" height="273" alt="Screenshot from 2026-03-02 10-45-01" src="https://github.com/user-attachments/assets/d6e767e4-bf44-4ccb-b4a2-23c996bb6031" />
--|--|--
New |  <img width="653" height="273" alt="Screenshot from 2026-03-02 10-45-52" src="https://github.com/user-attachments/assets/09578e5f-7da5-4464-b72a-13e0e180eba5" /> | <img width="653" height="273" alt="Screenshot from 2026-03-02 10-45-45" src="https://github.com/user-attachments/assets/a4f942ae-88f9-4678-a5a6-123b05965126" />


## Related Issue
- Fixes ocm test failure: https://ci.opencloud.rocks/repos/6/pipeline/2508/222

## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Types of changes
- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
