### PR TITLE
[stable-4.2] fix: backchannel logout react to sid (#1969)

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/auth.ts
+++ b/packages/web-pkg/src/composables/piniaStores/auth.ts
@@ -4,6 +4,7 @@ import { PublicLinkType } from '@opencloud-eu/web-client'
 
 export const useAuthStore = defineStore('auth', () => {
   const accessToken = ref<string>()
+  const sessionId = ref<string>()
   const idpContextReady = ref(false)
   const userContextReady = ref(false)
   const publicLinkToken = ref<string>()
@@ -13,6 +14,9 @@ export const useAuthStore = defineStore('auth', () => {
 
   const setAccessToken = (value: string) => {
     accessToken.value = value
+  }
+  const setSessionId = (value: string) => {
+    sessionId.value = value
   }
   const setIdpContextReady = (value: boolean) => {
     idpContextReady.value = value
@@ -34,6 +38,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   const clearUserContext = () => {
     setAccessToken(null)
+    setSessionId(null)
     setIdpContextReady(null)
     setUserContextReady(null)
   }
@@ -49,6 +54,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   return {
     accessToken,
+    sessionId,
     idpContextReady,
     userContextReady,
     publicLinkToken,
@@ -57,6 +63,7 @@ export const useAuthStore = defineStore('auth', () => {
     publicLinkContextReady,
 
     setAccessToken,
+    setSessionId,
     setIdpContextReady,
     setUserContextReady,
     setPublicLinkContext,

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -807,6 +807,7 @@ export const registerSSEEventListeners = ({
   previewService,
   configStore,
   userStore,
+  authStore,
   router
 }: {
   language: Language
@@ -818,6 +819,7 @@ export const registerSSEEventListeners = ({
   previewService: PreviewService
   configStore: ConfigStore
   userStore: UserStore
+  authStore: AuthStore
   router: Router
 }): void => {
   const resourceQueue = new PQueue({
@@ -842,7 +844,8 @@ export const registerSSEEventListeners = ({
     previewService,
     language,
     router,
-    resourceQueue
+    resourceQueue,
+    authStore
   } satisfies Partial<SseEventWrapperOptions>
 
   clientService.sseAuthenticated.addEventListener(MESSAGE_TYPE.ITEM_RENAMED, (msg) =>

--- a/packages/web-runtime/src/container/sse/common.ts
+++ b/packages/web-runtime/src/container/sse/common.ts
@@ -1,5 +1,7 @@
 import { SSEEventOptions } from './types'
 
-export const onSSEBackchannelLogoutEvent = ({ router }: SSEEventOptions) => {
-  return router.push({ name: 'logout' })
+export const onSSEBackchannelLogoutEvent = ({ router, authStore, sseData }: SSEEventOptions) => {
+  if (authStore.sessionId === sseData.sessionid) {
+    return router.push({ name: 'logout' })
+  }
 }

--- a/packages/web-runtime/src/container/sse/types.ts
+++ b/packages/web-runtime/src/container/sse/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import {
+  AuthStore,
   ClientService,
   ConfigStore,
   MessageStore,
@@ -19,7 +20,8 @@ export const eventSchema = z.object({
   spaceid: z.string().optional(),
   initiatorid: z.string().optional(),
   etag: z.string().optional(),
-  affecteduserids: z.array(z.string()).optional().nullable()
+  affecteduserids: z.array(z.string()).optional().nullable(),
+  sessionid: z.string().optional()
 })
 
 export type EventSchemaType = z.infer<typeof eventSchema>
@@ -31,6 +33,7 @@ export interface SSEEventOptions {
   messageStore: MessageStore
   sharesStore: SharesStore
   configStore: ConfigStore
+  authStore: AuthStore
   clientService: ClientService
   previewService: PreviewService
   router: Router

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -231,6 +231,7 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
           userStore,
           previewService,
           configStore,
+          authStore,
           router
         })
       }

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -57,7 +57,7 @@ const handleRequestedTokenEvent = (event: MessageEvent): void => {
   }
 
   console.debug('[page:oidcCallback:handleRequestedTokenEvent] - received delegated access_token')
-  authService.signInCallback(event.data.data.access_token)
+  authService.signInCallback(event.data.data.access_token, event.data.data.session_id)
 }
 
 onMounted(() => {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -164,7 +164,7 @@ export class AuthService implements AuthServiceInterface {
             `New User Loaded. access_token： ${user.access_token}, refresh_token: ${user.refresh_token}`
           )
           try {
-            await this.userManager.updateContext(user.access_token, fetchUserData)
+            await this.userManager.updateContext(user.access_token, user.profile.sid, fetchUserData)
           } catch (e) {
             console.error(e)
             await this.handleAuthError(unref(this.router.currentRoute))
@@ -211,12 +211,15 @@ export class AuthService implements AuthServiceInterface {
 
       // relevant for page reload: token is already in userStore
       // no userLoaded event and no signInCallback gets triggered
-      const accessToken = await this.userManager.getAccessToken()
+      const user = await this.userManager.getUser()
+      const accessToken = user?.access_token
+      const sessionId = user?.profile?.sid
+
       if (accessToken) {
         console.debug('[authService:initializeContext] - updating context with saved access_token')
 
         try {
-          await this.userManager.updateContext(accessToken, fetchUserData)
+          await this.userManager.updateContext(accessToken, sessionId, fetchUserData)
 
           if (!this.tokenTimerInitialized) {
             const user = await this.userManager.getUser()
@@ -247,7 +250,7 @@ export class AuthService implements AuthServiceInterface {
   /**
    * Sign in callback gets called from the IDP after initial login.
    */
-  public async signInCallback(accessToken?: string) {
+  public async signInCallback(accessToken?: string, sessionId?: string) {
     try {
       if (
         this.configStore.options.embed.enabled &&
@@ -255,7 +258,7 @@ export class AuthService implements AuthServiceInterface {
         accessToken
       ) {
         console.debug('[authService:signInCallback] - setting access_token and fetching user')
-        await this.userManager.updateContext(accessToken, true)
+        await this.userManager.updateContext(accessToken, sessionId, true)
 
         // Setup a listener to handle token refresh
         console.debug('[authService:signInCallback] - adding listener to update-token event')
@@ -383,7 +386,7 @@ export class AuthService implements AuthServiceInterface {
     }
 
     console.debug('[authService:handleDelegatedTokenUpdate] - going to update the access_token')
-    return this.userManager.updateContext(event.data, false)
+    return this.userManager.updateContext(event.data.accesssToken, event.data.sessionId, false)
   }
 }
 

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -132,6 +132,11 @@ export class UserManager extends OidcUserManager {
     return user?.access_token
   }
 
+  async getSessionId(): Promise<string | null> {
+    const user = await this.getUser()
+    return user?.profile?.sid
+  }
+
   async removeUser(unloadReason: UnloadReason = 'logout') {
     this._unloadReason = unloadReason
     await super.removeUser()
@@ -155,7 +160,7 @@ export class UserManager extends OidcUserManager {
     }
   }
 
-  updateContext(accessToken: string, fetchUserData: boolean) {
+  updateContext(accessToken: string, sessionId: string, fetchUserData: boolean) {
     const userKnown = !!this.userStore.user
     const accessTokenChanged = this.authStore.accessToken !== accessToken
     if (!accessTokenChanged) {
@@ -163,6 +168,7 @@ export class UserManager extends OidcUserManager {
     }
 
     this.authStore.setAccessToken(accessToken)
+    this.authStore.setSessionId(sessionId)
 
     this.updateAccessTokenPromise = (async () => {
       if (!fetchUserData) {

--- a/packages/web-runtime/tests/unit/container/sse/files.spec.ts
+++ b/packages/web-runtime/tests/unit/container/sse/files.spec.ts
@@ -1,6 +1,7 @@
 import {
   ClientService,
   PreviewService,
+  useAuthStore,
   useConfigStore,
   useMessages,
   useResourcesStore,
@@ -442,6 +443,7 @@ const getMocks = ({
   const userStore = useUserStore()
   const sharesStore = useSharesStore()
   const configStore = useConfigStore()
+  const authStore = useAuthStore()
   const clientService = mockDeep<ClientService>({ initiatorId: 'local1' })
   const previewService = mockDeep<PreviewService>()
   const router = mockDeep<Router>()
@@ -458,6 +460,7 @@ const getMocks = ({
     userStore,
     sharesStore,
     configStore,
+    authStore,
     clientService,
     previewService,
     resourceQueue,

--- a/packages/web-runtime/tests/unit/container/sse/helpers.spec.ts
+++ b/packages/web-runtime/tests/unit/container/sse/helpers.spec.ts
@@ -3,6 +3,7 @@ import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 import {
   ClientService,
   PreviewService,
+  useAuthStore,
   useConfigStore,
   useMessages,
   useResourcesStore,
@@ -63,6 +64,7 @@ const getMocks = ({
   const userStore = useUserStore()
   const configStore = useConfigStore()
   const sharesStore = useSharesStore()
+  const authStore = useAuthStore()
   const clientService = mockDeep<ClientService>()
   const previewService = mockDeep<PreviewService>()
   const router = mockDeep<Router>()
@@ -77,6 +79,7 @@ const getMocks = ({
     userStore,
     sharesStore,
     configStore,
+    authStore,
     clientService,
     previewService,
     resourceQueue,

--- a/packages/web-runtime/tests/unit/container/sse/shares.spec.ts
+++ b/packages/web-runtime/tests/unit/container/sse/shares.spec.ts
@@ -2,6 +2,7 @@ import {
   ClientService,
   eventBus,
   PreviewService,
+  useAuthStore,
   useConfigStore,
   useMessages,
   useResourcesStore,
@@ -696,6 +697,7 @@ const getMocks = ({
   const userStore = useUserStore()
   const configStore = useConfigStore()
   userStore.user = mockDeep<User>({ id: '1' })
+  const authStore = useAuthStore()
   const sharesStore = useSharesStore()
   const clientService = mockDeep<ClientService>({ initiatorId: 'local1' })
   const previewService = mockDeep<PreviewService>()
@@ -733,6 +735,7 @@ const getMocks = ({
     userStore,
     sharesStore,
     configStore,
+    authStore,
     clientService,
     previewService,
     resourceQueue,

--- a/packages/web-runtime/tests/unit/pages/oidcCallback.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/oidcCallback.spec.ts
@@ -83,14 +83,14 @@ describe('oidcCallback page', () => {
       window.postMessage(
         {
           name: 'opencloud-embed:update-token',
-          data: { access_token: 'access-token' }
+          data: { access_token: 'access-token', session_id: 'session-id' }
         },
         '*'
       )
 
       await new Promise<void>((resolve) => setTimeout(() => resolve(), 10))
 
-      expect(signInCallbackSpy).toHaveBeenCalledWith('access-token')
+      expect(signInCallbackSpy).toHaveBeenCalledWith('access-token', 'session-id')
     })
 
     it('when token update event is received but name is incorrect does not call signInCallback', async () => {

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -71,7 +71,9 @@ describe('AuthService', () => {
 
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
-          getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ access_token: 'access-token', profile: { sid: 'session-id' } }),
           updateContext: mockUpdateContext
         })
       })
@@ -80,7 +82,7 @@ describe('AuthService', () => {
 
       await authService.initializeContext(mock<RouteLocation>({}))
 
-      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
+      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', 'session-id', true)
     })
 
     it('when embed mode is disabled and access_token is not present, should not call updateContext', async () => {
@@ -88,7 +90,7 @@ describe('AuthService', () => {
 
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
-          getAccessToken: vi.fn().mockResolvedValue(null),
+          getUser: vi.fn().mockResolvedValue({ access_token: null, profile: { sid: null } }),
           updateContext: mockUpdateContext
         })
       })
@@ -105,7 +107,9 @@ describe('AuthService', () => {
 
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
-          getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ access_token: 'access-token', profile: { sid: 'session-id' } }),
           updateContext: mockUpdateContext
         })
       })
@@ -114,7 +118,7 @@ describe('AuthService', () => {
 
       await authService.initializeContext(mock<RouteLocation>({}))
 
-      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
+      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', 'session-id', true)
     })
 
     it('when embed mode is enabled, access_token is present and auth is delegated, should not call updateContext', async () => {
@@ -122,7 +126,9 @@ describe('AuthService', () => {
 
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
-          getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ access_token: 'access-token', profile: { sid: 'session-id' } }),
           updateContext: mockUpdateContext
         })
       })
@@ -141,7 +147,9 @@ describe('AuthService', () => {
 
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
-          getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ access_token: 'access-token', profile: { sid: 'session-id' } }),
           updateContext: mockUpdateContext
         })
       })
@@ -150,7 +158,7 @@ describe('AuthService', () => {
 
       await authService.initializeContext(mock<RouteLocation>({}))
 
-      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
+      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', 'session-id', true)
     })
   })
 })


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.2`:
 - [fix: backchannel logout react to sid (#1969)](https://github.com/opencloud-eu/web/pull/1969)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)