### PR TITLE
test(e2e): increase timeout for large file upload step

### DIFF
--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -85,6 +85,9 @@ When(
 
 When(
   '{string} {word} the file upload',
+  // increase the test timeout for large uploads.
+  // ignores the global timeout.
+  { timeout: config.largeUploadTimeout * 1000 },
   async function (this: World, stepUser: string, action: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1,5 +1,4 @@
 import { Download, Locator, Page, expect } from '@playwright/test'
-import { setDefaultTimeout } from '@cucumber/cucumber'
 import util from 'util'
 import path from 'path'
 import { waitForResources } from './utils'
@@ -762,13 +761,9 @@ export const resumeResourceUpload = async (page: Page): Promise<void> => {
   await pauseResumeUpload(page)
   await page.locator(pauseUploadButton).waitFor()
 
-  // increase the test timeout for large uploads
-  setDefaultTimeout(config.largeUploadTimeout * 1000)
   await page
     .locator(uploadInfoSuccessLabelSelector)
     .waitFor({ timeout: config.largeUploadTimeout * 1000 })
-  // revert  to the default timeout
-  setDefaultTimeout(config.testTimeout * 1000)
 
   await page.locator(uploadInfoCloseButton).click()
 }


### PR DESCRIPTION
## Description
The previous fix for increasing timeout for large file upload didn't work. Here, the timeout is applied to the step itself which ignores the global timeout and the new timeout works properly, see [timeouts](https://github.com/cucumber/cucumber-js/blob/HEAD/docs/support_files/timeouts.md)

Test fails as the upload is not completed yet:
- https://ci.opencloud.rocks/repos/6/pipeline/2646/100#L586

## Related Issue

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
