### PR TITLE
[full-ci] chore: bump opencloud for tests to v5.2.0

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,3 +1,3 @@
 # The version of OpenCloud to use in pipelines
-OPENCLOUD_COMMITID=5851db3d939399a54bdd14b3e08ec45de29ceb17
+OPENCLOUD_COMMITID=accbd90b433ec086273c5ed005bfe1ff34107a5e
 OPENCLOUD_BRANCH=main


### PR DESCRIPTION
## Description

Bumps the opencloud commit id to the state that will very likely be released as opencloud-rolling v5.2.0 so that we can verify with all tests.

## Related Issue

Works towards https://github.com/opencloud-eu/opencloud/issues/2437

## Types of changes

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
