### PR TITLE
[with-tracing] fix: e2e-test public deletes folders

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -193,6 +193,8 @@ export const clickResource = async ({
     )
     await resource.click()
     await propfindPromise
+    // wait for the loading spinner to disappear and page is loaded
+    await expect(page.locator('#app-loading-spinner')).toBeHidden()
   }
 }
 

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -15,7 +15,6 @@ export class Resource {
     const startUrl = this.#page.url()
     await po.createResources({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
-    await this.#page.locator('#files-view').waitFor()
   }
 
   async upload(args: Omit<po.uploadResourceArgs, 'page'>): Promise<void> {


### PR DESCRIPTION
https://ci.opencloud.rocks/repos/6/pipeline/2933/122

```
Scenario: public link (attempt 1, retried) # tests/e2e/cucumber/features/shares/link.feature:9
   ......
   ✔ And "Anonymous" creates the following resources # tests/e2e/cucumber/steps/ui/resources.ts:8
       | resource       | type   |
       | myfolder       | folder |
       | myfolder/child | folder |
   ✔ And "Anonymous" uploads the following resources in public link page # tests/e2e/cucumber/steps/ui/public.ts:91
       | resource | type   |
       | PARENT   | folder |
   ✔ And "Anonymous" moves the following resource using drag-drop # tests/e2e/cucumber/steps/ui/resources.ts:99
       | resource      | to        |
       | new-lorem.txt | SubFolder |
   ✔ And "Anonymous" copies the following resource using sidebar-panel # tests/e2e/cucumber/steps/ui/resources.ts:99
       | resource  | to       |
       | lorem.txt | myfolder |
   ✔ And "Anonymous" renames the following public link resources # tests/e2e/cucumber/steps/ui/public.ts:84
       | resource     | as               |
       | lorem.txt    | lorem_new.txt    |
       | textfile.txt | textfile_new.txt |
   ✖ And "Anonymous" deletes the following resources from public link using batch action # tests/e2e/cucumber/steps/ui/public.ts:109
       | resource  | from     |
       | lorem.txt | myfolder |
       | child     | myfolder |
       locator.waitFor: Timeout 30000ms exceeded.
       Call log:
         - waiting for locator('//*[@data-test-selection-resource-name="child"]//input[@type="checkbox"]') to be visible
       
           at selectOrDeselectResources (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/support/objects/app-files/resource/actions.ts:606:66)
           at async Module.deleteResource (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/support/objects/app-files/resource/actions.ts:868:13)
           at async Public.delete (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/support/objects/app-files/page/public.ts:54:9)
           at async processDelete (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/cucumber/steps/ui/resources.ts:305:9)
           at async World.<anonymous> (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/cucumber/steps/ui/public.ts:112:5)
```

fail is due this step: 

```
And "Anonymous" creates the following resources # tests/e2e/cucumber/steps/ui/resources.ts:8
       | resource       | type   |
       | myfolder       | folder |
       | myfolder/child | folder |
```
The test should have failed at this step because we were unable to create the `child` folder -> no `MKCOL` request on the network. I think the problem may be in the parent folder `myfolder`-> it is displayed in the interface, but we have not verified that `MKCOL` has been completed.

<img width="1633" height="698" alt="Screenshot 2026-03-12 at 09 30 40" src="https://github.com/user-attachments/assets/e343fbf0-5db2-4106-9cb5-e74f4ffdd0ab" />




