### PR TITLE
fix:list favorites endpoint

### DIFF
--- a/packages/web-client/src/webdav/index.ts
+++ b/packages/web-client/src/webdav/index.ts
@@ -78,7 +78,7 @@ export const webdav = (baseURI: string, headers?: () => Headers): WebDAV => {
 
   const { search } = SearchFactory(dav, options)
 
-  const { listFavoriteFiles } = ListFavoriteFilesFactory(dav, options)
+  const { listFavoriteFiles } = ListFavoriteFilesFactory(dav)
   const { setFavorite } = SetFavoriteFactory(dav, options)
 
   return {

--- a/packages/web-client/src/webdav/listFavoriteFiles.ts
+++ b/packages/web-client/src/webdav/listFavoriteFiles.ts
@@ -1,20 +1,21 @@
-import { urlJoin } from '../utils'
-import { WebDavOptions } from './types'
 import { DAV, DAVRequestOptions } from './client'
 import { DavProperties, DavPropertyValue } from './constants'
 
-export const ListFavoriteFilesFactory = (dav: DAV, options: WebDavOptions) => {
+export const ListFavoriteFilesFactory = (dav: DAV) => {
   return {
-    listFavoriteFiles({
+    async listFavoriteFiles({
       davProperties = DavProperties.Default,
-      username = '',
       ...opts
-    }: { davProperties?: DavPropertyValue[]; username?: string } & DAVRequestOptions = {}) {
-      return dav.report(urlJoin('files', username), {
+    }: { davProperties?: DavPropertyValue[] } & DAVRequestOptions = {}) {
+      const path = '/spaces/'
+
+      const { results } = await dav.report(path, {
+        pattern: 'is:favorite',
         properties: davProperties,
-        filterRules: { favorite: 1 },
         ...opts
       })
+
+      return results
     }
   }
 }

--- a/packages/web-pkg/src/services/folder/loaders/loaderFavorites.ts
+++ b/packages/web-pkg/src/services/folder/loaders/loaderFavorites.ts
@@ -19,15 +19,14 @@ export class FolderLoaderFavorites implements FolderLoader {
   }
 
   public getTask(context: TaskContext): FolderLoaderTask {
-    const { resourcesStore, clientService, userStore } = context
+    const { resourcesStore, clientService } = context
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    return useTask(function* (signal1, signal2) {
+    return useTask(function* (signal1) {
       resourcesStore.clearResourceList()
       resourcesStore.setAncestorMetaData({})
 
       let resources = yield clientService.webdav.listFavoriteFiles({
-        username: userStore.user?.onPremisesSamAccountName,
         signal: signal1
       })
 


### PR DESCRIPTION
fixed https://github.com/opencloud-eu/opencloud/issues/1633
here is new search favorites: https://github.com/opencloud-eu/opencloud/pull/2454


old favorites used old webdav `/files/{user}` endpoint and ` filterRules`

changed to using new DAV `/spaces` and correct search pattern `is:favorite`

result: 

https://github.com/user-attachments/assets/55318f6b-8897-43d5-9a42-7e190d54d0f2

@db-ot 

