### PR TITLE
[full-ci] test(e2e): fix share type label check

### DIFF
--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -30,7 +30,7 @@ const userTypeFilter = '.invite-form-share-role-type'
 const userTypeFilterDropdown = '.invite-form-share-role-type ul.oc-list'
 const userTypeSelector = '.invite-form-share-role-type-item'
 const selectedUserTypeLabel =
-  '//div[contains(@class,"invite-form-share-role-type")]//span[contains(@class,"oc-filter-chip-label") and text()="%s"]'
+  '//div[contains(@class,"invite-form-share-role-type")]//span[contains(@class,"oc-filter-chip-label")]'
 
 export interface ShareArgs {
   page: Page
@@ -101,7 +101,7 @@ export const createShare = async (args: createShareArgs): Promise<void> => {
     }
     await page.locator(userTypeFilterDropdown).waitFor()
     await page.locator(userTypeSelector).filter({ hasText: federatedShare }).click()
-    await page.locator(util.format(selectedUserTypeLabel, 'External users')).waitFor()
+    await page.locator(selectedUserTypeLabel).filter({ hasText: federatedShare }).waitFor()
   }
   await Collaborator.inviteCollaborators({ page, collaborators: recipients })
   await sidebar.close({ page })


### PR DESCRIPTION
## Description
Check the selected share-type using playwright's hasText filter.

## Related Issue
- Fixes failure: https://ci.opencloud.rocks/repos/6/pipeline/3230/222
```feature
    And "Alice" shares the following resource using the sidebar panel
      │ resource       │ recipient │ type │ role     │ resourceType │ shareType │
      │ folderPublic   │ Brian     │ user │ Can edit │ folder       │ external  │
      │ sampleGif.gif  │ Brian     │ user │ Can edit │ file         │ external  │
      │ testavatar.jpg │ Brian     │ user │ Can view │ file         │ external  │
    ✖ failed
      locator.waitFor: Timeout 30000ms exceeded.
      Call log:
        - waiting for locator('//div[contains(@class,"invite-form-share-role-type")]//span[contains(@class,"oc-filter-chip-label") and text()="External users"]') to be visible

          at Module.createShare (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/support/objects/app-files/share/actions.ts:71:82)
          at async Share.create (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/support/objects/app-files/share/index.ts:10:9)
          at async World.<anonymous> (/woodpecker/src/github.com/opencloud-eu/web/web/tests/e2e/cucumber/steps/ui/shares.ts:43:9)
```
## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
