### PR TITLE
add final step for branch protection

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -239,7 +239,8 @@ def main(ctx):
         return translation_sync(ctx)
     is_release_pr = (ctx.build.event == "pull_request" and ctx.build.sender == "openclouders" and "🎉 release" in ctx.build.title.lower())
     if is_release_pr:
-        return licenseCheck()
+        license = licenseCheck()
+        return license + pipelinesDependsOn(notifyMatrixCheckSteps(), license)
 
     release = readyReleaseGo()
 
@@ -279,7 +280,7 @@ def stagePipelines(ctx):
     return unit_test_pipelines + e2e_pipelines + keycloak_pipelines
 
 def afterPipelines(ctx):
-    return publishRelease(ctx) + [purgeBuildArtifactCache(ctx), purgeOpencloudBuildCache(ctx), purgeBrowserCache(ctx), purgeTracingCache(ctx)] + pipelinesDependsOn(notifyMatrix(), stagePipelines(ctx))
+    return publishRelease(ctx) + [purgeBuildArtifactCache(ctx), purgeOpencloudBuildCache(ctx), purgeBrowserCache(ctx), purgeTracingCache(ctx)] + pipelinesDependsOn(notifyMatrixCheckSteps(), stagePipelines(ctx))
 
 def translation_sync(ctx):
     return [{
@@ -637,11 +638,11 @@ def e2eTests(ctx):
 
     return pipelines
 
-def notifyMatrix():
+def notifyMatrixCheckSteps():
     pipelines = []
 
     result = {
-        "name": "chat-notifications",
+        "name": "all-checks-finished",
         "skip_clone": True,
         "runs_on": ["success", "failure"],
         "steps": [


### PR DESCRIPTION
similar as here https://github.com/opencloud-eu/opencloud/pull/2501

@kulmann now we should make [all-checks-finished](https://ci.opencloud.rocks/repos/6/pipeline/3256/1) required in GH
maybe this step [Require Pull Request Labels / label (pull_request)](https://github.com/opencloud-eu/web/actions/runs/23339765645/job/67890282471?pr=2192) should also be made required?