### PR TITLE
fix(extension-sdk): support vite 8 by switching from AMD to UMD format

### DIFF
--- a/packages/extension-sdk/index.mjs
+++ b/packages/extension-sdk/index.mjs
@@ -163,10 +163,12 @@ export const defineConfig = (overrides = {}) => {
               format: 'umd',
               name,
               // only used to avoid the MISSING_GLOBAL_NAME warning
-              globals: Object.fromEntries(external.map((e) => [
-                e,
-                e.replace(/^@/, '').replace(/[/-](\w)/g, (_, c) => c.toUpperCase())
-              ])),
+              globals: Object.fromEntries(
+                external.map((e) => [
+                  e,
+                  e.replace(/^@/, '').replace(/[/-](\w)/g, (_, c) => c.toUpperCase())
+                ])
+              ),
               entryFileNames: join('js', `[name]${isProduction ? '-[hash]' : ''}.js`)
             }
           }


### PR DESCRIPTION
## Summary

- Switch extension build format from `amd` to `umd` to support Vite 8 (Rolldown does not support AMD, [rolldown#2528](https://github.com/rolldown/rolldown/issues/2528))
- UMD includes an AMD branch, so extensions loaded via RequireJS continue to work via `define()`
- Add `completeUmdCurrentScriptPlugin` to fix `document.currentScript` resolution for async module loaders ([upstreamed to Vite](https://github.com/dschmidt/vite/tree/fix/umd-current-script-polyfill))
- Use `rollupOptions` (not `rolldownOptions`) to maintain vite 7 compatibility

### Trade-offs

- **No code splitting**: UMD bundles everything into a single file. Dynamic `import()` calls are inlined. This is the only way forward with UMD and Rolldown — code splitting requires ESM.
- **`import.meta` replaced with `{}`**: Rolldown replaces `import.meta` with `{}` in UMD. Extensions using dependencies that access `import.meta` will see `EMPTY_IMPORT_META` warnings and should suppress them per-app after verifying they're harmless.

## Test plan

- [x] All extensions in [web-extensions](https://github.com/opencloud-eu/web-extensions) build successfully with both vite 7 and vite 8
- [x] `?url` asset imports resolve correctly at runtime with RequireJS
- [x] `document.currentScript` polyfill verified working in browser
- [ ] End-to-end testing of all extensions in OpenCloud