### PR TITLE
build!: publish libs as esm only

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -47,22 +47,18 @@
     "exports": {
       ".": {
         "default": "./dist/design-system.js",
-        "require": "./dist/design-system.cjs",
         "types": "./dist/src/index.d.ts"
       },
       "./components": {
         "default": "./dist/design-system/components.js",
-        "require": "./dist/design-system/components.cjs",
         "types": "./dist/src/components/index.d.ts"
       },
       "./composables": {
         "default": "./dist/design-system/composables.js",
-        "require": "./dist/design-system/composables.cjs",
         "types": "./dist/src/composables/index.d.ts"
       },
       "./helpers": {
         "default": "./dist/design-system/helpers.js",
-        "require": "./dist/design-system/helpers.cjs",
         "types": "./dist/src/helpers/index.d.ts"
       },
       "./dist/design-system.css": {

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -41,7 +41,8 @@ export default defineConfig({
         'design-system/components': resolve(__dirname, 'src/components/index.ts'),
         'design-system/composables': resolve(__dirname, 'src/composables/index.ts'),
         'design-system/helpers': resolve(__dirname, 'src/helpers/index.ts')
-      }
+      },
+      formats: ['es']
     },
     rolldownOptions: {
       external: [
@@ -54,12 +55,7 @@ export default defineConfig({
         '**/*.spec.ts',
         'vue',
         'pinia'
-      ],
-      output: {
-        globals: {
-          vue: 'Vue'
-        }
-      }
+      ]
     }
   },
   plugins: [

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -21,32 +21,26 @@
     "exports": {
       ".": {
         "default": "./dist/web-client.js",
-        "require": "./dist/web-client.cjs",
         "types": "./dist/src/index.d.ts"
       },
       "./graph": {
         "default": "./dist/web-client/graph.js",
-        "require": "./dist/web-client/graph.cjs",
         "types": "./dist/src/graph/index.d.ts"
       },
       "./graph/generated": {
         "default": "./dist/web-client/graph/generated.js",
-        "require": "./dist/web-client/graph/generated.cjs",
         "types": "./dist/src/graph/generated/index.d.ts"
       },
       "./ocs": {
         "default": "./dist/web-client/ocs.js",
-        "require": "./dist/web-client/ocs.cjs",
         "types": "./dist/src/ocs/index.d.ts"
       },
       "./sse": {
         "default": "./dist/web-client/sse.js",
-        "require": "./dist/web-client/sse.cjs",
         "types": "./dist/src/sse/index.d.ts"
       },
       "./webdav": {
         "default": "./dist/web-client/webdav.js",
-        "require": "./dist/web-client/webdav.cjs",
         "types": "./dist/src/webdav/index.d.ts"
       }
     }

--- a/packages/web-client/vite.config.ts
+++ b/packages/web-client/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
         'web-client/ocs': resolve(__dirname, 'src/ocs/index.ts'),
         'web-client/sse': resolve(__dirname, 'src/sse/index.ts'),
         'web-client/webdav': resolve(__dirname, 'src/webdav/index.ts')
-      }
+      },
+      formats: ['es']
     }
   },
   plugins: [

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -22,8 +22,7 @@
     "linkDirectory": false,
     "exports": {
       ".": {
-        "import": "./dist/web-pkg.js",
-        "require": "./dist/web-pkg.umd.cjs",
+        "default": "./dist/web-pkg.js",
         "types": "./dist/src/index.d.ts"
       }
     }

--- a/packages/web-pkg/vite.config.ts
+++ b/packages/web-pkg/vite.config.ts
@@ -30,8 +30,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'web-pkg',
-      fileName: 'web-pkg'
+      fileName: 'web-pkg',
+      formats: ['es']
     },
     rolldownOptions: {
       external

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -21,8 +21,7 @@
     "linkDirectory": false,
     "exports": {
       ".": {
-        "import": "./dist/web-test-helpers.es.js",
-        "require": "./dist/web-test-helpers.umd.cjs",
+        "default": "./dist/web-test-helpers.js",
         "types": "./dist/src/index.d.ts"
       }
     }

--- a/packages/web-test-helpers/vite.config.ts
+++ b/packages/web-test-helpers/vite.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'web-test-helpers',
-      fileName: (format) => `web-test-helpers.${format}.js`
+      fileName: 'web-test-helpers',
+      formats: ['es']
     },
     rolldownOptions: {
       external: [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)]


### PR DESCRIPTION
Removes builds other than esm for our libs: `design-system`, `web-client`, `web-pkg`, `web-test-helpers`.

Technically this is a breaking change, but I don't expect any app using one of these libs without esm. So IMO it doesn't justify a new major release of Web.