### PR TITLE
feat: add module federation support for external apps

### DIFF
--- a/dev/docker/opencloud/csp.yaml
+++ b/dev/docker/opencloud/csp.yaml
@@ -6,6 +6,8 @@ directives:
     - 'blob:'
     - 'https://raw.githubusercontent.com/opencloud-eu/awesome-apps/'
     - 'https://update.opencloud.eu/'
+    - 'https://host.docker.internal:*'
+    - 'wss://host.docker.internal:*'
   default-src:
     - '''none'''
   font-src:
@@ -39,6 +41,8 @@ directives:
     - '''self'''
     - '''unsafe-inline'''
     - 'https://www.gstatic.com/'
+    - 'https://host.docker.internal:*'
   style-src:
     - '''self'''
     - '''unsafe-inline'''
+    - 'https://host.docker.internal:*'

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   ],
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",
+    "@module-federation/runtime": "2.2.3",
+    "@module-federation/vite": "1.13.4",
     "@cucumber/cucumber": "12.7.0",
     "@cucumber/messages": "32.2.0",
     "@cucumber/pretty-formatter": "3.2.0",

--- a/packages/extension-sdk/externalModules.mjs
+++ b/packages/extension-sdk/externalModules.mjs
@@ -1,0 +1,15 @@
+// Shared dependencies provided by the host to external apps.
+// Keep in sync with sharedModules in packages/web-runtime/src/container/application/index.ts
+export const externalModules = [
+  'vue',
+  'luxon',
+  'pinia',
+  'vue3-gettext',
+  '@opencloud-eu/web-pkg',
+  '@opencloud-eu/web-client',
+  '@opencloud-eu/web-client/graph',
+  '@opencloud-eu/web-client/graph/generated',
+  '@opencloud-eu/web-client/ocs',
+  '@opencloud-eu/web-client/sse',
+  '@opencloud-eu/web-client/webdav'
+]

--- a/packages/extension-sdk/index.mjs
+++ b/packages/extension-sdk/index.mjs
@@ -7,52 +7,27 @@ import { join } from 'path'
 import { cwd } from 'process'
 import { readFileSync, existsSync } from 'fs'
 import tailwindcss from '@tailwindcss/vite'
-
+import basicSsl from '@vitejs/plugin-basic-ssl'
 import vue from '@vitejs/plugin-vue'
+import { federation } from '@module-federation/vite'
+import { externalModules } from './externalModules.mjs'
 
 const distDir = process.env.OPENCLOUD_EXTENSION_DIST_DIR || 'dist'
 
-/**
- * Capture `document.currentScript` before the UMD factory is called.
- *
- * Vite's UMD URL resolution uses `document.currentScript` to resolve relative
- * asset paths. However, `document.currentScript` is only set by the browser
- * during synchronous script execution. When a module loader like RequireJS
- * calls the UMD factory callback asynchronously, `document.currentScript` is
- * `null`, causing a fallback to `document.baseURI` and incorrect URL resolution.
- *
- * This plugin captures `document.currentScript` at the top of the script
- * (while it's still valid) and replaces references inside with the captured
- * value.
- *
- * Upstreamed to Vite: https://github.com/dschmidt/vite/tree/fix/umd-current-script-polyfill
- */
-const completeUmdCurrentScriptPlugin = () => {
-  return {
-    name: 'vite:complete-umd-current-script',
-    renderChunk(code, _chunk, opts) {
-      if (opts.format !== 'umd') return
-      if (!code.includes('document.currentScript')) return
-
-      return {
-        code:
-          'var __vite_currentScript = typeof document !== "undefined" ? document.currentScript : null;' +
-          code.replaceAll('document.currentScript', '__vite_currentScript'),
-        map: null
-      }
-    }
-  }
-}
-
 const certsDir = process.env.OPENCLOUD_CERTS_DIR
-const defaultHttps = () =>
-  certsDir && {
-    key: readFileSync(join(certsDir, 'server.key')),
-    cert: readFileSync(join(certsDir, 'server.crt'))
-  }
+const customHttps = certsDir
+  ? {
+      key: readFileSync(join(certsDir, 'server.key')),
+      cert: readFileSync(join(certsDir, 'server.crt'))
+    }
+  : null
 
 const manifestFile = 'manifest.json'
 const manifestPath = join('./src/', manifestFile)
+const remoteEntryName = 'remoteEntry'
+const remoteEntryExt = '.mjs'
+
+// Generates manifest.json for OpenCloud app discovery.
 const manifestPlugin = () => {
   let outputDir
 
@@ -75,9 +50,9 @@ const manifestPlugin = () => {
         return
       }
 
-      // Find the entry chunk
+      // Find the remote entry chunk (emitted by the federation plugin)
       const entryChunk = Object.values(bundle).find(
-        (chunk) => chunk.type === 'chunk' && chunk.isEntry
+        (chunk) => chunk.type === 'chunk' && chunk.name === remoteEntryName
       )
 
       if (!entryChunk) {
@@ -104,7 +79,7 @@ const manifestPlugin = () => {
       // Add manifest.json to the bundle
       this.emitFile({
         type: 'asset',
-        fileName: 'manifest.json',
+        fileName: manifestFile,
         source: JSON.stringify(manifest, null, 2)
       })
     }
@@ -124,26 +99,7 @@ export const defineConfig = (overrides = {}) => {
     const name = overrides.name || packageJson.name
 
     // set default config
-    const { https = defaultHttps(), port = 9210 } = overrides?.server || {}
-    const isHttps = !!https
-
-    // keep in sync with packages/web-runtime/src/container/application/index.ts
-    const external = [
-      'vue',
-      'luxon',
-      'pinia',
-      'vue3-gettext',
-
-      '@opencloud-eu/web-client',
-      '@opencloud-eu/web-client/graph',
-      '@opencloud-eu/web-client/graph/generated',
-      '@opencloud-eu/web-client/ocs',
-      '@opencloud-eu/web-client/sse',
-      '@opencloud-eu/web-client/webdav',
-      '@opencloud-eu/web-pkg',
-      'web-client',
-      'web-pkg'
-    ]
+    const { port = 9210 } = overrides?.server || {}
 
     return mergeConfig(
       {
@@ -152,41 +108,58 @@ export const defineConfig = (overrides = {}) => {
           cssCodeSplit: true,
           minify: isProduction,
           outDir: distDir,
-          // use rollupOptions instead of rolldownOptions as long as we support vite 7
           rollupOptions: {
-            external,
-            preserveEntrySignatures: 'strict',
             input: {
               [name]: './src/index.ts'
             },
             output: {
-              format: 'umd',
-              name,
-              // only used to avoid the MISSING_GLOBAL_NAME warning
-              globals: Object.fromEntries(
-                external.map((e) => [
-                  e,
-                  e.replace(/^@/, '').replace(/[/-](\w)/g, (_, c) => c.toUpperCase())
-                ])
-              ),
-              entryFileNames: join('js', `[name]${isProduction ? '-[hash]' : ''}.js`)
+              entryFileNames: join('js', `[name]${isProduction ? '-[hash]' : ''}${remoteEntryExt}`),
+              chunkFileNames: join('js', `[name]-[hash]${remoteEntryExt}`)
             }
           }
         },
         plugins: [
           vue({
-            // set to true when switching to esm
             customElement: false,
             ...(isTesting && { template: { compilerOptions: { whitespace: 'preserve' } } })
           }),
-          manifestPlugin(),
-          completeUmdCurrentScriptPlugin(),
-          tailwindcss()
+          ...(customHttps ? [] : [basicSsl({ name: 'opencloud' })]),
+          {
+            name: 'fix-sec-fetch-dest',
+            configureServer(server) {
+              server.middlewares.use((req, res, next) => {
+                // Vite skips its transform middleware for requests with sec-fetch-dest: document,
+                // which breaks direct browser navigation to JS files like remoteEntry.js.
+                if (
+                  (req.url?.endsWith('.js') || req.url?.endsWith('.mjs')) &&
+                  req.headers['sec-fetch-dest'] === 'document'
+                ) {
+                  req.headers['sec-fetch-dest'] = 'script'
+                }
+                next()
+              })
+            }
+          },
+          federation({
+            name,
+            exposes: { '.': './src/index.ts' },
+            filename: `${remoteEntryName}${isProduction ? '-[hash]' : ''}${remoteEntryExt}`,
+            shared: Object.fromEntries(
+              externalModules.map((pkg) => [pkg, { singleton: true, import: false }])
+            ),
+            manifest: false,
+            dts: false
+          }),
+          tailwindcss(),
+          manifestPlugin()
         ],
         server: {
+          origin: `https://host.docker.internal:${port}`,
+          host: 'host.docker.internal',
           port,
           strictPort: true,
-          ...(isHttps && https)
+          cors: true,
+          ...(customHttps && { https: customHttps })
         },
         test: {
           globals: true,

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -14,7 +14,9 @@
     "directory": "packages/extension-sdk"
   },
   "dependencies": {
+    "@module-federation/vite": "^1.13.4",
     "@tailwindcss/vite": "^4.1.11",
+    "@vitejs/plugin-basic-ssl": "^2.2.0",
     "@vitejs/plugin-vue": "^6.0.0"
   },
   "peerDependencies": {

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -18,21 +18,22 @@ import * as webClientOcs from '@opencloud-eu/web-client/ocs'
 import * as webClientSse from '@opencloud-eu/web-client/sse'
 import * as webClientWebdav from '@opencloud-eu/web-client/webdav'
 
+import type { ModuleFederation } from '@module-federation/runtime'
 import { urlJoin } from '@opencloud-eu/web-client'
 import { App } from 'vue'
 import { AppConfigObject, ClassicApplicationScript } from '@opencloud-eu/web-pkg'
 
 export { NextApplication } from './next'
 
-// shim requirejs, trust me it's there... :
+// shim requirejs, trust me it's there...
 const { requirejs, define } = window as any
 
-// register modules with requirejs to provide them to applications
-// keep in sync with packages/extension-sdk/index.mjs
-const injectionMap = {
+// Shared modules provided to external apps via RequireJS (legacy AMD) and Module Federation.
+// Must match externalModules in packages/extension-sdk/externalModules.mjs — verified by unit test.
+export const sharedModules: Record<string, unknown> = {
+  vue,
   luxon,
   pinia,
-  vue,
   'vue3-gettext': vueGettext,
   '@opencloud-eu/web-pkg': webPkg,
   '@opencloud-eu/web-client': webClient,
@@ -40,17 +41,46 @@ const injectionMap = {
   '@opencloud-eu/web-client/graph/generated': webClientGraphGenerated,
   '@opencloud-eu/web-client/ocs': webClientOcs,
   '@opencloud-eu/web-client/sse': webClientSse,
-  '@opencloud-eu/web-client/webdav': webClientWebdav,
-  'web-pkg': webPkg,
-  'web-client': webClient
+  '@opencloud-eu/web-client/webdav': webClientWebdav
 }
 
-for (const [key, value] of Object.entries(injectionMap)) {
-  define(key, () => value)
+/**
+ * Register shared modules with RequireJS (legacy AMD) and Module Federation.
+ * Called once during bootstrap before any applications are loaded.
+ */
+export function registerSharedModules(federation: ModuleFederation) {
+  // RequireJS (legacy AMD apps)
+  const { define } = window as any
+  for (const [key, value] of Object.entries(sharedModules)) {
+    define(key, () => value)
+  }
+
+  // Module Federation
+  const shared: Record<
+    string,
+    { version: string; scope: string[]; get: () => Promise<() => unknown> }
+  > = {}
+  for (const [key, value] of Object.entries(sharedModules)) {
+    shared[key] = {
+      version: '0.0.0',
+      scope: ['default'],
+      get: () => Promise.resolve(() => value)
+    }
+  }
+  federation.registerShared(shared)
 }
 
 const loadScriptDynamicImport = async <T>(moduleUri: string) => {
   return ((await import(/* @vite-ignore */ moduleUri)) as any).default as T
+}
+
+const loadScriptModuleFederation = async <T>(
+  federation: ModuleFederation,
+  remoteUrl: string
+): Promise<T> => {
+  federation.registerRemotes([{ name: remoteUrl, entry: remoteUrl, type: 'module' }])
+  const module = await federation.loadRemote(remoteUrl)
+  return (module as any).default as T
 }
 
 const loadScriptRequireJS = <T>(moduleUri: string) => {
@@ -64,12 +94,14 @@ const loadScriptRequireJS = <T>(moduleUri: string) => {
 }
 
 export const loadApplication = async ({
+  federation,
   appName,
   applicationKey,
   applicationPath,
   applicationConfig,
   configStore
 }: {
+  federation: ModuleFederation
   appName?: string
   applicationKey: string
   applicationPath: string
@@ -97,8 +129,11 @@ export const loadApplication = async ({
         applicationPath = urlJoin(configStore.serverUrl, applicationPath)
       }
 
-      if (applicationPath.endsWith('.mjs') || applicationPath.endsWith('.ts')) {
-        applicationScript = await loadScriptDynamicImport<ClassicApplicationScript>(applicationPath)
+      if (applicationPath.endsWith('.mjs')) {
+        applicationScript = await loadScriptModuleFederation<ClassicApplicationScript>(
+          federation,
+          applicationPath
+        )
       } else {
         applicationScript = await loadScriptRequireJS<ClassicApplicationScript>(applicationPath)
       }

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -1,4 +1,10 @@
-import { buildApplication, loadApplication, NextApplication } from './application'
+import { ModuleFederation } from '@module-federation/runtime'
+import {
+  buildApplication,
+  loadApplication,
+  NextApplication,
+  registerSharedModules
+} from './application'
 import { RouteLocationRaw, Router, RouteRecordNormalized } from 'vue-router'
 import { App, computed, watch } from 'vue'
 import { loadTheme } from '../helpers/theme'
@@ -226,6 +232,9 @@ export const initializeApplications = async ({
     applicationScript: ClassicApplicationScript
   }
 
+  const federation = new ModuleFederation({ name: 'opencloud-web', remotes: [] })
+  registerSharedModules(federation)
+
   let applicationKeys: string[] = []
   let applicationResponses: PromiseSettledResult<ApplicationResponse>[] = []
   if (appProviderApps) {
@@ -233,6 +242,7 @@ export const initializeApplications = async ({
     applicationResponses = await Promise.allSettled(
       appProviderService.appNames.map((appName) =>
         loadApplication({
+          federation,
           appName,
           applicationKey: `web-app-external-${appName}`,
           applicationPath: 'web-app-external',
@@ -248,13 +258,15 @@ export const initializeApplications = async ({
       })),
       ...configStore.externalApps
     ]
+
     applicationKeys = rawApplications.map((rawApplication) => rawApplication.path)
     applicationResponses = await Promise.allSettled(
-      rawApplications.map((rawApplications) =>
+      rawApplications.map((rawApplication) =>
         loadApplication({
-          applicationKey: rawApplications.path,
-          applicationPath: rawApplications.path,
-          applicationConfig: rawApplications.config || {},
+          federation,
+          applicationKey: rawApplication.path,
+          applicationPath: rawApplication.path,
+          applicationConfig: rawApplication.config || {},
           configStore
         })
       )

--- a/packages/web-runtime/tests/unit/container/application/sharedModules.spec.ts
+++ b/packages/web-runtime/tests/unit/container/application/sharedModules.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error — no type declaration for .mjs, not worth shipping one for a test
+import { externalModules } from '../../../../../extension-sdk/externalModules.mjs'
+import { sharedModules } from '../../../../src/container/application'
+
+describe('sharedModules', () => {
+  it('matches externalModules from extension-sdk exactly', () => {
+    expect(Object.keys(sharedModules).sort()).toEqual(externalModules.sort())
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,12 @@ importers:
       '@cucumber/pretty-formatter':
         specifier: 3.2.0
         version: 3.2.0(@cucumber/messages@32.2.0)
+      '@module-federation/runtime':
+        specifier: 2.2.3
+        version: 2.2.3(node-fetch@3.3.2)
+      '@module-federation/vite':
+        specifier: 1.13.4
+        version: 1.13.4(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))
       '@noble/hashes':
         specifier: 2.0.1
         version: 2.0.1
@@ -270,9 +276,15 @@ importers:
 
   packages/extension-sdk:
     dependencies:
+      '@module-federation/vite':
+        specifier: ^1.13.4
+        version: 1.13.4(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.2.2(vite@8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3))
+      '@vitejs/plugin-basic-ssl':
+        specifier: ^2.2.0
+        version: 2.3.0(vite@8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3))
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
         version: 6.0.5(vite@8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
@@ -1916,6 +1928,43 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@module-federation/dts-plugin@2.2.3':
+    resolution: {integrity: sha512-a7Rv2nPJGLufeeOFiLmgRNxw97peAB+SjyBZdpPa3g5ojOEdhZYxdpB15RYiyOtPUc7PhZsSvfYKgj4cEU8f1w==}
+    peerDependencies:
+      typescript: ^4.9.0 || ^5.0.0
+      vue-tsc: '>=1.0.24'
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
+
+  '@module-federation/error-codes@2.2.3':
+    resolution: {integrity: sha512-3+qOylnuljh1XulzXd3iNhALXuVXPVGFUupz9qnUL1paWX48F89Wex3egu6psZhxi3F7y7TA7ykjfWpP0vlrjQ==}
+
+  '@module-federation/managers@2.2.3':
+    resolution: {integrity: sha512-xBv2hg88K4QIPVYKNAYm+LnH5hRuTPGeFya2obSxalagnMb6lEw7Gko5QqXAZDgCK44dkuqslu8/YtMEXc3v7w==}
+
+  '@module-federation/runtime-core@2.2.3':
+    resolution: {integrity: sha512-muGMkv1AQIkCQy8mIa6lmgHu3qTasl/se+bZHERulD3gddK6ninM/Hc7mHyUVNO9rVhb+5Fv7QiCYahH4pRrIg==}
+
+  '@module-federation/runtime@2.2.3':
+    resolution: {integrity: sha512-5xAIPhzNPLXL7J61ZJxNiM+kpKfKw2IKf4oAT1KFVxntZnnWZiZFAkzTeRiNlfIjwbgasKqBoARTLbu1GEaydA==}
+
+  '@module-federation/sdk@2.2.3':
+    resolution: {integrity: sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==}
+    peerDependencies:
+      node-fetch: ^3.3.2
+    peerDependenciesMeta:
+      node-fetch:
+        optional: true
+
+  '@module-federation/third-party-dts-extractor@2.2.3':
+    resolution: {integrity: sha512-PweNCC79K+fV/BxBjnkJnK1xrrSq9rWmqZat2CfmxStwPhO9yy5Q7XikZnwwUF7mb4p7WoniQRsz//h1aYUdqw==}
+
+  '@module-federation/vite@1.13.4':
+    resolution: {integrity: sha512-7XJJacrc8ctlOfzMS1klQQl1r1wEY/lWGuHVfDwKwH/CLvKL5z+A0VajT+/6lnaotyiYKYy35Iormr2abzTgHg==}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
@@ -2861,6 +2910,12 @@ packages:
   '@vavt/util@2.1.2':
     resolution: {integrity: sha512-L3UbSJthJwr3wq0x93O5TrCepimrmVZaIl2ciZbeL18G5++gBhJXNhcH7RcVk/6rr3SavWOvwhig0mqRLoR7dw==}
 
+  '@vitejs/plugin-basic-ssl@2.3.0':
+    resolution: {integrity: sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    peerDependencies:
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3086,6 +3141,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -3117,6 +3176,10 @@ packages:
 
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-regex@4.1.1:
     resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
@@ -3196,6 +3259,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -3338,6 +3405,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3488,6 +3559,10 @@ packages:
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
   cropperjs@1.6.2:
     resolution: {integrity: sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA==}
 
@@ -3527,6 +3602,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  date-format@4.0.14:
+    resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
+    engines: {node: '>=4.0'}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -3562,6 +3641,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -3668,6 +3750,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -3807,6 +3892,10 @@ packages:
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
+  expand-tilde@2.0.2:
+    resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
+    engines: {node: '>=0.10.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3869,6 +3958,14 @@ packages:
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-file-up@2.0.1:
+    resolution: {integrity: sha512-qVdaUhYO39zmh28/JLQM5CoYN9byEOKEH4qfa8K1eNV17W0UUMJ9WgbR/hHFH+t5rcl+6RTb5UC7ck/I+uRkpQ==}
+    engines: {node: '>=8'}
+
+  find-pkg@2.0.0:
+    resolution: {integrity: sha512-WgZ+nKbELDa6N3i/9nrHeNznm+lY3z4YfhDDWgW+5P0pdmMj26bxaxU11ookgY3NyP9GC7HvZ9etp0jRFqGEeQ==}
     engines: {node: '>=8'}
 
   find-replace@5.0.2:
@@ -3936,6 +4033,14 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3991,6 +4096,14 @@ packages:
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
     engines: {node: '>=10'}
+
+  global-modules@1.0.0:
+    resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
+    engines: {node: '>=0.10.0'}
+
+  global-prefix@1.0.2:
+    resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
+    engines: {node: '>=0.10.0'}
 
   globals@17.4.0:
     resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
@@ -4056,6 +4169,10 @@ packages:
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  homedir-polyfill@1.0.3:
+    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
+    engines: {node: '>=0.10.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -4200,6 +4317,10 @@ packages:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
 
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -4212,6 +4333,11 @@ packages:
   isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
     engines: {node: '>=10'}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -4286,6 +4412,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -4446,6 +4575,9 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
+  lodash.clonedeepwith@4.5.0:
+    resolution: {integrity: sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -4463,6 +4595,13 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  log4js@6.9.1:
+    resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
+    engines: {node: '>=8.0'}
+
+  long-timeout@0.1.1:
+    resolution: {integrity: sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==}
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -4701,6 +4840,10 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  node-schedule@2.1.1:
+    resolution: {integrity: sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==}
+    engines: {node: '>=6'}
+
   node-stdlib-browser@1.3.1:
     resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
     engines: {node: '>=10'}
@@ -4817,6 +4960,10 @@ packages:
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
+
+  parse-passwd@1.0.0:
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
+    engines: {node: '>=0.10.0'}
 
   password-sheriff@2.0.0:
     resolution: {integrity: sha512-wt/vYZVdrROLi6LWBBsau8lM0V24KTvtzN62Iunh+C6dV+5q8Jn1HccOBO6dmm8+4IuM7plSUyD2ZV6ykSIj6g==}
@@ -5068,6 +5215,9 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  rambda@9.4.2:
+    resolution: {integrity: sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -5149,9 +5299,17 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  resolve-dir@1.0.1:
+    resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
+    engines: {node: '>=0.10.0'}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
+    hasBin: true
+
+  resolve@1.22.8:
+    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
 
   retry@0.12.0:
@@ -5285,6 +5443,9 @@ packages:
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
+  sorted-array-functions@1.3.0:
+    resolution: {integrity: sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -5345,6 +5506,10 @@ packages:
 
   stream-http@3.2.0:
     resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
+
+  streamroller@3.1.5:
+    resolution: {integrity: sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==}
+    engines: {node: '>=8.0'}
 
   string-argv@0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
@@ -5600,6 +5765,10 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -5915,6 +6084,10 @@ packages:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -5942,6 +6115,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -6966,6 +7151,90 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@module-federation/dts-plugin@2.2.3(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+    dependencies:
+      '@module-federation/error-codes': 2.2.3
+      '@module-federation/managers': 2.2.3(node-fetch@3.3.2)
+      '@module-federation/sdk': 2.2.3(node-fetch@3.3.2)
+      '@module-federation/third-party-dts-extractor': 2.2.3
+      adm-zip: 0.5.16
+      ansi-colors: 4.1.3
+      axios: 1.13.6
+      chalk: 3.0.0
+      fs-extra: 9.1.0
+      isomorphic-ws: 5.0.0(ws@8.18.0)
+      lodash.clonedeepwith: 4.5.0
+      log4js: 6.9.1
+      node-schedule: 2.1.1
+      rambda: 9.4.2
+      typescript: 5.9.3
+      ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 3.2.6(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - node-fetch
+      - supports-color
+      - utf-8-validate
+
+  '@module-federation/error-codes@2.2.3': {}
+
+  '@module-federation/managers@2.2.3(node-fetch@3.3.2)':
+    dependencies:
+      '@module-federation/sdk': 2.2.3(node-fetch@3.3.2)
+      find-pkg: 2.0.0
+      fs-extra: 9.1.0
+    transitivePeerDependencies:
+      - node-fetch
+
+  '@module-federation/runtime-core@2.2.3(node-fetch@3.3.2)':
+    dependencies:
+      '@module-federation/error-codes': 2.2.3
+      '@module-federation/sdk': 2.2.3(node-fetch@3.3.2)
+    transitivePeerDependencies:
+      - node-fetch
+
+  '@module-federation/runtime@2.2.3(node-fetch@3.3.2)':
+    dependencies:
+      '@module-federation/error-codes': 2.2.3
+      '@module-federation/runtime-core': 2.2.3(node-fetch@3.3.2)
+      '@module-federation/sdk': 2.2.3(node-fetch@3.3.2)
+    transitivePeerDependencies:
+      - node-fetch
+
+  '@module-federation/sdk@2.2.3(node-fetch@3.3.2)':
+    optionalDependencies:
+      node-fetch: 3.3.2
+
+  '@module-federation/third-party-dts-extractor@2.2.3':
+    dependencies:
+      find-pkg: 2.0.0
+      fs-extra: 9.1.0
+      resolve: 1.22.8
+
+  '@module-federation/vite@1.13.4(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))':
+    dependencies:
+      '@module-federation/dts-plugin': 2.2.3(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/runtime': 2.2.3(node-fetch@3.3.2)
+      '@module-federation/sdk': 2.2.3(node-fetch@3.3.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      defu: 6.1.4
+      es-module-lexer: 1.7.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      vite: 8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - node-fetch
+      - rollup
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.9.1
@@ -7820,6 +8089,10 @@ snapshots:
 
   '@vavt/util@2.1.2': {}
 
+  '@vitejs/plugin-basic-ssl@2.3.0(vite@8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3))':
+    dependencies:
+      vite: 8.0.2(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.98.0)(yaml@2.8.3)
+
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.2.0)(lightningcss@1.32.0)(sass@1.98.0))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@25.2.0)(lightningcss@1.32.0)(sass@1.98.0)
@@ -8093,6 +8366,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.16: {}
+
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -8135,6 +8410,8 @@ snapshots:
   alien-signals@0.4.14: {}
 
   alien-signals@3.1.2: {}
+
+  ansi-colors@4.1.3: {}
 
   ansi-regex@4.1.1: {}
 
@@ -8210,6 +8487,8 @@ snapshots:
       ast-kit: 2.2.0
 
   asynckit@0.4.0: {}
+
+  at-least-node@1.0.0: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -8369,6 +8648,11 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -8525,6 +8809,10 @@ snapshots:
 
   crelt@1.0.6: {}
 
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
   cropperjs@1.6.2: {}
 
   cross-fetch@4.1.0:
@@ -8571,6 +8859,8 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  date-format@4.0.14: {}
+
   dateformat@4.6.3: {}
 
   de-indent@1.0.2: {}
@@ -8603,6 +8893,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  defu@6.1.4: {}
 
   delayed-stream@1.0.0: {}
 
@@ -8712,6 +9004,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -8922,6 +9216,10 @@ snapshots:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
 
+  expand-tilde@2.0.2:
+    dependencies:
+      homedir-polyfill: 1.0.3
+
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -8974,6 +9272,14 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-file-up@2.0.1:
+    dependencies:
+      resolve-dir: 1.0.1
+
+  find-pkg@2.0.0:
+    dependencies:
+      find-file-up: 2.0.1
 
   find-replace@5.0.2: {}
 
@@ -9029,6 +9335,19 @@ snapshots:
 
   fs-extra@11.3.3:
     dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
@@ -9098,6 +9417,20 @@ snapshots:
   global-dirs@3.0.1:
     dependencies:
       ini: 2.0.0
+
+  global-modules@1.0.0:
+    dependencies:
+      global-prefix: 1.0.2
+      is-windows: 1.0.2
+      resolve-dir: 1.0.1
+
+  global-prefix@1.0.2:
+    dependencies:
+      expand-tilde: 2.0.2
+      homedir-polyfill: 1.0.3
+      ini: 1.3.8
+      is-windows: 1.0.2
+      which: 1.3.1
 
   globals@17.4.0: {}
 
@@ -9181,6 +9514,10 @@ snapshots:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  homedir-polyfill@1.0.3:
+    dependencies:
+      parse-passwd: 1.0.0
 
   hookable@5.5.3: {}
 
@@ -9292,6 +9629,8 @@ snapshots:
 
   is-what@5.5.0: {}
 
+  is-windows@1.0.2: {}
+
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
@@ -9299,6 +9638,10 @@ snapshots:
   isexe@2.0.0: {}
 
   isomorphic-timers-promises@1.0.1: {}
+
+  isomorphic-ws@5.0.0(ws@8.18.0):
+    dependencies:
+      ws: 8.18.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -9358,6 +9701,10 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonfile@6.2.0:
     dependencies:
@@ -9511,6 +9858,8 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
+  lodash.clonedeepwith@4.5.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.mergewith@4.6.2: {}
@@ -9525,6 +9874,18 @@ snapshots:
       lodash._baseuniq: 4.6.0
 
   lodash@4.17.23: {}
+
+  log4js@6.9.1:
+    dependencies:
+      date-format: 4.0.14
+      debug: 4.4.3(supports-color@8.1.1)
+      flatted: 3.4.2
+      rfdc: 1.4.1
+      streamroller: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  long-timeout@0.1.1: {}
 
   lower-case@2.0.2:
     dependencies:
@@ -9761,6 +10122,12 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  node-schedule@2.1.1:
+    dependencies:
+      cron-parser: 4.9.0
+      long-timeout: 0.1.1
+      sorted-array-functions: 1.3.0
+
   node-stdlib-browser@1.3.1:
     dependencies:
       assert: 2.1.0
@@ -9911,6 +10278,8 @@ snapshots:
       '@babel/code-frame': 7.29.0
       index-to-position: 1.2.0
       type-fest: 4.41.0
+
+  parse-passwd@1.0.0: {}
 
   password-sheriff@2.0.0: {}
 
@@ -10204,6 +10573,8 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  rambda@9.4.2: {}
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -10298,7 +10669,18 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  resolve-dir@1.0.1:
+    dependencies:
+      expand-tilde: 2.0.2
+      global-modules: 1.0.0
+
   resolve@1.22.11:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  resolve@1.22.8:
     dependencies:
       is-core-module: 2.16.1
       path-parse: 1.0.7
@@ -10487,6 +10869,8 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
+  sorted-array-functions@1.3.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -10549,6 +10933,14 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       xtend: 4.0.2
+
+  streamroller@3.1.5:
+    dependencies:
+      date-format: 4.0.14
+      debug: 4.4.3(supports-color@8.1.1)
+      fs-extra: 8.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   string-argv@0.3.1: {}
 
@@ -10784,6 +11176,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 
@@ -11136,6 +11530,10 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -11162,6 +11560,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  ws@8.18.0: {}
 
   ws@8.19.0: {}
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -185,6 +185,9 @@ export default defineConfig(({ mode, command }) => {
           exclude: ['crypto']
         }),
 
+        // Module Federation shared deps are registered at runtime in bootstrap.ts.
+        // The @module-federation/vite plugin is only used on the remote (extension-sdk) side.
+
         // We need to "undefine" `define` which is set by requirejs loaded in index.html
         treatAsCommonjs(),
 


### PR DESCRIPTION
## Summary

Replace the ESM dynamic import path for external apps with Vite Module Federation. External apps built with the extension-sdk now produce a federated `remoteEntry.mjs` that shares dependencies with the host via the `@module-federation/runtime`.

### What changed

**Extension SDK** — the biggest change:
- Replace AMD output format with `@module-federation/vite` federation plugin
- Shared deps (`vue`, `pinia`, `luxon`, `vue3-gettext`, `web-pkg`, `web-client`) declared with `import: false` (host provides them)
- `remoteEntry.mjs` output for ESM identification
- `@vitejs/plugin-basic-ssl` for dev HTTPS (falls back to `OPENCLOUD_CERTS_DIR` if set)
- Manifest plugin for OpenCloud app discovery
- `sec-fetch-dest` middleware workaround for direct browser navigation to JS/MJS files
- `externalModules.mjs` as single source of truth for the shared dep list

**Host (web-runtime)**:
- `bootstrap.ts`: create `ModuleFederation` instance, register shared modules via `registerSharedModules()`
- `application/index.ts`: route `.mjs` external apps through `loadRemote()`, keep AMD path for legacy `.js` apps

**CSP (dev only)**:
- Allow `https://` and `wss://` `host.docker.internal:*` for cross-origin remote dev server loading

### Tested combinations

| Host | Remote | Remote Vite | Result |
| --- | --- | --- | --- |
| Dev server (Vite 8) | Dev server | Vite 7 | ✅ |
| Dev server (Vite 8) | Dev server | Vite 8 | ✅ |
| Dev server (Vite 8) | Production build, served by OpenCloud | Vite 7 | ✅ |
| Dev server (Vite 8) | Production build, served by OpenCloud | Vite 8 | ✅ |
| Dev server (Vite 8) | Dev build (`--mode development`), served by OpenCloud | Vite 7 | ✅ |
| Production build, served by OpenCloud | Dev server | Vite 7 | ✅ |
| Production build, served by OpenCloud | Production build, served by OpenCloud | Vite 7 | ✅ |
| Production build, served by OpenCloud | Production build, served by OpenCloud | Vite 8 | ✅ |

## How to test

### Dev host + dev remote

1. Start the docker dev stack: `cd web && docker compose up -d`
2. Add to `web/dev/docker/opencloud.web.config.json`:
   ```json
   "external_apps": [
     { "id": "counter", "path": "https://host.docker.internal:9210/remoteEntry.mjs" }
   ]
   ```
3. In the extension app (e.g. `opencloud-counter/frontend`):
   - `pnpm link /path/to/web/packages/extension-sdk`
   - Add `"@module-federation/vite": "1.13.4"` to devDependencies
   - `pnpm install`
4. Start the remote: `cd opencloud-counter/frontend && pnpm vite --host`
5. Start the host: `cd web && pnpm vite`
6. Open `https://host.docker.internal:9201`

### Prod host + prod remote (served by OpenCloud)

1. Build the remote: `cd opencloud-counter/frontend && OPENCLOUD_EXTENSION_DIST_DIR=/path/to/web/dev/docker/apps/counter pnpm build`
2. Build the host: `cd web && pnpm build`
3. Restart OpenCloud: `docker compose restart opencloud`
4. Open `https://host.docker.internal:9200`
   - No `external_apps` config needed — OpenCloud auto-discovers from `dev/docker/apps/`

## Test plan

- [ ] Verify dev+dev: `pnpm vite` in both web and an extension-sdk app, load host
- [x] Verify prod+prod: build both, deploy via OpenCloud, load host
- [x] Verify internal apps (files, search, etc.) still load via WEB_APPS_MAP
- [x] Verify legacy AMD external apps still load via RequireJS path