### PR TITLE
Fix password modal can be confirmed even if the password is empty

### DIFF
--- a/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
+++ b/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
@@ -42,7 +42,7 @@ export default defineComponent({
     }
   },
   emits: ['confirm', 'update:confirmDisabled'],
-  setup(props, { expose }) {
+  setup(props, { emit, expose }) {
     const { showMessage, showErrorMessage } = useMessages()
     const clientService = useClientService()
     const passwordPolicyService = usePasswordPolicyService()
@@ -52,9 +52,15 @@ export default defineComponent({
     const password = ref('')
     const errorMessage = ref<string>()
 
+    emit('update:confirmDisabled', true)
+
     const onInput = (value: string) => {
       password.value = value
       errorMessage.value = undefined
+
+      if (!value) {
+        emit('update:confirmDisabled', true)
+      }
     }
 
     const onConfirm = async () => {

--- a/packages/web-app-files/tests/unit/components/Modals/SetLinkPasswordModal.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Modals/SetLinkPasswordModal.spec.ts
@@ -10,6 +10,21 @@ describe('SetLinkPasswordModal', () => {
 
     expect(wrapper.find('oc-text-input-stub').exists()).toBeTruthy()
   })
+  it('should disable the confirm button on mount', () => {
+    const { wrapper } = getWrapper()
+
+    expect(wrapper.emitted('update:confirmDisabled')).toBeTruthy()
+    expect(wrapper.emitted('update:confirmDisabled')![0]).toEqual([true])
+  })
+  it('should disable the confirm button when the password is cleared', async () => {
+    const { wrapper } = getWrapper()
+
+    wrapper.vm.onInput('somepassword')
+    wrapper.vm.onInput('')
+
+    const emitted = wrapper.emitted('update:confirmDisabled')!
+    expect(emitted[emitted.length - 1]).toEqual([true])
+  })
   describe('method "onConfirm"', () => {
     it('updates the link', async () => {
       const { wrapper } = getWrapper()


### PR DESCRIPTION
## Related Issue

- Fixes #2027 

## Types of changes

- [x] Bugfix
