### PR TITLE
fix: idp logout on network errors

### DIFF
--- a/packages/web-app-webfinger/src/views/Resolve.vue
+++ b/packages/web-app-webfinger/src/views/Resolve.vue
@@ -56,7 +56,7 @@ export default defineComponent({
       } catch (e) {
         console.error(e)
         if (e.response?.status === 401) {
-          return authService.handleAuthError(unref(route), { forceLogout: true })
+          return authService.handleAuthError(unref(route))
         }
         hasError.value = true
       }

--- a/packages/web-pkg/src/composables/authContext/useAuthService.ts
+++ b/packages/web-pkg/src/composables/authContext/useAuthService.ts
@@ -2,7 +2,11 @@ import { useService } from '../service'
 import { NavigationFailure } from 'vue-router'
 
 export interface AuthServiceInterface {
-  handleAuthError(route: any, options?: { forceLogout?: boolean }): any
+  handleAuthError(
+    route: any,
+    /** @deprecated This option is no longer used. */
+    options?: { forceLogout?: boolean }
+  ): any
   signinSilent(): Promise<unknown>
   logoutUser(): Promise<void | NavigationFailure>
   getRefreshToken(): Promise<string>

--- a/packages/web-pkg/src/composables/webWorkers/tokenTimerWorker/useTokenTimerWorker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/tokenTimerWorker/useTokenTimerWorker.ts
@@ -2,11 +2,18 @@ import { ref, unref } from 'vue'
 import { ErrorTimeout } from 'oidc-client-ts'
 import { AuthServiceInterface } from '../../authContext'
 import { WebWorker, useWebWorkersStore } from '../../piniaStores/webWorkers'
+import { Router } from 'vue-router'
 import TokenWorker from './worker?worker'
 
 export type TokenTimerWorkerTopic = 'set' | 'reset'
 
-export const useTokenTimerWorker = ({ authService }: { authService: AuthServiceInterface }) => {
+export const useTokenTimerWorker = ({
+  authService,
+  router
+}: {
+  authService: AuthServiceInterface
+  router: Router
+}) => {
   const { createWorker } = useWebWorkersStore()
 
   const worker = ref<WebWorker>()
@@ -15,20 +22,15 @@ export const useTokenTimerWorker = ({ authService }: { authService: AuthServiceI
     worker.value = createWorker(TokenWorker as unknown as string)
 
     unref(unref(worker).worker).onmessage = () => {
-      authService.signinSilent().catch(async (error) => {
-        if (error instanceof ErrorTimeout) {
-          console.warn('token renewal timed out, retrying in 5 seconds...')
+      authService.signinSilent().catch((error) => {
+        if (error instanceof ErrorTimeout || error instanceof TypeError) {
+          console.warn('token renewal failed due to network error, retrying in 5 seconds...')
           unref(worker).post(JSON.stringify({ topic: 'set', expiry: 5, expiryThreshold: 0 }))
           return
         }
 
         console.error('token renewal error:', error)
-
-        // log out user if they don't have a refresh token
-        const refreshToken = await authService.getRefreshToken()
-        if (!refreshToken) {
-          return authService.logoutUser()
-        }
+        authService.handleAuthError(unref(router.currentRoute))
       })
     }
   }

--- a/packages/web-pkg/tests/unit/composables/webWorkers/tokenTimerWorker/useTokenTimerWorker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/tokenTimerWorker/useTokenTimerWorker.spec.ts
@@ -1,6 +1,7 @@
 import { unref } from 'vue'
 import { getComposableWrapper } from '@opencloud-eu/web-test-helpers'
 import { mock } from 'vitest-mock-extended'
+import { Router } from 'vue-router'
 import {
   AuthServiceInterface,
   WebWorker,
@@ -86,7 +87,10 @@ function getWrapper({
 }) {
   return {
     wrapper: getComposableWrapper(() => {
-      const instance = useTokenTimerWorker({ authService: mock<AuthServiceInterface>() })
+      const instance = useTokenTimerWorker({
+        authService: mock<AuthServiceInterface>(),
+        router: mock<Router>()
+      })
 
       const webWorkersStore = useWebWorkersStore()
 

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -121,7 +121,7 @@ export class AuthService implements AuthServiceInterface {
         const { options } = this.configStore
 
         if (!options.embed?.enabled || !options.embed?.delegateAuthentication) {
-          this.tokenTimerWorker = useTokenTimerWorker({ authService: this })
+          this.tokenTimerWorker = useTokenTimerWorker({ authService: this, router: this.router })
           this.tokenTimerWorker.startWorker()
         }
       }
@@ -144,13 +144,8 @@ export class AuthService implements AuthServiceInterface {
 
       if (!this.userManager.areEventHandlersRegistered) {
         this.userManager.events.addAccessTokenExpired((): void => {
-          const handleExpirationError = () => {
-            console.error('AccessToken Expired')
-            this.handleAuthError(unref(this.router.currentRoute), { forceLogout: true })
-          }
-
-          // retry silent signin once, force logout if it fails
-          this.userManager.signinSilent().catch(handleExpirationError)
+          console.debug('AccessToken Expired')
+          // error (+ potential retry) is handled by the token timer worker
         })
 
         this.userManager.events.addAccessTokenExpiring(() => {
@@ -162,6 +157,10 @@ export class AuthService implements AuthServiceInterface {
             expiry: user.expires_in,
             expiryThreshold: this.accessTokenExpiryThreshold
           })
+
+          if (!this.tokenTimerInitialized) {
+            this.tokenTimerInitialized = true
+          }
 
           console.debug(`New User Loaded`)
           try {
@@ -186,7 +185,7 @@ export class AuthService implements AuthServiceInterface {
           }
         })
         this.userManager.events.addSilentRenewError(async (error) => {
-          console.error('Silent Renew Error：', error)
+          console.error('Silent Renew Error:', error)
           await this.handleAuthError(unref(this.router.currentRoute))
         })
 
@@ -290,10 +289,7 @@ export class AuthService implements AuthServiceInterface {
     return '/?' + new URLSearchParams(currentQuery as Record<string, string>).toString()
   }
 
-  public async handleAuthError(
-    route: RouteLocation,
-    { forceLogout = false }: { forceLogout?: boolean } = {}
-  ) {
+  public async handleAuthError(route: RouteLocation) {
     if (isPublicLinkContextRequired(this.router, route)) {
       const token = extractPublicLinkToken(route)
       this.publicLinkManager.clear(token)
@@ -304,20 +300,22 @@ export class AuthService implements AuthServiceInterface {
       })
     }
     if (isUserContextRequired(this.router, route) || isIdpContextRequired(this.router, route)) {
-      if (forceLogout) {
+      const throwAuthError = async () => {
+        await this.userManager.removeUser('authError')
         this.tokenTimerWorker?.resetTokenTimer()
-        await this.logoutUser()
-        return
       }
-
       const user = await this.userManager.getUser()
-      if (user?.expires_in !== undefined && user.expires_in < 0) {
-        // token expired, simply return and let the regular auth flow do its thing
+      if (user?.expired === true) {
+        // token expired, attempt an immediate silent signin
+        try {
+          await this.userManager.signinSilent()
+        } catch {
+          await throwAuthError()
+        }
         return
       }
 
-      await this.userManager.removeUser('authError')
-      this.tokenTimerWorker?.resetTokenTimer()
+      await throwAuthError()
       return
     }
     // authGuard is taking care of redirecting the user to the


### PR DESCRIPTION
Improves the general IDP flow on network errors in 2 ways:

- When the silent signin fails due to a network error, web now tries to re-authenticate every 5 seconds until the network is back up (or the browser tab gets closed). This should be safe to do since we're not causing any server load.
- When throwing an auth error due to an expired token, web now tries one more silent signin before actually throwing the error. This can happen asynchronously to the retry mechanism described above, e.g. when the network comes back, and the token has yet to be renewed, but the user performs an action in the meantime.

fixes https://github.com/opencloud-eu/web/issues/2128

supersedes https://github.com/opencloud-eu/web/pull/2129