### PR TITLE
fix: v-oc-tooltip not reactive

### DIFF
--- a/packages/design-system/src/directives/OcTooltip.ts
+++ b/packages/design-system/src/directives/OcTooltip.ts
@@ -2,6 +2,7 @@ import { computePosition, offset, flip, shift, arrow } from '@floating-ui/dom'
 import { DirectiveBinding } from 'vue'
 
 interface TooltipData {
+  content: string
   tooltipEl: HTMLElement | null
   showHandler: () => void
   hideHandler: () => void
@@ -11,7 +12,7 @@ interface TooltipData {
 
 const tooltipMap = new WeakMap<HTMLElement, TooltipData>()
 
-const showTooltip = async (el: HTMLElement, content: string) => {
+const showTooltip = async (el: HTMLElement) => {
   const data = tooltipMap.get(el)
   if (!data || data.tooltipEl) {
     return
@@ -19,7 +20,11 @@ const showTooltip = async (el: HTMLElement, content: string) => {
 
   const tooltipEl = document.createElement('div')
   tooltipEl.setAttribute('role', 'tooltip')
-  tooltipEl.textContent = content
+
+  const textEl = document.createElement('span')
+  textEl.classList.add('oc-tooltip-content')
+  textEl.textContent = data.content
+  tooltipEl.appendChild(textEl)
 
   const arrowEl = document.createElement('div')
   arrowEl.classList.add('arrow')
@@ -94,15 +99,18 @@ const initOrUpdate = (el: HTMLElement, { value }: DirectiveBinding) => {
   }
 
   const existingTooltip = tooltipMap.get(el)
-  if (existingTooltip && existingTooltip.tooltipEl) {
-    const contentEl = existingTooltip.tooltipEl
-    if (contentEl) {
-      contentEl.textContent = value
+  if (existingTooltip) {
+    existingTooltip.content = value
+    if (existingTooltip.tooltipEl) {
+      const contentEl = existingTooltip.tooltipEl.querySelector('.oc-tooltip-content')
+      if (contentEl) {
+        contentEl.textContent = value
+      }
     }
     return
   }
 
-  const showHandler = () => showTooltip(el, value)
+  const showHandler = () => showTooltip(el)
   const hideHandler = () => hideTooltip(el)
   const clickHandler = () => hideTooltip(el)
   const escapeHandler = (e: KeyboardEvent) => {
@@ -112,6 +120,7 @@ const initOrUpdate = (el: HTMLElement, { value }: DirectiveBinding) => {
   }
 
   tooltipMap.set(el, {
+    content: value,
     tooltipEl: null,
     showHandler,
     hideHandler,


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

This PR fixes the bug where the tooltip doesn't update when the content changes.

This happens, for example, when you reduce the viewport width and toggle the favorites, the favorite state changes but the tooltip text stays the same.

<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
