### PR TITLE
feat: handle UI_InsertFile postMessage from Collabora

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
     restart: unless-stopped
 
   collabora:
-    image: collabora/code:25.04.8.2.1
+    image: collabora/code:25.04.9.4.1
     entrypoint: ['/bin/bash', '-c']
     command: ['coolconfig generate-proof-key && /start-collabora-online.sh']
     environment:

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -361,6 +361,39 @@ const handlePostMessagesCollabora = async (event: MessageEvent) => {
         }),
         focusTrapInitial: false
       })
+      return
+    }
+
+    if (message.MessageId === 'UI_InsertFile') {
+      const callback = message.Values?.callback
+      const mimeTypeFilter = message.Values?.mimeTypeFilter
+
+      dispatchModal({
+        elementClass: 'file-picker-modal',
+        title:
+          callback === 'Action_CompareDocuments'
+            ? $gettext('Select document to compare')
+            : $gettext('Insert file'),
+        customComponent: FilePickerModal,
+        hideActions: true,
+        customComponentAttrs: () => ({
+          parentFolderLink: getParentFolderLink(resource),
+          allowedFileTypes: mimeTypeFilter || [],
+          callbackFn: async ({ resource }: { resource: Resource }) => {
+            const { downloadURL: url } = await webdav.getFileInfo(space, resource, {
+              davProperties: [DavProperty.DownloadURL]
+            })
+
+            const values: Record<string, unknown> = { url }
+            if (callback === 'Action_CompareDocuments') {
+              values.filename = resource.name
+            }
+
+            postMessageToCollabora(callback, values)
+          }
+        }),
+        focusTrapInitial: false
+      })
     }
   } catch (e) {
     console.debug('Error parsing Collabora PostMessage', e)


### PR DESCRIPTION
Add handler for Collabora's UI_InsertFile postMessage, which is sent
when EnableInsertRemoteFile is true. Opens the OpenCloud file picker
filtered by MIME types from the message, then sends back the selected
file's download URL via the callback specified by
Collabora (Action_CompareDocuments).

Note: line 364, added the return after the UI_InsertGraphic handler for
consistency with the other handlers.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>

<img width="1820" height="756" alt="opencloud-compare-documents" src="https://github.com/user-attachments/assets/4715fc8f-27d3-470b-982a-3d63ac684f75" />
