### PR TITLE
feat: add intent parameter to distinguish file preview from download

### DIFF
--- a/packages/web-app-epub-reader/src/index.ts
+++ b/packages/web-app-epub-reader/src/index.ts
@@ -18,6 +18,9 @@ export default defineWebApplication({
             applicationId: appId,
             fileContentOptions: {
               responseType: 'blob'
+            },
+            urlForResourceOptions: {
+              intent: 'preview'
             }
           })
         },

--- a/packages/web-app-pdf-viewer/src/index.ts
+++ b/packages/web-app-pdf-viewer/src/index.ts
@@ -13,7 +13,8 @@ const routes = [
     component: AppWrapperRoute(PdfViewer, {
       applicationId: 'pdf-viewer',
       urlForResourceOptions: {
-        disposition: 'inline'
+        disposition: 'inline',
+        intent: 'preview'
       }
     }),
     name: 'pdf-viewer',

--- a/packages/web-app-preview/src/index.ts
+++ b/packages/web-app-preview/src/index.ts
@@ -21,7 +21,8 @@ export default defineWebApplication({
         component: AppWrapperRoute(App, {
           applicationId: appId,
           urlForResourceOptions: {
-            disposition: 'inline'
+            disposition: 'inline',
+            intent: 'preview'
           }
         }),
         name: 'media',

--- a/packages/web-app-text-editor/src/index.ts
+++ b/packages/web-app-text-editor/src/index.ts
@@ -93,7 +93,10 @@ export default defineWebApplication({
       {
         path: '/:driveAliasAndItem(.*)?',
         component: AppWrapperRoute(TextEditor, {
-          applicationId: appId
+          applicationId: appId,
+          fileContentOptions: {
+            intent: 'preview'
+          }
         }),
         name: 'text-editor',
         meta: {

--- a/packages/web-client/src/webdav/getFileUrl.ts
+++ b/packages/web-client/src/webdav/getFileUrl.ts
@@ -7,6 +7,19 @@ import { ocs } from '../ocs'
 import { GetFileInfoFactory } from './getFileInfo'
 import { DavProperty } from './constants'
 
+/**
+ * Add intent query parameter to URL for audit logging
+ * @param url The original URL
+ * @param intent The access intent ('preview' or 'download')
+ * @returns URL with intent parameter added
+ */
+const addIntentToUrl = (url: string, intent: 'preview' | 'download'): string => {
+  if (!url) return url
+  const urlObj = new URL(url, window.location.origin)
+  urlObj.searchParams.set('intent', intent)
+  return urlObj.toString()
+}
+
 export const GetFileUrlFactory = (
   dav: DAV,
   getFileContentsFactory: ReturnType<typeof GetFileContentsFactory>,
@@ -21,11 +34,13 @@ export const GetFileUrlFactory = (
         disposition = 'attachment',
         version = null,
         username = '',
+        intent = 'download',
         ...opts
       }: {
         disposition?: 'inline' | 'attachment'
         version?: string
         username?: string
+        intent?: 'preview' | 'download'
       } & DAVRequestOptions
     ): Promise<string> {
       // FIXME: re-introduce query parameters
@@ -40,6 +55,10 @@ export const GetFileUrlFactory = (
       if (disposition === 'inline') {
         const response = await getFileContentsFactory.getFileContents(space, resource, {
           responseType: 'blob',
+          headers: {
+            'X-OC-Intent': intent,
+            ...opts.headers
+          },
           ...opts
         })
         return URL.createObjectURL(response.body)
@@ -56,13 +75,13 @@ export const GetFileUrlFactory = (
       }
 
       if (resource.downloadURL) {
-        return resource.downloadURL
+        return addIntentToUrl(resource.downloadURL, intent)
       }
 
       const { downloadURL } = await getFileInfoFactory.getFileInfo(space, resource, {
         davProperties: [DavProperty.DownloadURL]
       })
-      return downloadURL
+      return addIntentToUrl(downloadURL, intent)
     },
     revokeUrl: (url: string) => {
       if (url && url.startsWith('blob:')) {

--- a/packages/web-pkg/src/composables/download/useDownloadFile.ts
+++ b/packages/web-pkg/src/composables/download/useDownloadFile.ts
@@ -28,7 +28,8 @@ export const useDownloadFile = (options?: DownloadFileOptions) => {
       }
       const url = await clientService.webdav.getFileUrl(space, file, {
         version,
-        username: userStore.user?.onPremisesSamAccountName
+        username: userStore.user?.onPremisesSamAccountName,
+        intent: 'download'
       })
       triggerDownloadWithFilename(url, file.name)
     } catch (e) {

--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -101,6 +101,7 @@ export class PreviewService {
       scalingup: options.scalingup || 0,
       preview: Object.hasOwnProperty.call(options, 'preview') ? options.preview : 1,
       a: Object.hasOwnProperty.call(options, 'a') ? options.a : 1,
+      intent: 'preview',
       ...(options.processor && { processor: options.processor }),
       ...(options.etag && { c: options.etag.replaceAll('"', '') }),
       ...(options.dimensions && options.dimensions[0] && { x: options.dimensions[0] }),


### PR DESCRIPTION
## Summary

Add client-side intent signaling to distinguish between file previews and downloads for audit logging. This enables fine-grained access control policies (e.g., ban downloads of MP4/PDF while allowing previews).

## Purpose

Enable OpenCloud to audit and control file access patterns by distinguishing:
- **View**: User opens file in browser/app for reading
- **Download**: User saves file locally

This allows organizations to implement policies like:
- Allow viewing of MP4 videos but ban downloads
- Allow previews of PDFs but track/restrict downloads
- Enforce different rules based on file type and user group

Microsoft 365 implements similar intent signaling, making this a standard pattern for collaborative platforms.

## Changes

- **Intent Parameter Support**: Added `intent` parameter ('preview'|'download') to `getFileUrl()` 
- **Viewer Apps Updated**: All file viewers now explicitly signal intent:
  - Preview app (images, videos, audio)
  - PDF viewer
  - EPUB reader
  - Text editor
- **Download Signaling**: Download composable explicitly passes `intent: 'download'`
- **Query Parameter & Headers**: Intent propagates via:
  - Query parameter: `?intent=preview|download`
  - HTTP header: `X-OC-Intent`
- **Preview Service**: Thumbnail generation includes `intent: 'preview'`

## Testing Status

⚠️ **Proof of Concept**: Changes have not been fully tested. This PR is a reference implementation and requires:
- Integration testing with opencloud-eu/opencloud#2563
- Backend verification that intent is properly detected
- End-to-end testing of audit event distinction

## Notes

- Backward compatible: defaults to 'download' intent if not specified
- No changes to existing API contracts
- Purely additive - existing code paths unchanged