### PR TITLE
fix(runtime): optimize auth flow with expired token

### DIFF
--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="oc-login h-screen" :style="backgroundImgStyle">
-    <h1 class="sr-only" v-text="pageTitle" />
-    <router-view class="relative z-1" />
-    <img
-      v-if="!backgroundImg && route.fullPath !== '/'"
-      alt="OpenCloud emblem"
-      src="/packages/design-system/src/assets/images/icon-lilac.svg"
-      class="hidden sm:block fixed w-3xs xs:w-xs md:w-md lg:w-lg bottom-[-40px] right-[-40px]"
-    />
+    <div v-if="pathIsRoot" class="flex items-center justify-center h-full bg-role-surface">
+      <oc-spinner size="large" :aria-label="$gettext('Loading')" />
+    </div>
+    <template v-else>
+      <h1 class="sr-only" v-text="pageTitle" />
+      <router-view class="relative z-1" />
+      <img
+        v-if="!backgroundImg && !pathIsRoot"
+        alt="OpenCloud emblem"
+        src="/packages/design-system/src/assets/images/icon-lilac.svg"
+        class="hidden sm:block fixed w-3xs xs:w-xs md:w-md lg:w-lg bottom-[-40px] right-[-40px]"
+      />
+    </template>
   </div>
 </template>
 
@@ -31,5 +36,9 @@ const pageTitle = computed(() => {
 const backgroundImg = computed(() => unref(currentTheme).background)
 const backgroundImgStyle = computed(() => {
   return unref(backgroundImg) ? { backgroundImage: `url(${unref(backgroundImg)})` } : {}
+})
+
+const pathIsRoot = computed(() => {
+  return unref(route)?.fullPath === '/'
 })
 </script>

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -204,6 +204,12 @@ export class AuthService implements AuthServiceInterface {
       const accessToken = user?.access_token
       const sessionId = user?.profile?.sid
 
+      if (user?.expired === true) {
+        // throw auth error, which will retry another silent signin
+        await this.handleAuthError(unref(this.router.currentRoute))
+        return
+      }
+
       if (accessToken) {
         console.debug('[authService:initializeContext] - updating context with saved access_token')
 
@@ -294,7 +300,7 @@ export class AuthService implements AuthServiceInterface {
       if (user?.expired === true) {
         // token expired, attempt an immediate silent signin
         try {
-          await this.userManager.signinSilent()
+          await this.userManager.signinSilent({ silentRequestTimeoutInSeconds: 2 })
         } catch {
           await throwAuthError()
         }


### PR DESCRIPTION
- Calls `handleAuthError` before firing any other initial protected API request, which then retries a silent signin. This prevents unnecessary requests that would only return `401`.
- Reduces the timeout for the silent signin retry in `handleAuthError` to 2 seconds. This should be enough to check the validity of the current session, no need to let the user wait longer.

Also, adds a loading state to the plain layout for the `/` route. This route is not known to the web client and signals that this is only a temporary state (hence "loading").

refs https://github.com/opencloud-eu/opencloud/issues/1595