### PR TITLE
feat(preview): play next audio file automatically after current track…

### DIFF
--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -434,12 +434,12 @@ watch(activeMediaFile, (newValue, oldValue) => {
   currentImageRotation.value = 0
 
   if (oldValue !== null) {
-      if (unref(isAutoAdvancing)) {
-        isAutoAdvancing.value = false
-      } else {
-        isAutoPlayEnabled.value = false
-      }
+    if (unref(isAutoAdvancing)) {
+      isAutoAdvancing.value = false
+    } else {
+      isAutoPlayEnabled.value = false
     }
+  }
 
   emit('update:resource', unref(activeMediaFile).resource)
 })

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -54,6 +54,7 @@
           v-else-if="activeMediaFile.isAudio"
           :file="activeMediaFile"
           :is-auto-play-enabled="isAutoPlayEnabled"
+          @ended="onAudioEnded"
         />
       </div>
       <media-controls
@@ -180,6 +181,7 @@ const activeIndex = ref<number>()
 const mediaFiles = ref<MediaFile[]>([])
 const folderLoaded = ref(false)
 const isAutoPlayEnabled = ref(true)
+const isAutoAdvancing = ref(false)
 const photoRollEnabled = ref(true)
 const preview = useTemplateRef<HTMLElement>('preview')
 const keyBindings: string[] = []
@@ -339,6 +341,15 @@ const goToPrev = () => {
   updateLocalHistory()
 }
 
+const onAudioEnded = () => {
+  if (unref(activeIndex) + 1 >= unref(mediaFiles).length) {
+    return
+  }
+  isAutoAdvancing.value = true
+  isAutoPlayEnabled.value = true
+  goToNext()
+}
+
 const onDeleteResourceCallback = async () => {
   await nextTick()
 
@@ -423,8 +434,12 @@ watch(activeMediaFile, (newValue, oldValue) => {
   currentImageRotation.value = 0
 
   if (oldValue !== null) {
-    isAutoPlayEnabled.value = false
-  }
+      if (unref(isAutoAdvancing)) {
+        isAutoAdvancing.value = false
+      } else {
+        isAutoPlayEnabled.value = false
+      }
+    }
 
   emit('update:resource', unref(activeMediaFile).resource)
 })

--- a/packages/web-app-preview/src/components/Sources/MediaAudio.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaAudio.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="flex flex-col w-xs">
-    <audio :key="`media-audio-${file.id}`" controls preload="preload" :autoplay="isAutoPlayEnabled">
+    <audio
+      :key="`media-audio-${file.id}`"
+      controls
+      preload="preload"
+      :autoplay="isAutoPlayEnabled"
+      @ended="$emit('ended')"
+    >
       <source :src="file.url" :type="file.mimeType" />
     </audio>
     <p v-if="audioText" class="text-role-on-surface-variant text-sm" v-text="audioText"></p>
@@ -22,6 +28,7 @@ export default defineComponent({
       default: true
     }
   },
+  emits: ['ended'],
   setup(props) {
     const audioText = computed(() => {
       if (props.file.resource.audio?.artist && props.file.resource.audio?.title) {


### PR DESCRIPTION
## Description

When playing audio files in the preview app, playback now automatically advances to the next file when the current track ends. Playback stops after the last file.

Manual navigation (arrow keys, next/prev buttons) still disables autoplay as before.

## Related Issue

<!-- No existing issue -->

## How Has This Been Tested?

- test environment: OpenCloud 6.0.0, Firefox/Chromium on Manjaro KDE
- test case 1: Open a folder with multiple MP3 files → playback advances automatically to next track
- test case 2: Last track ends → playback stops, does not wrap around to first track
- test case 3: Manual navigation via arrow buttons → autoplay stays disabled

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Enhancement (a change that doesn't break existing code or deployments)

## Notes
This is my first pull request ever — I hope everything is in order. Happy to fix anything if needed!

The implementation was developed with the assistance of Claude (Anthropic).