### PR TITLE
fix: extension action 'context' category 

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -1,5 +1,4 @@
 import kebabCase from 'lodash-es/kebabCase'
-import isNil from 'lodash-es/isNil'
 import { isShareSpaceResource, Resource, SpaceResource } from '@opencloud-eu/web-client'
 import { routeToContextQuery } from '../../appDefaults'
 import { isLocationTrashActive } from '../../../router'
@@ -100,10 +99,7 @@ export const useFileActions = () => {
       }) || []
     )
       .map((e) => e.action)
-      .filter(
-        (action) =>
-          isNil(action.category) || action.category === 'context' || action.category === 'actions'
-      )
+      .filter((action) => action.category === 'context')
   })
 
   const editorActions = computed(() => {

--- a/packages/web-pkg/src/composables/actions/types.ts
+++ b/packages/web-pkg/src/composables/actions/types.ts
@@ -8,7 +8,15 @@ export type ActionOptions = Record<string, unknown | unknown[]>
 
 type ActionCategory = 'actions' | 'context' | 'share' | 'sidebar'
 
+/**
+ * Generic action interface.
+ * When implementing actions on your own, it's recommended to use the `ActionMenuItem`
+ * component from `web-pkg` to ensure the defaults are being set properly.
+ */
 export interface Action<T = ActionOptions> {
+  /**
+   * The unique name of the action. This is used for identifying it.
+   */
   name: string
   /**
    * Determines where an action will be displayed in the resource context menu.
@@ -22,35 +30,94 @@ export interface Action<T = ActionOptions> {
    * @default actions
    */
   category?: ActionCategory
+  /**
+   * The name of an icon from the OpenCloud icon set or a function
+   * that returns the icon name based on the given options.
+   */
   icon: string | ((options?: ActionOptions) => string)
+  /**
+   * Determines the fill type of the icon in the UI.
+   * @default line
+   */
   iconFillType?: IconFillType
+  /**
+   * The appearance of the action element in the UI.
+   * @default raw
+   */
   appearance?: AppearanceType
+  /**
+   * ID of the action, used as DOM selector.
+   */
   id?: string
+  /**
+   * @deprecated this is unused.
+   */
   img?: string
+  /**
+   * Additional CSS classes to apply to the action element in the UI.
+   */
   class?: string
+  /**
+   * Setting this to true will make the action more prominent in the UI
+   * as well as in the order for default actions.
+   */
   hasPriority?: boolean
+  /**
+   * Setting this to true will hide the action label in the UI and only show the icon.
+   */
   hideLabel?: boolean
+  /**
+   * Specify a shortcut label that will be shown in the UI.
+   * This does not automatically register a keyboard shortcut for the action.
+   */
   shortcut?: string
+  /**
+   * Setting this will call `stopPropagation()` on the click event.
+   * @default false
+   * @deprecated This should not be used anymore, as it can lead to unexpected behavior.
+   */
   keepOpen?: boolean
+  /**
+   * External actions come first in the "New" context menu. Therefore, this flag only has
+   * an effect for actions appearing in that menu.
+   * @default false
+   */
   isExternal?: boolean
+  /**
+   * This determines the file icon for the action in the "New" menu and will show as
+   * file extension label.
+   */
   ext?: string
-
+  /**
+   * The label of the action in the UI.
+   * This can be a string or a function that returns a string based on the given options.
+   */
   label(options?: T): string
-
+  /**
+   * Determines whether the action should be visible in the UI based on the given options.
+   */
   isVisible(options?: T): boolean
-
-  // componentType: button
+  /**
+   * Actions with a handler will be rendered as buttons in the UI.
+   */
   handler?(options?: T): Promise<void> | void
-
-  // componentType: router-link
+  /**
+   * Actions with a route will be rendered as anchor elements in the UI.
+   * This is intended for internal links.
+   */
   route?(options?: T): RouteLocationRaw | undefined
-
-  // componentType: a
+  /**
+   * Actions with a href will be rendered as anchor elements in the UI.
+   * This is intended for external links.
+   */
   href?(options?: T): string
-
-  // can be used to display the action in a disabled state in the UI
+  /**
+   * Determines whether the action should be disabled in the UI based on the given options.
+   */
   isDisabled?(options?: T): boolean
-
+  /**
+   * If specified, this will show a tooltip with the given message when the action is disabled.
+   */
   disabledTooltip?(options?: T): string
 }
 

--- a/packages/web-pkg/src/composables/actions/types.ts
+++ b/packages/web-pkg/src/composables/actions/types.ts
@@ -2,14 +2,26 @@ import { Resource, SpaceResource } from '@opencloud-eu/web-client'
 import { Group, User } from '@opencloud-eu/web-client/graph/generated'
 import { RouteLocationRaw } from 'vue-router'
 import { IconFillType } from '../../helpers'
-import { StringUnionOrAnyString } from '../../utils'
 import { AppearanceType } from '@opencloud-eu/design-system/helpers'
 
 export type ActionOptions = Record<string, unknown | unknown[]>
 
+type ActionCategory = 'actions' | 'context' | 'share' | 'sidebar'
+
 export interface Action<T = ActionOptions> {
   name: string
-  category?: StringUnionOrAnyString<'context' | 'share' | 'actions' | 'sidebar'>
+  /**
+   * Determines where an action will be displayed in the resource context menu.
+   *
+   * - actions: action will appear in the "actions" section of the resource context menu.
+   * - context: action will appear in the "Open with..."-menu of the resource context menu.
+   *   It will also be the default when no other action is available for the given file type.
+   * - share: action will appear in the "shares" section of the resource context menu.
+   * - sidebar: action will appear in the "sidebar" section of the resource context menu.
+   *
+   * @default actions
+   */
+  category?: ActionCategory
   icon: string | ((options?: ActionOptions) => string)
   iconFillType?: IconFillType
   appearance?: AppearanceType


### PR DESCRIPTION
Makes sure that extension actions of category `context` are the only actions that get used for the "Open with" menu while also being candidates for default actions.

This prevents certain actions from showing up multiple times in the context menu.

fixes https://github.com/opencloud-eu/web/issues/2256