### PR TITLE
e2e-tests: favorites

### DIFF
--- a/tests/e2e/cucumber/features/file-action/favorites.feature
+++ b/tests/e2e/cucumber/features/file-action/favorites.feature
@@ -2,13 +2,11 @@ Feature: Favorites
   As a user
   I want to mark resources as favorites and find them in the favorites section
 
-
   Background:
     Given "Admin" creates following user using API
       | id    |
       | Alice |
       | Brian |
-
 
   Scenario: mark resources as favorites
     Given "Admin" assigns following roles to the users using API
@@ -47,13 +45,6 @@ Feature: Favorites
     When "Brian" marks the following resources as favorite using "context menu"
       | resource        |
       | testavatar.jpg  |
-    And "Brian" navigates to the favorites page
-    Then following resources should be displayed in the files list for user "Brian"
-      | resource       |
-      | testavatar.jpg |
-    But following resources should not be displayed in the files list for user "Brian"
-      | resource  |
-      | image.png |
     And "Brian" navigates to the project space "service-team"
     And "Brian" marks the following resources as favorite using "batch action"
       | resource     |
@@ -79,4 +70,16 @@ Feature: Favorites
       | lorem.txt      |
       | image.png      |
       | video.mp4      |
+    And "Brian" removes the following resources from favorites using "context menu"
+      | resource     |
+      | spaceFolder  |
+    And "Brian" removes the following resources from favorites using "batch action"
+      | resource  |
+      | lorem.txt |
+      | image.png |
+    And following resources should not be displayed in the files list for user "Brian"
+      | resource       |
+      | spaceFolder    |
+      | lorem.txt      |
+      | image.png      |
     And "Brian" logs out

--- a/tests/e2e/cucumber/features/file-action/favorites.feature
+++ b/tests/e2e/cucumber/features/file-action/favorites.feature
@@ -1,0 +1,82 @@
+Feature: Favorites
+  As a user
+  I want to mark resources as favorites and find them in the favorites section
+
+
+  Background:
+    Given "Admin" creates following user using API
+      | id    |
+      | Alice |
+      | Brian |
+
+
+  Scenario: mark resources as favorites
+    Given "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following project space using API
+      | name         | id           |
+      | service-team | service-team |
+    And "Alice" creates the following folder in space "service-team" using API
+      | name        |
+      | spaceFolder |
+    And "Alice" creates the following file in space "service-team" using API
+      | name      | content    |
+      | lorem.txt | space team |
+    And "Alice" adds the following members to the space "service-team" using API
+      | user  | role     | shareType |
+      | Brian | Can view | user      |
+    And "Alice" creates the following folder in personal space using API
+      | name   |
+      | shared |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile      | to                    |
+      | testavatar.jpg | shared/testavatar.jpg |
+    And "Alice" shares the following resource using API
+      | resource | recipient | type  | role     |
+      | shared   | Brian     | user  | Can edit |
+    And "Brian" uploads the following local file into personal space using API
+      | localFile       | to        |
+      | user-avatar.png | image.png |
+      | test_video.mp4  | video.mp4 |
+    
+
+    And "Brian" logs in
+    And "Brian" navigates to the shared with me page
+    And "Brian" opens folder "shared"
+    When "Brian" marks the following resources as favorite using "context menu"
+      | resource        |
+      | testavatar.jpg  |
+    And "Brian" navigates to the favorites page
+    Then following resources should be displayed in the files list for user "Brian"
+      | resource       |
+      | testavatar.jpg |
+    But following resources should not be displayed in the files list for user "Brian"
+      | resource  |
+      | image.png |
+    And "Brian" navigates to the project space "service-team"
+    And "Brian" marks the following resources as favorite using "batch action"
+      | resource     |
+      | spaceFolder  |
+      | lorem.txt    |
+    And "Brian" navigates to the personal space page
+    And "Brian" marks the following resources as favorite using "sidebar panel"
+      | resource   |
+      | image.png  |
+    And "Brian" opens the following file in mediaviewer
+      | resource  |
+      | video.mp4 |
+    And "Brian" is in a media-viewer
+    And "Brian" marks the following resources as favorite using "preview"
+      | resource  |
+      | video.mp4 |
+    And "Brian" closes the file viewer
+    And "Brian" navigates to the favorites page
+    And following resources should be displayed in the files list for user "Brian"
+      | resource       |
+      | testavatar.jpg |
+      | spaceFolder    |
+      | lorem.txt      |
+      | image.png      |
+      | video.mp4      |
+    And "Brian" logs out

--- a/tests/e2e/cucumber/steps/ui/favorites.ts
+++ b/tests/e2e/cucumber/steps/ui/favorites.ts
@@ -1,0 +1,12 @@
+import { When } from '@cucumber/cucumber'
+import { World } from '../../environment'
+import { objects } from '../../../support'
+
+When(
+  '{string} navigates to the favorites page',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const pageObject = new objects.applicationFiles.page.favorites.Favorites({ page })
+    await pageObject.navigate()
+  }
+)

--- a/tests/e2e/cucumber/steps/ui/favorites.ts
+++ b/tests/e2e/cucumber/steps/ui/favorites.ts
@@ -1,4 +1,4 @@
-import { When } from '@cucumber/cucumber'
+import { DataTable, When } from '@cucumber/cucumber'
 import { World } from '../../environment'
 import { objects } from '../../../support'
 
@@ -8,5 +8,21 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.favorites.Favorites({ page })
     await pageObject.navigate()
+  }
+)
+
+When(
+  '{string} removes the following resources from favorites using {string}',
+  async function (
+    this: World,
+    stepUser: string,
+    method: 'context menu' | 'batch action',
+    stepTable: DataTable
+  ): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    const resources = stepTable.hashes().map((row) => row.resource)
+
+    await resourceObject.unmarkAsFavorite({ method, resources })
   }
 )

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -1172,3 +1172,19 @@ When(
     })
   }
 )
+
+When(
+  '{string} marks the following resources as favorite using {string}',
+  async function (
+    this: World,
+    stepUser: string,
+    method: 'context menu' | 'sidebar panel' | 'batch action' | 'preview',
+    stepTable: DataTable
+  ): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    const resources = stepTable.hashes().map((row) => row.resource)
+
+    await resourceObject.markAsFavorite({ method, resources })
+  }
+)

--- a/tests/e2e/support/objects/app-files/page/favorites/favorites.ts
+++ b/tests/e2e/support/objects/app-files/page/favorites/favorites.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test'
+
+export class Favorites {
+  #page: Page
+
+  constructor({ page }: { page: Page }) {
+    this.#page = page
+  }
+
+  async navigate(): Promise<void> {
+    await this.#page.locator('a[data-nav-name="files-common-favorites"]').click()
+    await this.#page.locator('#app-loading-spinner').waitFor({ state: 'detached' })
+  }
+}

--- a/tests/e2e/support/objects/app-files/page/index.ts
+++ b/tests/e2e/support/objects/app-files/page/index.ts
@@ -3,6 +3,7 @@ import { Personal } from './spaces/personal'
 import { Projects } from './spaces/projects'
 import { WithOthers } from './shares/withOthers'
 import { ViaLink } from './shares/viaLink'
+import { Favorites } from './favorites/favorites'
 
 export { Public } from './public'
 
@@ -11,3 +12,4 @@ import { Overview } from './trashbin/overview'
 export const shares = { WithMe, WithOthers, ViaLink }
 export const spaces = { Personal, Projects }
 export const trashbin = { Overview }
+export const favorites = { Favorites }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -2406,6 +2406,10 @@ export const markAsFavorite = async ({
   method: 'context menu' | 'sidebar panel' | 'batch action' | 'preview'
   resources: string[]
 }): Promise<void> => {
+  const postPromise = page.waitForResponse(
+    (resp) =>
+      resp.status() === 201 && resp.request().method() === 'POST' && resp.url().endsWith('/follow')
+  )
   switch (method) {
     case 'context menu':
       for (const resource of resources) {
@@ -2436,4 +2440,40 @@ export const markAsFavorite = async ({
       await expect(favoriteBtn).toHaveAttribute('aria-label', 'Remove from favorites')
       break
   }
+  await postPromise
+}
+
+export const unmarkAsFavorite = async ({
+  page,
+  method,
+  resources
+}: {
+  page: Page
+  method: 'context menu' | 'batch action'
+  resources: string[]
+}): Promise<void> => {
+  const deletePromise = page.waitForResponse(
+    (resp) =>
+      resp.status() === 204 &&
+      resp.request().method() === 'DELETE' &&
+      resp.url().includes('me/drive/following')
+  )
+  switch (method) {
+    case 'context menu':
+      for (const resource of resources) {
+        await page.locator(util.format(resourceNameSelector, resource)).click({ button: 'right' })
+        const removeFavoriteBtn = page.locator(util.format(filesContextMenuAction, 'favorite'))
+        await expect(removeFavoriteBtn).toHaveAttribute('aria-label', 'Remove from favorites')
+        await removeFavoriteBtn.click()
+      }
+      break
+
+    case 'batch action':
+      for (const resource of resources) {
+        await page.locator(util.format(checkBox, resource)).click()
+      }
+      await selectBatchAction(page, 'favorite')
+      break
+  }
+  await deletePromise
 }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -149,12 +149,12 @@ const fileIcon = '#oc-file-details-sidebar .details-icon'
 const fileIconPreview = '#oc-file-details-sidebar .details-preview'
 const activitySidebarPanel = 'sidebar-panel-activities'
 const activitySidebarPanelBodyContent = '#sidebar-panel-activities .sidebar-panel__body-content'
-const contextMenuAction = '//*[@id="oc-files-context-actions-context"]//span[text()="%s"]'
 const subContextMenuAction = '//*[@id="app-runtime-drop"]//span[text()="%s"]'
 const openWithAction = '.oc-files-actions-%s-trigger'
 const openWithButton = '//*[@id="oc-files-context-actions-context"]//span[text()="Open with..."]'
 const tilesSlider = '#tiles-size-slider'
 const undoBtn = 'action-handler'
+const previewFavoriteButton = '.preview-controls-favorite'
 
 export const getResourceLocator = ({
   page,
@@ -2395,4 +2395,45 @@ export const deleteAndUndo = async ({
     await undoButton.first().click()
   }
   await responsePromise
+}
+
+export const markAsFavorite = async ({
+  page,
+  method,
+  resources
+}: {
+  page: Page
+  method: 'context menu' | 'sidebar panel' | 'batch action' | 'preview'
+  resources: string[]
+}): Promise<void> => {
+  switch (method) {
+    case 'context menu':
+      for (const resource of resources) {
+        await page.locator(util.format(resourceNameSelector, resource)).click({ button: 'right' })
+        await page.locator(util.format(filesContextMenuAction, 'favorite')).click()
+      }
+      break
+
+    case 'sidebar panel':
+      for (const resource of resources) {
+        await sidebar.open({ page, resource })
+        await sidebar.openPanel({ page, name: 'actions' })
+        await page.locator(util.format(sideBarActionButton, 'Add to favorites')).click()
+      }
+      break
+
+    case 'batch action':
+      for (const resource of resources) {
+        await page.locator(util.format(checkBox, resource)).click()
+      }
+      await selectBatchAction(page, 'favorite')
+      break
+
+    case 'preview':
+      const favoriteBtn = page.locator(previewFavoriteButton)
+      await expect(favoriteBtn).toHaveAttribute('aria-label', 'Add to favorites')
+      await favoriteBtn.click()
+      await expect(favoriteBtn).toHaveAttribute('aria-label', 'Remove from favorites')
+      break
+  }
 }

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -438,4 +438,15 @@ export class Resource {
       folder: args.folder
     })
   }
+
+  async markAsFavorite(args: {
+    method: 'context menu' | 'sidebar panel' | 'batch action' | 'preview'
+    resources: string[]
+  }): Promise<void> {
+    await po.markAsFavorite({
+      page: this.#page,
+      method: args.method,
+      resources: args.resources
+    })
+  }
 }

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -449,4 +449,15 @@ export class Resource {
       resources: args.resources
     })
   }
+
+  async unmarkAsFavorite(args: {
+    method: 'context menu' | 'batch action'
+    resources: string[]
+  }): Promise<void> {
+    await po.unmarkAsFavorite({
+      page: this.#page,
+      method: args.method,
+      resources: args.resources
+    })
+  }
 }


### PR DESCRIPTION
Marking resources as favorites from multiple entry points:
- [x] context menu
- [x] batch actions
- [x] sidebar panel
- [x] preview (media viewer)

Verifying that favorited items appear in the Favorites page
Ensuring non-favorited items are not displayed
Validating behavior across:
- [x] shared resources
- [x] project spaces
- [x] personal space

Remove resources from favorites
- [x] context menu
- [x] batch actions