### PR TITLE
feat: set global color-scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1.0, minimum-scale=1.0" />
-    <meta name="theme-color" content="#375f7E" />
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
 
     <title>__TITLE__</title>

--- a/packages/design-system/src/components/OcDatepicker/OcDatepicker.vue
+++ b/packages/design-system/src/components/OcDatepicker/OcDatepicker.vue
@@ -120,13 +120,5 @@ watch(
   .oc-date-picker input::-webkit-calendar-picker-indicator {
     @apply cursor-pointer;
   }
-
-  .oc-date-picker-dark input {
-    color-scheme: dark;
-  }
-
-  .oc-date-picker-dark input::-webkit-calendar-picker-indicator {
-    filter: invert(0);
-  }
 }
 </style>

--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -119,6 +119,7 @@ export const useThemeStore = defineStore('theme', () => {
       currentLocalStorageThemeName.value = unref(currentTheme).label
     }
 
+    document.documentElement.style.colorScheme = theme.isDark ? 'dark' : 'light'
     const customizableDesignTokens = [
       { name: 'roles', prefix: 'role' },
       { name: 'colorPalette', prefix: 'color' }


### PR DESCRIPTION
Sets the current theme via the `color-scheme` CSS prop, ensuring that native browser elements like scroll bars have the proper color.

closes https://github.com/opencloud-eu/web/issues/2123