### PR TITLE
fix(extension-sdk): use posix path to support windows build

### DIFF
--- a/packages/extension-sdk/src/index.ts
+++ b/packages/extension-sdk/src/index.ts
@@ -1,5 +1,5 @@
 import { mergeConfig, searchForWorkspaceRoot, ViteDevServer } from 'vite'
-import { join } from 'path'
+import { join, posix as posixPath } from 'path'
 import { cwd } from 'process'
 import { readFileSync, existsSync } from 'fs'
 import type { IncomingMessage, ServerResponse } from 'http'
@@ -88,8 +88,11 @@ export function defineConfig(overrides: ExtensionConfigOverrides = {}) {
               [name]: './src/index.ts'
             },
             output: {
-              entryFileNames: join('js', `[name]${isProduction ? '-[hash]' : ''}${remoteEntryExt}`),
-              chunkFileNames: join('js', `[name]-[hash]${remoteEntryExt}`)
+              entryFileNames: posixPath.join(
+                'js',
+                `[name]${isProduction ? '-[hash]' : ''}${remoteEntryExt}`
+              ),
+              chunkFileNames: posixPath.join('js', `[name]-[hash]${remoteEntryExt}`)
             }
           }
         },


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->

Extensions built using the sdk on Windows will not work out of the box. This is because the entrypoint path is being exported with non-POSIX compliant file separators.


```json
{
  "entrypoint": "js\\remoteEntry-Cx_RoXqY.mjs"
}
```

Export posix‑compatible paths to Vite to fix issues on Windows.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- Manual: checked correct `entrypoint` path in `manifest.json` build output
```json
{
  "entrypoint": "js/remoteEntry-Cx_RoXqY.mjs"
}
```

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
