### PR TITLE
feat: handle UI_PickLink postMessage from Collabora Online

### DIFF
--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -394,6 +394,27 @@ const handlePostMessagesCollabora = async (event: MessageEvent) => {
         }),
         focusTrapInitial: false
       })
+      return
+    }
+
+    if (message.MessageId === 'UI_PickLink') {
+      dispatchModal({
+        elementClass: 'file-picker-modal',
+        title: $gettext('Pick a file to link'),
+        customComponent: FilePickerModal,
+        hideActions: true,
+        customComponentAttrs: () => ({
+          parentFolderLink: getParentFolderLink(resource),
+          allowedFileTypes: [],
+          callbackFn: ({ resource }: { resource: Resource }) => {
+            postMessageToCollabora('Action_InsertLink', {
+              url: resource.privateLink,
+              text: resource.name
+            })
+          }
+        }),
+        focusTrapInitial: false
+      })
     }
   } catch (e) {
     console.debug('Error parsing Collabora PostMessage', e)


### PR DESCRIPTION
## Summary
- Handles the `UI_PickLink` postMessage by opening the existing `FilePickerModal` and replying with `Action_InsertLink` carrying `{url: resource.privateLink, text: resource.name}`.
- Companion to opencloud-eu/opencloud#2663 which adds `EnableRemoteLinkPicker: true` to CheckFileInfo.

## Details
Reuses the same file-picker infrastructure as the existing `UI_InsertFile` / `UI_InsertGraphic` handlers. The `text` field is an optional argument honoured by coolwsd since CollaboraOnline/online#15561 (MERGED) — older coolwsd ignores it and falls back to the URL, so this change is backward-compatible with any coolwsd release.


SDK reference: https://sdk.collaboraonline.com/docs/postmessage_api.html#ui-picklink-ui-editor-host
