### PR TITLE
refactor: ensure module federation gets initialized once

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@cucumber/messages": "32.3.1",
     "@cucumber/pretty-formatter": "3.2.0",
     "@module-federation/runtime": "2.3.3",
-    "@module-federation/vite": "1.14.5",
+    "@module-federation/vite": "1.15.1",
     "@noble/hashes": "2.2.0",
     "@opencloud-eu/eslint-config": "workspace:*",
     "@opencloud-eu/prettier-config": "workspace:*",

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -29,7 +29,7 @@
     "check:types": "vue-tsc --declaration --noEmit --project tsconfig.build.json"
   },
   "dependencies": {
-    "@module-federation/vite": "^1.13.5",
+    "@module-federation/vite": "^1.15.1",
     "@tailwindcss/vite": "^4.2.2",
     "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-vue": "^6.0.5"

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -1,10 +1,5 @@
 import { ModuleFederation } from '@module-federation/runtime'
-import {
-  buildApplication,
-  loadApplication,
-  NextApplication,
-  registerSharedModules
-} from './application'
+import { buildApplication, loadApplication, NextApplication } from './application'
 import { RouteLocationRaw, Router, RouteRecordNormalized } from 'vue-router'
 import { App, computed, watch } from 'vue'
 import { loadTheme } from '../helpers/theme'
@@ -209,12 +204,14 @@ export const announceConfiguration = async ({
  * - bulk initializes all applications
  */
 export const initializeApplications = async ({
+  federation,
   app,
   configStore,
   router,
   appProviderService,
   appProviderApps
 }: {
+  federation: ModuleFederation
   app: App
   configStore: ConfigStore
   router: Router
@@ -232,9 +229,6 @@ export const initializeApplications = async ({
     applicationConfig: AppConfigObject
     applicationScript: ClassicApplicationScript
   }
-
-  const federation = new ModuleFederation({ name: 'opencloud-web', remotes: [] })
-  registerSharedModules(federation)
 
   let applicationKeys: string[] = []
   let applicationResponses: PromiseSettledResult<ApplicationResponse>[] = []

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -3,6 +3,8 @@ import { router } from './router'
 import { abilitiesPlugin } from '@casl/vue'
 import { createMongoAbility } from '@casl/ability'
 
+import { ModuleFederation } from '@module-federation/runtime'
+import { registerSharedModules } from './container/application'
 import {
   announceConfiguration,
   initializeApplications,
@@ -87,11 +89,15 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
     clientService
   })
 
+  const federation = new ModuleFederation({ name: 'opencloud-web', remotes: [] })
+  registerSharedModules(federation)
+
   const [coreTranslations, customTranslations] = await Promise.all([
     loadTranslations(),
     loadCustomTranslations({ configStore }),
     announceTheme({ app, designSystem, configStore }),
     initializeApplications({
+      federation,
       app,
       configStore,
       router,
@@ -106,6 +112,7 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
   // Reason: the `external` app serves as a blueprint for creating the app provider apps.
   if (applicationStore.has('web-app-external')) {
     await initializeApplications({
+      federation,
       app,
       configStore,
       router,

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../src/container/bootstrap'
 import { buildApplication, loadApplication } from '../../../src/container/application'
 import { createTestingPinia, mockAxiosResolve } from '@opencloud-eu/web-test-helpers'
+import type { ModuleFederation } from '@module-federation/runtime'
 
 vi.mock('../../../src/container/application')
 
@@ -63,6 +64,7 @@ describe('initialize applications', () => {
     ]
 
     const applications = await initializeApplications({
+      federation: mock<ModuleFederation>(),
       app: createApp(defineComponent({})),
       configStore,
       router: undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: 2.3.3
         version: 2.3.3(node-fetch@3.3.2)
       '@module-federation/vite':
-        specifier: 1.14.5
-        version: 1.14.5(node-fetch@3.3.2)(rollup@4.60.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.3))
+        specifier: 1.15.1
+        version: 1.15.1(node-fetch@3.3.2)(rollup@4.60.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.3))
       '@noble/hashes':
         specifier: 2.2.0
         version: 2.2.0
@@ -262,8 +262,8 @@ importers:
   packages/extension-sdk:
     dependencies:
       '@module-federation/vite':
-        specifier: ^1.13.5
-        version: 1.14.5(node-fetch@3.3.2)(rollup@4.60.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.3))
+        specifier: ^1.15.1
+        version: 1.15.1(node-fetch@3.3.2)(rollup@4.60.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.3))
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))
@@ -1955,8 +1955,8 @@ packages:
   '@module-federation/third-party-dts-extractor@2.3.3':
     resolution: {integrity: sha512-rR94TjC1QVQLQPTazI0waLc76hI8dnv6aHTl+PUEIY9s5hXp8TA85XS0QJQqIf2KTjlPgZbWAwyFjOAJluTjaw==}
 
-  '@module-federation/vite@1.14.5':
-    resolution: {integrity: sha512-uTIPnW+ibZZCVcmj/A+hriP9rPQkPIEKwGWLYoedJJh/Hg4RyHnkWMqIuezzFNKtcyaoHFltAKR4RFbi+gNdGA==}
+  '@module-federation/vite@1.15.1':
+    resolution: {integrity: sha512-omp8UYFsKiGIWj9nTSIGF1GsybA+8A/Z8W0P7Y2PRdf4oL/GveXF3haQT6u0OFPm/v3veKYphC1LpvOZoDQBHQ==}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
@@ -6976,7 +6976,7 @@ snapshots:
       find-pkg: 2.0.0
       resolve: 1.22.8
 
-  '@module-federation/vite@1.14.5(node-fetch@3.3.2)(rollup@4.60.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.3))':
+  '@module-federation/vite@1.15.1(node-fetch@3.3.2)(rollup@4.60.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sass@1.99.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.3))':
     dependencies:
       '@module-federation/dts-plugin': 2.3.3(node-fetch@3.3.2)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
       '@module-federation/runtime': 2.3.3(node-fetch@3.3.2)


### PR DESCRIPTION
No need for the module federation to get initialized more than once. Also bumps it to `v1.15.1` to fix recent issues.