### PR TITLE
feat(editor): add insert image functionality

### DIFF
--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -81,7 +81,12 @@
               v-if="!hideConfirmButton"
               class="oc-modal-body-actions-confirm ml-2"
               :appearance="buttonConfirmAppearance"
-              :disabled="isLoading || buttonConfirmDisabled || !!inputError"
+              :disabled="
+                isLoading ||
+                buttonConfirmDisabled ||
+                !!inputError ||
+                (hasInput && inputRequiredMark && !userInputValue)
+              "
               :show-spinner="showSpinner"
               @click="confirm"
               >{{ $gettext(confirmLabel) }}

--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -2,7 +2,7 @@
   <div v-if="visible" class="text-editor-toolbar relative border-b border-b-role-border py-1">
     <div
       ref="scrollContainer"
-      class="flex items-center justify-center gap-1 overflow-x-auto"
+      class="flex items-center gap-1 overflow-x-auto before:grow after:grow"
       @scroll="updateScrollState"
     >
       <div

--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -11,10 +11,14 @@
         class="text-editor-toolbar-group inline-flex items-stretch"
         :class="{ 'border-l border-l-role-border pl-1': groupIndex > 0 }"
       >
-        <template v-for="item in group.actions" :key="`toolbar-item-${item.id}`">
+        <template
+          v-for="item in group.actions.filter((a) => a.showInToolbar !== false)"
+          :key="`toolbar-item-${item.id}`"
+        >
           <template v-if="item.isDropdown && item.dropdownOptions">
             <oc-button
               :id="`toolbar-dropdown-trigger-${item.id}`"
+              v-oc-tooltip="item.title"
               type="button"
               appearance="raw"
               class="text-editor-toolbar-btn min-w-[52px] inline-flex items-center justify-center"
@@ -33,6 +37,7 @@
               mode="click"
               class="text-editor-toolbar-dropdown"
               padding-size="small"
+              close-on-click
             >
               <ul class="oc-list">
                 <li

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -63,6 +63,7 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
     blockquote,
     codeBlock,
     horizontalRule,
+    image,
     imageUrl,
     imageUpload,
     table,
@@ -108,7 +109,7 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
       {
         id: 'image',
         title: $gettext('Image'),
-        actions: [imageUrl(), imageUpload()]
+        actions: [image(), imageUrl(), imageUpload()]
       },
       {
         id: 'table-editing',

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -63,6 +63,8 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
     blockquote,
     codeBlock,
     horizontalRule,
+    imageUrl,
+    imageUpload,
     table,
     addRowBefore,
     addRowAfter,
@@ -102,6 +104,11 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
         id: 'advanced',
         title: $gettext('Advanced'),
         actions: [blockquote(), codeBlock(), horizontalRule(), table()]
+      },
+      {
+        id: 'image',
+        title: $gettext('Image'),
+        actions: [imageUrl(), imageUpload()]
       },
       {
         id: 'table-editing',

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -3,6 +3,7 @@ import { ContentTypeStrategy } from './types'
 import type { Extension } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import { Markdown } from '@tiptap/markdown'
+import Image from '@tiptap/extension-image'
 import Link from '@tiptap/extension-link'
 import { Table, TableRow, TableCell, TableHeader } from '@tiptap/extension-table'
 import TaskList from '@tiptap/extension-task-list'
@@ -41,7 +42,8 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
       TableCell,
       TableHeader,
       TaskList,
-      TaskItem.configure({ nested: true })
+      TaskItem.configure({ nested: true }),
+      Image.configure({ inline: false })
     ]
   }
 

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -83,6 +83,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     blockquote,
     codeBlock,
     horizontalRule,
+    image,
     imageUrl,
     imageUpload,
     table,
@@ -133,7 +134,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
       {
         id: 'image',
         title: $gettext('Image'),
-        actions: [imageUrl(), imageUpload()]
+        actions: [image(), imageUrl(), imageUpload()]
       },
       {
         id: 'table-editing',

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -83,6 +83,8 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     blockquote,
     codeBlock,
     horizontalRule,
+    imageUrl,
+    imageUpload,
     table,
     addRowBefore,
     addRowAfter,
@@ -127,6 +129,11 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
         id: 'advanced',
         title: $gettext('Advanced'),
         actions: [blockquote(), codeBlock(), horizontalRule(), table()]
+      },
+      {
+        id: 'image',
+        title: $gettext('Image'),
+        actions: [imageUrl(), imageUpload()]
       },
       {
         id: 'table-editing',

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -430,7 +430,7 @@ export function useEditorActions(
     id: 'image-url',
     title: $gettext('Image from URL'),
     description: $gettext('Insert an image from a web URL'),
-    icon: 'links-line',
+    icon: 'link-line',
     keywords: ['image', 'picture', 'url'],
     showInToolbar: false,
     slashCommandAction: ({ editor, range }) => {

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -2,6 +2,7 @@ import { unref } from 'vue'
 import type { MaybeRef } from 'vue'
 import type { Editor, Range } from '@tiptap/core'
 import { useGettext } from 'vue3-gettext'
+import { useModals } from '../../composables/piniaStores'
 import { TextEditorState } from '../types'
 
 export interface EditorAction {
@@ -56,6 +57,7 @@ export function useEditorActions(
   options: MaybeRef<UseEditorActionsOptions> = {}
 ) {
   const { $gettext } = useGettext()
+  const { dispatchModal } = useModals()
 
   // History actions
   const undo = (): EditorAction => ({
@@ -399,19 +401,89 @@ export function useEditorActions(
     showInSlashCommands: false
   })
 
-  const image = (): EditorAction => ({
-    id: 'image',
-    title: $gettext('Image'),
-    icon: 'image-line',
-    toolbarAction: (editor) => {
-      const opts = unref(options)
-      if (opts.onRequestImageUrl) {
-        opts.onRequestImageUrl(editor)
+  const dispatchImageModal = (editor: Editor) => {
+    dispatchModal({
+      title: $gettext('Insert image from URL'),
+      hasInput: true,
+      inputLabel: $gettext('Image URL'),
+      confirmText: $gettext('Insert'),
+      inputRequiredMark: true,
+      onInput: (value: string, setError: (error: string) => void) => {
+        const trimmed = value.trim()
+        if (trimmed && !/^https?:\/\//i.test(trimmed)) {
+          setError($gettext('URL must start with http:// or https://'))
+          return
+        }
+        setError(null)
+      },
+      onConfirm: (value: string) => {
+        const trimmed = value.trim()
+        if (!trimmed || !/^https?:\/\//i.test(trimmed)) {
+          return
+        }
+        editor.chain().focus().setImage({ src: trimmed }).run()
       }
+    })
+  }
+
+  const imageUrl = (): EditorAction => ({
+    id: 'image-url',
+    title: $gettext('Image from URL'),
+    description: $gettext('Insert an image from a web URL'),
+    icon: 'links-line',
+    keywords: ['image', 'picture', 'url'],
+    toolbarAction: (editor) => {
+      dispatchImageModal(editor)
     },
-    isActive: () => false,
-    showInSlashCommands: false
+    slashCommandAction: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).run()
+      dispatchImageModal(editor)
+    },
+    isActive: () => false
   })
+
+  const imageUpload = (): EditorAction => ({
+    id: 'image-upload',
+    title: $gettext('Image from file'),
+    description: $gettext('Upload an image from your device'),
+    icon: 'image-line',
+    keywords: ['image', 'picture', 'upload', 'file'],
+    toolbarAction: (editor) => {
+      insertImageFromFile(editor)
+    },
+    slashCommandAction: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).run()
+      insertImageFromFile(editor)
+    },
+    isActive: () => false
+  })
+
+  const maxImageSizeBytes = 5 * 1024 * 1024 // 5 MB
+
+  const insertImageFromFile = (editor: Editor) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/*'
+    input.addEventListener('change', () => {
+      const file = input.files?.[0]
+      if (!file) {
+        return
+      }
+      if (!file.type.startsWith('image/')) {
+        return
+      }
+      if (file.size > maxImageSizeBytes) {
+        return
+      }
+      const reader = new FileReader()
+      reader.addEventListener('load', () => {
+        const dataUrl = reader.result as string
+        editor.chain().focus().setImage({ src: dataUrl }).run()
+      })
+      reader.readAsDataURL(file)
+    })
+    input.click()
+  }
 
   const table = (): EditorAction => ({
     id: 'table',
@@ -564,7 +636,8 @@ export function useEditorActions(
     taskList,
     // Insert
     link,
-    image,
+    imageUrl,
+    imageUpload,
     table,
     // Table manipulation
     addRowBefore,

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -432,9 +432,7 @@ export function useEditorActions(
     description: $gettext('Insert an image from a web URL'),
     icon: 'links-line',
     keywords: ['image', 'picture', 'url'],
-    toolbarAction: (editor) => {
-      dispatchImageModal(editor)
-    },
+    showInToolbar: false,
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).run()
       dispatchImageModal(editor)
@@ -448,12 +446,32 @@ export function useEditorActions(
     description: $gettext('Upload an image from your device'),
     icon: 'image-line',
     keywords: ['image', 'picture', 'upload', 'file'],
-    toolbarAction: (editor) => {
-      insertImageFromFile(editor)
-    },
+    showInToolbar: false,
+    showInSlashCommands: true,
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).run()
       insertImageFromFile(editor)
+    },
+    isActive: () => false
+  })
+
+  const image = (): EditorAction => ({
+    id: 'image',
+    title: $gettext('Insert image'),
+    icon: 'image-line',
+    keywords: ['image', 'picture', 'upload', 'url'],
+    isDropdown: true,
+    showInSlashCommands: false,
+    dropdownOptions: [
+      { value: 'file', label: $gettext('Upload image') },
+      { value: 'url', label: $gettext('Insert via URL') }
+    ],
+    toolbarAction: (editor, value) => {
+      if (value === 'url') {
+        dispatchImageModal(editor)
+      } else if (value === 'file') {
+        insertImageFromFile(editor)
+      }
     },
     isActive: () => false
   })
@@ -636,6 +654,7 @@ export function useEditorActions(
     taskList,
     // Insert
     link,
+    image,
     imageUrl,
     imageUpload,
     table,

--- a/packages/web-pkg/tests/unit/editor/composables/helpers.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/helpers.ts
@@ -70,7 +70,8 @@ export function createMockEditor(options: MockEditorOptions = {}) {
       'addRowBefore',
       'addRowAfter',
       'addColumnBefore',
-      'addColumnAfter'
+      'addColumnAfter',
+      'setImage'
     ]
     for (const method of methods) {
       chain[method] = vi.fn().mockReturnValue(chain)

--- a/packages/web-pkg/tests/unit/editor/composables/useContentStrategy.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useContentStrategy.spec.ts
@@ -7,12 +7,17 @@ vi.mock('vue3-gettext', () => ({
 }))
 
 import { useContentStrategy } from '../../../../src/editor/composables/useContentStrategy'
+import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 
 function createState(): TextEditorState {
   return { sourceMode: ref(false) }
 }
 
 describe('useContentStrategy', () => {
+  beforeEach(() => {
+    createTestingPinia()
+  })
+
   describe('resolveStrategy', () => {
     const { resolveStrategy } = useContentStrategy()
 

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ref } from 'vue'
 import type { Range } from '@tiptap/core'
 import { createMockEditor } from './helpers'
@@ -9,6 +9,8 @@ vi.mock('vue3-gettext', () => ({
 
 import { useEditorActions } from '../../../../src/editor/composables/useEditorActions'
 import type { TextEditorState } from '../../../../src/editor/types'
+import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
+import { useModals } from '../../../../src/composables/piniaStores'
 
 function createState(): TextEditorState {
   return { sourceMode: ref(false) }
@@ -21,6 +23,7 @@ describe('useEditorActions', () => {
   let actions: ReturnType<typeof useEditorActions>
 
   beforeEach(() => {
+    createTestingPinia({ stubActions: false })
     state = createState()
     actions = useEditorActions(state)
   })
@@ -267,30 +270,6 @@ describe('useEditorActions', () => {
     })
   })
 
-  describe('image', () => {
-    it('toolbarAction calls onRequestImageUrl with editor', () => {
-      const onRequestImageUrl = vi.fn()
-      const actionsWithOpts = useEditorActions(state, { onRequestImageUrl })
-      const editor = createMockEditor()
-      actionsWithOpts.image().toolbarAction!(editor)
-      expect(onRequestImageUrl).toHaveBeenCalledWith(editor)
-    })
-
-    it('toolbarAction is a no-op when onRequestImageUrl is undefined', () => {
-      const editor = createMockEditor()
-      expect(() => actions.image().toolbarAction!(editor)).not.toThrow()
-    })
-
-    it('isActive always returns false', () => {
-      const editor = createMockEditor()
-      expect(actions.image().isActive!(editor)).toBe(false)
-    })
-
-    it('is hidden from slash commands', () => {
-      expect(actions.image().showInSlashCommands).toBe(false)
-    })
-  })
-
   describe('table', () => {
     it('toolbarAction inserts 3x3 table with header row', () => {
       const editor = createMockEditor()
@@ -397,6 +376,259 @@ describe('useEditorActions', () => {
         expect(editor._chain.deleteRange).toHaveBeenCalledWith(mockRange)
         expect(editor._chain.deleteTable).toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('imageUrl', () => {
+    it('toolbarAction dispatches a modal with input', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const { dispatchModal } = useModals()
+      expect(dispatchModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasInput: true,
+          inputLabel: 'Image URL',
+          confirmText: 'Insert'
+        })
+      )
+    })
+
+    it('toolbarAction onConfirm inserts image when a valid https URL is entered', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const store = useModals()
+      const modal = store.modals[0]
+      modal.onConfirm('https://example.com/photo.png')
+      expect(editor._chain.setImage).toHaveBeenCalledWith({ src: 'https://example.com/photo.png' })
+    })
+
+    it('toolbarAction onConfirm inserts image when a valid http URL is entered', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const store = useModals()
+      const modal = store.modals[0]
+      modal.onConfirm('http://example.com/photo.png')
+      expect(editor._chain.setImage).toHaveBeenCalledWith({ src: 'http://example.com/photo.png' })
+    })
+
+    it('toolbarAction onConfirm trims whitespace from URL', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const store = useModals()
+      const modal = store.modals[0]
+      modal.onConfirm('  https://example.com/photo.png  ')
+      expect(editor._chain.setImage).toHaveBeenCalledWith({ src: 'https://example.com/photo.png' })
+    })
+
+    it('toolbarAction onConfirm does nothing when URL is empty', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const store = useModals()
+      const modal = store.modals[0]
+      modal.onConfirm('   ')
+      expect(editor._chain.setImage).not.toHaveBeenCalled()
+    })
+
+    it('toolbarAction onConfirm rejects URLs without http(s) protocol', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const store = useModals()
+      const modal = store.modals[0]
+      modal.onConfirm('javascript:alert(1)')
+      expect(editor._chain.setImage).not.toHaveBeenCalled()
+    })
+
+    it('toolbarAction onInput sets error for invalid protocol', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const store = useModals()
+      const modal = store.modals[0]
+      const setError = vi.fn()
+      modal.onInput('example.com/photo.png', setError)
+      expect(setError).toHaveBeenCalledWith('URL must start with http:// or https://')
+    })
+
+    it('toolbarAction onInput clears error for valid URL', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().toolbarAction!(editor)
+      const store = useModals()
+      const modal = store.modals[0]
+      const setError = vi.fn()
+      modal.onInput('https://example.com/photo.png', setError)
+      expect(setError).toHaveBeenCalledWith(null)
+    })
+
+    it('slashCommandAction onConfirm deletes range and inserts image for valid URL', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().slashCommandAction!({ editor, range: mockRange })
+      const store = useModals()
+      const modal = store.modals[0]
+      modal.onConfirm('https://example.com/photo.png')
+      expect(editor._chain.deleteRange).toHaveBeenCalledWith(mockRange)
+      expect(editor._chain.setImage).toHaveBeenCalledWith({ src: 'https://example.com/photo.png' })
+    })
+
+    it('slashCommandAction onConfirm does nothing for invalid URL', () => {
+      const editor = createMockEditor()
+      actions.imageUrl().slashCommandAction!({ editor, range: mockRange })
+      const store = useModals()
+      const modal = store.modals[0]
+      modal.onConfirm('ftp://example.com/photo.png')
+      expect(editor._chain.setImage).not.toHaveBeenCalled()
+    })
+
+    it('isActive always returns false', () => {
+      const editor = createMockEditor()
+      expect(actions.imageUrl().isActive!(editor)).toBe(false)
+    })
+  })
+
+  describe('imageUpload', () => {
+    let createElementSpy: ReturnType<typeof vi.spyOn>
+    let mockInput: {
+      type: string
+      accept: string
+      click: ReturnType<typeof vi.fn>
+      addEventListener: ReturnType<typeof vi.fn>
+      files: File[] | null
+    }
+
+    beforeEach(() => {
+      mockInput = {
+        type: '',
+        accept: '',
+        click: vi.fn(),
+        addEventListener: vi.fn(),
+        files: null
+      }
+      createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'input') {
+          return mockInput as unknown as HTMLElement
+        }
+        return document.createElement(tag)
+      })
+    })
+
+    afterEach(() => {
+      createElementSpy.mockRestore()
+    })
+
+    it('toolbarAction creates a file input with image accept type', () => {
+      const editor = createMockEditor()
+      actions.imageUpload().toolbarAction!(editor)
+      expect(mockInput.type).toBe('file')
+      expect(mockInput.accept).toBe('image/*')
+      expect(mockInput.click).toHaveBeenCalled()
+    })
+
+    it('toolbarAction inserts base64 data URL for valid image file', () => {
+      const editor = createMockEditor()
+      const fakeDataUrl = 'data:image/png;base64,iVBORw0KGgo='
+
+      let loadHandler: (() => void) | undefined
+      const mockReaderInstance = {
+        result: fakeDataUrl,
+        readAsDataURL: vi.fn(),
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          if (event === 'load') {
+            loadHandler = handler
+          }
+        })
+      }
+
+      vi.spyOn(globalThis, 'FileReader').mockImplementation(function (this: unknown) {
+        Object.assign(this as object, mockReaderInstance)
+      } as unknown as () => FileReader)
+
+      actions.imageUpload().toolbarAction!(editor)
+
+      const changeHandler = mockInput.addEventListener.mock.calls.find(
+        (call: unknown[]) => call[0] === 'change'
+      )![1] as () => void
+
+      const file = new File(['fake'], 'photo.png', { type: 'image/png' })
+      Object.defineProperty(file, 'size', { value: 1024 })
+      mockInput.files = [file]
+
+      changeHandler()
+
+      expect(mockReaderInstance.readAsDataURL).toHaveBeenCalledWith(file)
+      loadHandler!()
+
+      expect(editor._chain.setImage).toHaveBeenCalledWith({ src: fakeDataUrl })
+    })
+
+    it('toolbarAction rejects files that are not images', () => {
+      const editor = createMockEditor()
+
+      const mockReaderInstance = { readAsDataURL: vi.fn(), addEventListener: vi.fn() }
+      vi.spyOn(globalThis, 'FileReader').mockImplementation(function (this: unknown) {
+        Object.assign(this as object, mockReaderInstance)
+      } as unknown as () => FileReader)
+
+      actions.imageUpload().toolbarAction!(editor)
+
+      const changeHandler = mockInput.addEventListener.mock.calls.find(
+        (call: unknown[]) => call[0] === 'change'
+      )![1] as () => void
+
+      const file = new File(['fake'], 'script.js', { type: 'application/javascript' })
+      mockInput.files = [file]
+
+      changeHandler()
+
+      expect(mockReaderInstance.readAsDataURL).not.toHaveBeenCalled()
+    })
+
+    it('toolbarAction rejects files exceeding 5 MB', () => {
+      const editor = createMockEditor()
+
+      const mockReaderInstance = { readAsDataURL: vi.fn(), addEventListener: vi.fn() }
+      vi.spyOn(globalThis, 'FileReader').mockImplementation(function (this: unknown) {
+        Object.assign(this as object, mockReaderInstance)
+      } as unknown as () => FileReader)
+
+      actions.imageUpload().toolbarAction!(editor)
+
+      const changeHandler = mockInput.addEventListener.mock.calls.find(
+        (call: unknown[]) => call[0] === 'change'
+      )![1] as () => void
+
+      const file = new File(['fake'], 'huge.png', { type: 'image/png' })
+      Object.defineProperty(file, 'size', { value: 6 * 1024 * 1024 })
+      mockInput.files = [file]
+
+      changeHandler()
+
+      expect(mockReaderInstance.readAsDataURL).not.toHaveBeenCalled()
+    })
+
+    it('toolbarAction does nothing when no file is selected', () => {
+      const editor = createMockEditor()
+
+      actions.imageUpload().toolbarAction!(editor)
+
+      const changeHandler = mockInput.addEventListener.mock.calls.find(
+        (call: unknown[]) => call[0] === 'change'
+      )![1] as () => void
+
+      mockInput.files = []
+
+      changeHandler()
+
+      expect(editor._chain.setImage).not.toHaveBeenCalled()
+    })
+
+    it('slashCommandAction deletes range then opens file picker', () => {
+      const editor = createMockEditor()
+      actions.imageUpload().slashCommandAction!({ editor, range: mockRange })
+      expect(editor._chain.deleteRange).toHaveBeenCalledWith(mockRange)
+      expect(mockInput.click).toHaveBeenCalled()
+    })
+
+    it('isActive always returns false', () => {
+      const editor = createMockEditor()
+      expect(actions.imageUpload().isActive!(editor)).toBe(false)
     })
   })
 

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -382,7 +382,7 @@ describe('useEditorActions', () => {
   describe('imageUrl', () => {
     it('toolbarAction dispatches a modal with input', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const { dispatchModal } = useModals()
       expect(dispatchModal).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -395,7 +395,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm inserts image when a valid https URL is entered', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('https://example.com/photo.png')
@@ -404,7 +404,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm inserts image when a valid http URL is entered', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('http://example.com/photo.png')
@@ -413,7 +413,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm trims whitespace from URL', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('  https://example.com/photo.png  ')
@@ -422,7 +422,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm does nothing when URL is empty', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('   ')
@@ -431,7 +431,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm rejects URLs without http(s) protocol', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('javascript:alert(1)')
@@ -440,7 +440,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onInput sets error for invalid protocol', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       const setError = vi.fn()
@@ -450,7 +450,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onInput clears error for valid URL', () => {
       const editor = createMockEditor()
-      actions.imageUrl().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       const setError = vi.fn()
@@ -515,7 +515,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction creates a file input with image accept type', () => {
       const editor = createMockEditor()
-      actions.imageUpload().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'file')
       expect(mockInput.type).toBe('file')
       expect(mockInput.accept).toBe('image/*')
       expect(mockInput.click).toHaveBeenCalled()
@@ -540,7 +540,7 @@ describe('useEditorActions', () => {
         Object.assign(this as object, mockReaderInstance)
       } as unknown as () => FileReader)
 
-      actions.imageUpload().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'
@@ -566,7 +566,7 @@ describe('useEditorActions', () => {
         Object.assign(this as object, mockReaderInstance)
       } as unknown as () => FileReader)
 
-      actions.imageUpload().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'
@@ -588,7 +588,7 @@ describe('useEditorActions', () => {
         Object.assign(this as object, mockReaderInstance)
       } as unknown as () => FileReader)
 
-      actions.imageUpload().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'
@@ -606,7 +606,7 @@ describe('useEditorActions', () => {
     it('toolbarAction does nothing when no file is selected', () => {
       const editor = createMockEditor()
 
-      actions.imageUpload().toolbarAction!(editor)
+      actions.image().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'

--- a/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
@@ -2,6 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { useTextEditor } from '../../../../src/editor/composables/useTextEditor'
 import { withSetup } from './helpers'
 import { toRef } from 'vue'
+import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 
 function createEditor(options = {}) {
   const defaults = { contentType: 'html' as const, modelValue: toRef('<p>hello</p>') }
@@ -9,6 +10,10 @@ function createEditor(options = {}) {
 }
 
 describe('useTextEditor', () => {
+  beforeEach(() => {
+    createTestingPinia()
+  })
+
   it('creates an editor instance', () => {
     const { result } = createEditor()
     expect(result.editor.value).not.toBeNull()

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -7,6 +7,7 @@ vi.mock('vue3-gettext', () => ({
 }))
 
 import { useStrategyHtml } from '../../../../src/editor/composables/strategies/html'
+import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 
 function createStrategy() {
   const state: TextEditorState = { sourceMode: ref(false) }
@@ -14,6 +15,10 @@ function createStrategy() {
 }
 
 describe('useStrategyHtml', () => {
+  beforeEach(() => {
+    createTestingPinia()
+  })
+
   describe('extensions', () => {
     it('includes rich text extensions', () => {
       const strategy = createStrategy()

--- a/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
@@ -15,14 +15,14 @@ function createStrategy() {
 
 describe('useStrategyMarkdown', () => {
   describe('extensions', () => {
-    it('includes markdown-relevant extensions but not underline or image', () => {
+    it('includes markdown-relevant extensions but not underline', () => {
       const strategy = createStrategy()
       const names = strategy.extensions().map((e) => e.name)
       expect(names).toContain('link')
       expect(names).toContain('table')
       expect(names).toContain('taskList')
+      expect(names).toContain('image')
       expect(names).not.toContain('underline')
-      expect(names).not.toContain('image')
     })
   })
 

--- a/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
@@ -7,6 +7,7 @@ vi.mock('vue3-gettext', () => ({
 }))
 
 import { useStrategyMarkdown } from '../../../../src/editor/composables/strategies/markdown'
+import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 
 function createStrategy() {
   const state: TextEditorState = { sourceMode: ref(false) }
@@ -14,6 +15,10 @@ function createStrategy() {
 }
 
 describe('useStrategyMarkdown', () => {
+  beforeEach(() => {
+    createTestingPinia()
+  })
+
   describe('extensions', () => {
     it('includes markdown-relevant extensions but not underline', () => {
       const strategy = createStrategy()
@@ -27,12 +32,14 @@ describe('useStrategyMarkdown', () => {
   })
 
   describe('editorActionGroups', () => {
-    it('does not include underline or image actions', () => {
+    it('does not include underline action but includes image actions', () => {
       const strategy = createStrategy()
       const allIds = strategy.editorActionGroups().flatMap((g) => g.actions.map((a) => a.id))
       expect(allIds).toContain('bold')
       expect(allIds).not.toContain('underline')
       expect(allIds).not.toContain('image')
+      expect(allIds).toContain('image-url')
+      expect(allIds).toContain('image-upload')
     })
 
     it('includes source mode toggle', () => {

--- a/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
@@ -37,7 +37,7 @@ describe('useStrategyMarkdown', () => {
       const allIds = strategy.editorActionGroups().flatMap((g) => g.actions.map((a) => a.id))
       expect(allIds).toContain('bold')
       expect(allIds).not.toContain('underline')
-      expect(allIds).not.toContain('image')
+      expect(allIds).toContain('image')
       expect(allIds).toContain('image-url')
       expect(allIds).toContain('image-upload')
     })

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -7,6 +7,7 @@ vi.mock('vue3-gettext', () => ({
 }))
 
 import { useStrategyTiptapJson } from '../../../../src/editor/composables/strategies/tiptapJson'
+import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 
 function createStrategy() {
   const state: TextEditorState = { sourceMode: ref(false) }
@@ -14,6 +15,10 @@ function createStrategy() {
 }
 
 describe('useStrategyTiptapJson', () => {
+  beforeEach(() => {
+    createTestingPinia()
+  })
+
   describe('extensions', () => {
     it('includes same rich text extensions as HTML strategy', () => {
       const strategy = createStrategy()


### PR DESCRIPTION
Adds the option to insert images from the local disk or a URL to the toolbar and the slash command menu. Also fixes displaying those images in md files and another issue with the centered placement of the toolbar.

Note that the drop menus of the toolbar are still not looking very good. I want to tackle this in a follow-up.

works towards https://github.com/opencloud-eu/web/issues/2455