### PR TITLE
feat(editor): improve toolbar ordering and dropdowns

### DIFF
--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -15,49 +15,62 @@
           v-for="item in group.actions.filter((a) => a.showInToolbar !== false)"
           :key="`toolbar-item-${item.id}`"
         >
-          <template v-if="item.isDropdown && item.dropdownOptions">
+          <template v-if="item.childActions">
             <oc-button
               :id="`toolbar-dropdown-trigger-${item.id}`"
               v-oc-tooltip="item.title"
               type="button"
               appearance="raw"
-              class="text-editor-toolbar-btn min-w-[52px] inline-flex items-center justify-center"
+              class="text-editor-toolbar-btn min-w-[52px] inline-flex items-center justify-center p-2"
               :class="{
                 'text-editor-toolbar-btn--active': isItemActive(item)
               }"
               :aria-label="item.title"
-              :disabled="!isItemEnabled(item)"
             >
-              <oc-icon :name="item.icon" :fill-type="item.iconFillType || 'none'" size="small" />
+              <oc-icon
+                :name="getActiveIcon(item).icon"
+                :fill-type="getActiveIcon(item).iconFillType || 'none'"
+                size="small"
+              />
               <oc-icon name="arrow-down-s" fill-type="line" size="small" />
             </oc-button>
             <oc-drop
               :drop-id="`toolbar-dropdown-${item.id}`"
               :toggle="`#toolbar-dropdown-trigger-${item.id}`"
               mode="click"
-              class="text-editor-toolbar-dropdown"
+              class="text-editor-toolbar-dropdown w-auto min-w-40"
               padding-size="small"
               close-on-click
             >
               <ul class="oc-list">
                 <li
-                  v-for="option in item.dropdownOptions"
-                  :key="`${item.id}-${option.value}`"
+                  v-for="child in item.childActions"
+                  :key="`${item.id}-${child.id}`"
                   class="oc-rounded oc-menu-item-hover"
                 >
                   <oc-button
-                    appearance="raw"
+                    :appearance="isItemActive(child) ? 'filled' : 'raw-inverse'"
+                    :color-role="isItemActive(child) ? 'secondaryContainer' : 'surface'"
+                    :no-hover="isItemActive(child)"
                     justify-content="space-between"
-                    class="oc-width-1-1 oc-p-xs"
-                    @click="item.toolbarAction?.(textEditor.editor.value!, option.value)"
+                    class="p-1"
+                    :disabled="!isItemEnabled(child)"
+                    @click="child.toolbarAction?.(textEditor.editor.value!)"
                   >
+                    <span class="inline-flex items-center gap-2">
+                      <oc-icon
+                        :name="child.icon"
+                        :fill-type="child.iconFillType || 'none'"
+                        size="small"
+                      />
+                      <span>{{ child.title }}</span>
+                    </span>
                     <oc-icon
-                      v-if="option.value === getCurrentValue(item)"
+                      v-if="isItemActive(child)"
                       name="check"
                       fill-type="line"
                       size="small"
                     />
-                    <span>{{ option.label }}</span>
                   </oc-button>
                 </li>
               </ul>
@@ -68,7 +81,7 @@
             v-oc-tooltip="item.title"
             type="button"
             appearance="raw"
-            class="text-editor-toolbar-btn min-w-[42px] inline-flex items-center justify-center"
+            class="text-editor-toolbar-btn min-w-[42px] inline-flex items-center justify-center p-2"
             :class="{ 'text-editor-toolbar-btn--active': isItemActive(item) }"
             :aria-label="item.title"
             :disabled="!isItemEnabled(item)"
@@ -93,6 +106,7 @@
 <script setup lang="ts">
 import { computed, inject, nextTick, onMounted, ref, unref, useTemplateRef, watch } from 'vue'
 import type { TextEditorInstance } from '../types'
+import { EditorAction } from '../composables'
 
 const textEditor = inject<TextEditorInstance>('textEditor')!
 
@@ -148,7 +162,7 @@ const updateEditorState = () => {
   editorStateKey.value++
 }
 
-const isItemEnabled = (item: any) => {
+const isItemEnabled = (item: EditorAction) => {
   // Access editorStateKey to make this reactive to editor state changes
   editorStateKey.value
 
@@ -163,7 +177,7 @@ const isItemEnabled = (item: any) => {
   return true
 }
 
-const isItemActive = (item: any) => {
+const isItemActive = (item: EditorAction) => {
   // Access editorStateKey to make this reactive to editor state changes
   editorStateKey.value
 
@@ -178,16 +192,18 @@ const isItemActive = (item: any) => {
   return false
 }
 
-const getCurrentValue = (item: any) => {
+const getActiveIcon = (item: EditorAction) => {
   // Access editorStateKey to make this reactive to editor state changes
   editorStateKey.value
 
   const editor = unref(textEditor.editor)
-  if (!editor || !item.currentValue) {
-    return undefined
+  if (editor && item.activeIcon) {
+    const active = item.activeIcon(editor)
+    if (active) {
+      return active
+    }
   }
-
-  return item.currentValue(editor)
+  return { icon: item.icon, iconFillType: item.iconFillType }
 }
 </script>
 
@@ -204,7 +220,6 @@ const getCurrentValue = (item: any) => {
 }
 
 .text-editor-toolbar-btn {
-  @apply h-[42px];
   gap: 0 !important;
 }
 .text-editor-toolbar-btn--active {

--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -64,7 +64,6 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
   const {
     undo,
     redo,
-    fontFamily,
     fontSize,
     lineHeight,
     backgroundColor,
@@ -73,17 +72,19 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
     italic,
     underline,
     strikethrough,
-    paragraph,
+    heading,
     heading1,
     heading2,
     heading3,
+    heading4,
     bulletList,
     orderedList,
     taskList,
     blockquote,
     codeBlock,
     horizontalRule,
-    table,
+    tableMenu,
+    createTable,
     addRowBefore,
     addRowAfter,
     deleteRow,
@@ -99,10 +100,14 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
         actions: [undo(), redo()]
       },
       {
-        id: 'text',
-        title: $gettext('Text'),
+        id: 'formatting',
+        title: $gettext('Formatting'),
         actions: [
-          fontFamily(),
+          heading(),
+          heading1(),
+          heading2(),
+          heading3(),
+          heading4(),
           fontSize(),
           lineHeight(),
           backgroundColor(),
@@ -114,30 +119,28 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
         ]
       },
       {
-        id: 'basic-blocks',
-        title: $gettext('Basic blocks'),
-        actions: [paragraph(), heading1(), heading2(), heading3()]
-      },
-      {
         id: 'lists',
         title: $gettext('Lists'),
         actions: [bulletList(), orderedList(), taskList()]
       },
       {
-        id: 'advanced',
-        title: $gettext('Advanced'),
-        actions: [blockquote(), codeBlock(), horizontalRule(), table()]
+        id: 'blocks',
+        title: $gettext('Blocks'),
+        actions: [blockquote(), codeBlock()]
       },
       {
-        id: 'table-editing',
-        title: $gettext('Table editing'),
+        id: 'insert',
+        title: $gettext('Insert'),
         actions: [
-          addRowBefore(),
-          addRowAfter(),
-          deleteRow(),
-          addColumnBefore(),
+          tableMenu(),
+          createTable(),
           addColumnAfter(),
-          deleteColumn()
+          addColumnBefore(),
+          addRowAfter(),
+          addRowBefore(),
+          deleteColumn(),
+          deleteRow(),
+          horizontalRule()
         ]
       }
     ]

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -54,9 +54,11 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
     bold,
     italic,
     strikethrough,
+    heading,
     heading1,
     heading2,
     heading3,
+    heading4,
     bulletList,
     orderedList,
     taskList,
@@ -66,7 +68,8 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
     image,
     imageUrl,
     imageUpload,
-    table,
+    tableMenu,
+    createTable,
     addRowBefore,
     addRowAfter,
     deleteRow,
@@ -87,14 +90,18 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
         actions: [toggleSourceMode()]
       },
       {
-        id: 'text',
-        title: $gettext('Text'),
-        actions: [bold(), italic(), strikethrough()]
-      },
-      {
-        id: 'basic-blocks',
-        title: $gettext('Basic blocks'),
-        actions: [heading1(), heading2(), heading3()]
+        id: 'formatting',
+        title: $gettext('Formatting'),
+        actions: [
+          heading(),
+          heading1(),
+          heading2(),
+          heading3(),
+          heading4(),
+          bold(),
+          italic(),
+          strikethrough()
+        ]
       },
       {
         id: 'lists',
@@ -102,25 +109,26 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
         actions: [bulletList(), orderedList(), taskList()]
       },
       {
-        id: 'advanced',
-        title: $gettext('Advanced'),
-        actions: [blockquote(), codeBlock(), horizontalRule(), table()]
+        id: 'blocks',
+        title: $gettext('Blocks'),
+        actions: [blockquote(), codeBlock()]
       },
       {
-        id: 'image',
-        title: $gettext('Image'),
-        actions: [image(), imageUrl(), imageUpload()]
-      },
-      {
-        id: 'table-editing',
-        title: $gettext('Table editing'),
+        id: 'insert',
+        title: $gettext('Insert'),
         actions: [
-          addRowBefore(),
-          addRowAfter(),
-          deleteRow(),
-          addColumnBefore(),
+          image(),
+          imageUrl(),
+          imageUpload(),
+          tableMenu(),
+          createTable(),
           addColumnAfter(),
-          deleteColumn()
+          addColumnBefore(),
+          addRowAfter(),
+          addRowBefore(),
+          deleteColumn(),
+          deleteRow(),
+          horizontalRule()
         ]
       }
     ]

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -64,7 +64,6 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
   const {
     undo,
     redo,
-    fontFamily,
     fontSize,
     lineHeight,
     backgroundColor,
@@ -73,10 +72,11 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     italic,
     underline,
     strikethrough,
-    paragraph,
+    heading,
     heading1,
     heading2,
     heading3,
+    heading4,
     bulletList,
     orderedList,
     taskList,
@@ -86,7 +86,8 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     image,
     imageUrl,
     imageUpload,
-    table,
+    tableMenu,
+    createTable,
     addRowBefore,
     addRowAfter,
     deleteRow,
@@ -102,12 +103,15 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
         actions: [undo(), redo()]
       },
       {
-        id: 'text',
-        title: $gettext('Text'),
+        id: 'formatting',
+        title: $gettext('Formatting'),
         actions: [
-          fontFamily(),
+          heading(),
+          heading1(),
+          heading2(),
+          heading3(),
+          heading4(),
           fontSize(),
-          lineHeight(),
           backgroundColor(),
           textColor(),
           bold(),
@@ -117,35 +121,31 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
         ]
       },
       {
-        id: 'basic-blocks',
-        title: $gettext('Basic blocks'),
-        actions: [paragraph(), heading1(), heading2(), heading3()]
-      },
-      {
         id: 'lists',
         title: $gettext('Lists'),
         actions: [bulletList(), orderedList(), taskList()]
       },
       {
-        id: 'advanced',
-        title: $gettext('Advanced'),
-        actions: [blockquote(), codeBlock(), horizontalRule(), table()]
+        id: 'blocks',
+        title: $gettext('Blocks'),
+        actions: [lineHeight(), blockquote(), codeBlock()]
       },
       {
-        id: 'image',
-        title: $gettext('Image'),
-        actions: [image(), imageUrl(), imageUpload()]
-      },
-      {
-        id: 'table-editing',
-        title: $gettext('Table editing'),
+        id: 'insert',
+        title: $gettext('Insert'),
         actions: [
-          addRowBefore(),
-          addRowAfter(),
-          deleteRow(),
-          addColumnBefore(),
+          image(),
+          imageUrl(),
+          imageUpload(),
+          tableMenu(),
+          createTable(),
           addColumnAfter(),
-          deleteColumn()
+          addColumnBefore(),
+          addRowAfter(),
+          addRowBefore(),
+          deleteColumn(),
+          deleteRow(),
+          horizontalRule()
         ]
       }
     ]

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -14,6 +14,9 @@ export interface EditorAction {
   description?: string
   icon: string
   iconFillType?: 'fill' | 'line' | 'none'
+  activeIcon?: (
+    editor: Editor
+  ) => { icon: string; iconFillType?: 'fill' | 'line' | 'none' } | undefined
 
   // Search & discovery (for slash commands)
   keywords?: string[]
@@ -23,7 +26,6 @@ export interface EditorAction {
   slashCommandAction?: (ctx: { editor: Editor; range: Range }) => void
 
   // State management
-  currentValue?: (editor: Editor) => string | undefined
   isActive?: (editor: Editor) => boolean
   isEnabled?: (editor: Editor) => boolean
 
@@ -31,9 +33,10 @@ export interface EditorAction {
   showInToolbar?: boolean
   showInSlashCommands?: boolean
 
-  // Dropdown configuration
-  isDropdown?: boolean
-  dropdownOptions?: Array<{ value: string; label: string }>
+  // Child actions (rendered as a dropdown menu in the toolbar)
+  // For child actions to appear as slash commands, they must be registered
+  // as separate action in the respective strategy as well
+  childActions?: EditorAction[]
 }
 
 export interface EditorActionGroup {
@@ -96,65 +99,22 @@ export function useEditorActions(
     id: 'font-size',
     title: $gettext('Font size'),
     icon: 'font-size-2',
-    isDropdown: true,
-    dropdownOptions: [
-      { value: '12px', label: '12px' },
-      { value: '14px', label: '14px' },
-      { value: '16px', label: '16px' },
-      { value: '18px', label: '18px' },
-      { value: '20px', label: '20px' },
-      { value: '24px', label: '24px' },
-      { value: '28px', label: '28px' },
-      { value: '32px', label: '32px' }
-    ],
-    currentValue: (editor) => editor.getAttributes('textStyle').fontSize as string | undefined,
-    toolbarAction: (editor, value) => editor.chain().focus().setFontSize(value).run(),
-    showInSlashCommands: false
-  })
-
-  const fontFamily = (): EditorAction => ({
-    id: 'font-family',
-    title: $gettext('Font family'),
-    icon: 'font-family',
-    isDropdown: true,
-    dropdownOptions: [
-      { value: 'Arial', label: $gettext('Arial') },
-      { value: 'Courier New', label: $gettext('Courier New') },
-      { value: 'Georgia', label: $gettext('Georgia') },
-      { value: 'Times New Roman', label: $gettext('Times New Roman') },
-      { value: 'Trebuchet MS', label: $gettext('Trebuchet MS') },
-      { value: 'Verdana', label: $gettext('Verdana') }
-    ],
-    currentValue: (editor) => editor.getAttributes('textStyle').fontFamily as string | undefined,
-    toolbarAction: (editor, value) => editor.chain().focus().setFontFamily(value).run(),
-    showInSlashCommands: false
-  })
-
-  const lineHeight = (): EditorAction => ({
-    id: 'line-height',
-    title: $gettext('Line height'),
-    icon: 'line-height',
-    isDropdown: true,
-    dropdownOptions: [
-      { value: '1', label: '1' },
-      { value: '1.15', label: '1.15' },
-      { value: '1.5', label: '1.5' },
-      { value: '1.75', label: '1.75' },
-      { value: '2', label: '2' },
-      { value: '2.5', label: '2.5' },
-      { value: '3', label: '3' }
-    ],
-    currentValue: (editor) => editor.getAttributes('textStyle').lineHeight as string | undefined,
-    toolbarAction: (editor, value) => editor.chain().focus().setLineHeight(value).run(),
-    showInSlashCommands: false
+    showInSlashCommands: false,
+    childActions: ['12px', '14px', '16px', '18px', '20px', '24px', '28px', '32px'].map((size) => ({
+      id: `font-size-${size}`,
+      title: size,
+      icon: 'font-size-2',
+      toolbarAction: (editor) => editor.chain().focus().setFontSize(size).run(),
+      isActive: (editor) => editor.getAttributes('textStyle').fontSize === size
+    }))
   })
 
   const textColor = (): EditorAction => ({
     id: 'text-color',
     title: $gettext('Text color'),
     icon: 'font-color',
-    isDropdown: true,
-    dropdownOptions: [
+    showInSlashCommands: false,
+    childActions: [
       { value: '#000000', label: $gettext('Black') },
       { value: '#e60000', label: $gettext('Red') },
       { value: '#ff9900', label: $gettext('Orange') },
@@ -169,10 +129,13 @@ export function useEditorActions(
       { value: '#cce8cc', label: $gettext('Light green') },
       { value: '#cce0f5', label: $gettext('Light blue') },
       { value: '#ebd6ff', label: $gettext('Light purple') }
-    ],
-    currentValue: (editor) => editor.getAttributes('textStyle').color as string | undefined,
-    toolbarAction: (editor, value) => editor.chain().focus().setColor(value).run(),
-    showInSlashCommands: false
+    ].map(({ value, label }) => ({
+      id: `text-color-${value.replace('#', '')}`,
+      title: label,
+      icon: 'font-color',
+      toolbarAction: (editor) => editor.chain().focus().setColor(value).run(),
+      isActive: (editor) => editor.getAttributes('textStyle').color === value
+    }))
   })
 
   const backgroundColor = (): EditorAction => ({
@@ -180,8 +143,8 @@ export function useEditorActions(
     title: $gettext('Background color'),
     icon: 'mark-pen',
     iconFillType: 'line',
-    isDropdown: true,
-    dropdownOptions: [
+    showInSlashCommands: false,
+    childActions: [
       { value: 'transparent', label: $gettext('None') },
       { value: '#facccc', label: $gettext('Light red') },
       { value: '#ffebcc', label: $gettext('Light orange') },
@@ -196,11 +159,14 @@ export function useEditorActions(
       { value: '#0066cc', label: $gettext('Blue') },
       { value: '#9933ff', label: $gettext('Purple') },
       { value: '#000000', label: $gettext('Black') }
-    ],
-    currentValue: (editor) =>
-      editor.getAttributes('textStyle').backgroundColor as string | undefined,
-    toolbarAction: (editor, value) => editor.chain().focus().setBackgroundColor(value).run(),
-    showInSlashCommands: false
+    ].map(({ value, label }) => ({
+      id: `background-color-${value.replace('#', '')}`,
+      title: label,
+      icon: 'mark-pen',
+      iconFillType: 'line' as const,
+      toolbarAction: (editor) => editor.chain().focus().setBackgroundColor(value).run(),
+      isActive: (editor) => editor.getAttributes('textStyle').backgroundColor === value
+    }))
   })
 
   const bold = (): EditorAction => ({
@@ -253,18 +219,22 @@ export function useEditorActions(
     isActive: (editor) => editor.isActive('code')
   })
 
-  // Block actions
-  const paragraph = (): EditorAction => ({
-    id: 'paragraph',
-    title: $gettext('Paragraph'),
-    description: $gettext('Plain text block'),
-    icon: 'paragraph',
-    keywords: ['text', 'body'],
-    toolbarAction: (editor) => editor.chain().focus().setParagraph().run(),
-    slashCommandAction: ({ editor, range }) => {
-      editor.chain().focus().deleteRange(range).setNode('paragraph').run()
+  // Heading actions
+  const heading = (): EditorAction => ({
+    id: 'heading',
+    title: $gettext('Heading'),
+    icon: 'heading',
+    activeIcon: (editor) => {
+      for (const level of [1, 2, 3, 4] as const) {
+        if (editor.isActive('heading', { level })) {
+          return { icon: `h-${level}` }
+        }
+      }
+      return undefined
     },
-    showInToolbar: false
+    isActive: (editor) => editor.isActive('heading'),
+    showInSlashCommands: false,
+    childActions: [heading1(), heading2(), heading3(), heading4()]
   })
 
   const heading1 = (): EditorAction => ({
@@ -277,7 +247,8 @@ export function useEditorActions(
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).setNode('heading', { level: 1 }).run()
     },
-    isActive: (editor) => editor.isActive('heading', { level: 1 })
+    isActive: (editor) => editor.isActive('heading', { level: 1 }),
+    showInToolbar: false
   })
 
   const heading2 = (): EditorAction => ({
@@ -290,7 +261,8 @@ export function useEditorActions(
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).setNode('heading', { level: 2 }).run()
     },
-    isActive: (editor) => editor.isActive('heading', { level: 2 })
+    isActive: (editor) => editor.isActive('heading', { level: 2 }),
+    showInToolbar: false
   })
 
   const heading3 = (): EditorAction => ({
@@ -303,7 +275,37 @@ export function useEditorActions(
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).setNode('heading', { level: 3 }).run()
     },
-    isActive: (editor) => editor.isActive('heading', { level: 3 })
+    isActive: (editor) => editor.isActive('heading', { level: 3 }),
+    showInToolbar: false
+  })
+
+  const heading4 = (): EditorAction => ({
+    id: 'heading-4',
+    title: $gettext('Heading 4'),
+    description: $gettext('Extra small section heading'),
+    icon: 'h-4',
+    keywords: ['h4'],
+    toolbarAction: (editor) => editor.chain().focus().toggleHeading({ level: 4 }).run(),
+    slashCommandAction: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).setNode('heading', { level: 4 }).run()
+    },
+    isActive: (editor) => editor.isActive('heading', { level: 4 }),
+    showInToolbar: false
+  })
+
+  // Block actions
+  const lineHeight = (): EditorAction => ({
+    id: 'line-height',
+    title: $gettext('Line height'),
+    icon: 'line-height',
+    showInSlashCommands: false,
+    childActions: ['1', '1.15', '1.5', '1.75', '2', '2.5', '3'].map((value) => ({
+      id: `line-height-${value}`,
+      title: value,
+      icon: 'line-height',
+      toolbarAction: (editor) => editor.chain().focus().setLineHeight(value).run(),
+      isActive: (editor) => editor.getAttributes('textStyle').lineHeight === value
+    }))
   })
 
   const blockquote = (): EditorAction => ({
@@ -330,19 +332,6 @@ export function useEditorActions(
       editor.chain().focus().deleteRange(range).toggleCodeBlock().run()
     },
     isActive: (editor) => editor.isActive('codeBlock')
-  })
-
-  const horizontalRule = (): EditorAction => ({
-    id: 'horizontal-rule',
-    title: $gettext('Horizontal rule'),
-    description: $gettext('Divider line'),
-    icon: 'separator',
-    keywords: ['hr', 'divider'],
-    toolbarAction: (editor) => editor.chain().focus().setHorizontalRule().run(),
-    slashCommandAction: ({ editor, range }) => {
-      editor.chain().focus().deleteRange(range).setHorizontalRule().run()
-    },
-    isActive: () => false
   })
 
   // List actions
@@ -433,6 +422,7 @@ export function useEditorActions(
     icon: 'link-line',
     keywords: ['image', 'picture', 'url'],
     showInToolbar: false,
+    toolbarAction: (editor) => dispatchImageModal(editor),
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).run()
       dispatchImageModal(editor)
@@ -448,6 +438,7 @@ export function useEditorActions(
     keywords: ['image', 'picture', 'upload', 'file'],
     showInToolbar: false,
     showInSlashCommands: true,
+    toolbarAction: (editor) => insertImageFromFile(editor),
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).run()
       insertImageFromFile(editor)
@@ -460,19 +451,8 @@ export function useEditorActions(
     title: $gettext('Insert image'),
     icon: 'image-line',
     keywords: ['image', 'picture', 'upload', 'url'],
-    isDropdown: true,
     showInSlashCommands: false,
-    dropdownOptions: [
-      { value: 'file', label: $gettext('Upload image') },
-      { value: 'url', label: $gettext('Insert via URL') }
-    ],
-    toolbarAction: (editor, value) => {
-      if (value === 'url') {
-        dispatchImageModal(editor)
-      } else if (value === 'file') {
-        insertImageFromFile(editor)
-      }
-    },
+    childActions: [imageUpload(), imageUrl()],
     isActive: () => false
   })
 
@@ -503,12 +483,27 @@ export function useEditorActions(
     input.click()
   }
 
-  const table = (): EditorAction => ({
+  const horizontalRule = (): EditorAction => ({
+    id: 'horizontal-rule',
+    title: $gettext('Horizontal rule'),
+    description: $gettext('Divider line'),
+    icon: 'separator',
+    keywords: ['hr', 'divider'],
+    toolbarAction: (editor) => editor.chain().focus().setHorizontalRule().run(),
+    slashCommandAction: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).setHorizontalRule().run()
+    },
+    isActive: () => false
+  })
+
+  // Table actions
+  const createTable = (): EditorAction => ({
     id: 'table',
-    title: $gettext('Table'),
+    title: $gettext('Create a table'),
     description: $gettext('3×3 table with header row'),
     icon: 'table-line',
     keywords: ['grid'],
+    showInToolbar: false,
     toolbarAction: (editor) =>
       editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
     slashCommandAction: ({ editor, range }) => {
@@ -522,13 +517,13 @@ export function useEditorActions(
     isActive: () => false
   })
 
-  // Table manipulation actions
   const addRowBefore = (): EditorAction => ({
     id: 'add-row-before',
     title: $gettext('Add row above'),
     description: $gettext('Insert row before current'),
     icon: 'insert-row-top',
     keywords: ['table', 'row', 'above', 'before'],
+    showInToolbar: false,
     toolbarAction: (editor) => editor.chain().focus().addRowBefore().run(),
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).addRowBefore().run()
@@ -543,6 +538,7 @@ export function useEditorActions(
     description: $gettext('Insert row after current'),
     icon: 'insert-row-bottom',
     keywords: ['table', 'row', 'below', 'after'],
+    showInToolbar: false,
     toolbarAction: (editor) => editor.chain().focus().addRowAfter().run(),
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).addRowAfter().run()
@@ -557,6 +553,7 @@ export function useEditorActions(
     description: $gettext('Remove current row'),
     icon: 'delete-row',
     keywords: ['table', 'row', 'remove'],
+    showInToolbar: false,
     toolbarAction: (editor) => {
       const deleted = editor.chain().focus().deleteRow().run()
       if (!deleted && editor.isActive('table')) {
@@ -579,6 +576,7 @@ export function useEditorActions(
     description: $gettext('Insert column before current'),
     icon: 'insert-column-left',
     keywords: ['table', 'column', 'left', 'before'],
+    showInToolbar: false,
     toolbarAction: (editor) => editor.chain().focus().addColumnBefore().run(),
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).addColumnBefore().run()
@@ -593,6 +591,7 @@ export function useEditorActions(
     description: $gettext('Insert column after current'),
     icon: 'insert-column-right',
     keywords: ['table', 'column', 'right', 'after'],
+    showInToolbar: false,
     toolbarAction: (editor) => editor.chain().focus().addColumnAfter().run(),
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).addColumnAfter().run()
@@ -607,6 +606,7 @@ export function useEditorActions(
     description: $gettext('Remove current column'),
     icon: 'delete-column',
     keywords: ['table', 'column', 'remove'],
+    showInToolbar: false,
     toolbarAction: (editor) => {
       const deleted = editor.chain().focus().deleteColumn().run()
       if (!deleted && editor.isActive('table')) {
@@ -623,6 +623,22 @@ export function useEditorActions(
     isEnabled: (editor) => editor.isActive('table')
   })
 
+  const tableMenu = (): EditorAction => ({
+    id: 'table-menu',
+    title: $gettext('Table'),
+    icon: 'table-line',
+    showInSlashCommands: false,
+    childActions: [
+      createTable(),
+      addRowBefore(),
+      addRowAfter(),
+      deleteRow(),
+      addColumnBefore(),
+      addColumnAfter(),
+      deleteColumn()
+    ]
+  })
+
   return {
     // History
     undo,
@@ -630,9 +646,12 @@ export function useEditorActions(
     // View options
     toggleSourceMode,
     // Text formatting
+    heading,
+    heading1,
+    heading2,
+    heading3,
+    heading4,
     fontSize,
-    fontFamily,
-    lineHeight,
     textColor,
     backgroundColor,
     bold,
@@ -641,13 +660,9 @@ export function useEditorActions(
     strikethrough,
     codeInline,
     // Blocks
-    paragraph,
-    heading1,
-    heading2,
-    heading3,
+    lineHeight,
     blockquote,
     codeBlock,
-    horizontalRule,
     // Lists
     bulletList,
     orderedList,
@@ -657,8 +672,10 @@ export function useEditorActions(
     image,
     imageUrl,
     imageUpload,
-    table,
-    // Table manipulation
+    horizontalRule,
+    // Table
+    tableMenu,
+    createTable,
     addRowBefore,
     addRowAfter,
     deleteRow,

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -37,6 +37,9 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
   }
 
   watch(options.modelValue, (content) => {
+    if (!unref(editor) || unref(editor).options.editable) {
+      return
+    }
     setContent(content)
   })
 

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -88,7 +88,7 @@ describe('useEditorActions', () => {
   })
 
   describe('text formatting', () => {
-    const formattingActions = [
+    const inlineActions = [
       { name: 'bold', toggleMethod: 'toggleBold', markName: 'bold' },
       { name: 'italic', toggleMethod: 'toggleItalic', markName: 'italic' },
       { name: 'underline', toggleMethod: 'toggleUnderline', markName: 'underline' },
@@ -96,7 +96,7 @@ describe('useEditorActions', () => {
       { name: 'codeInline', toggleMethod: 'toggleCode', markName: 'code' }
     ] as const
 
-    for (const { name, toggleMethod, markName } of formattingActions) {
+    for (const { name, toggleMethod, markName } of inlineActions) {
       describe(name, () => {
         it('toolbarAction calls the correct toggle command', () => {
           const editor = createMockEditor()
@@ -118,37 +118,40 @@ describe('useEditorActions', () => {
         })
       })
     }
-  })
 
-  describe('dropdowns', () => {
     const dropdownActions = [
-      { name: 'fontSize', setMethod: 'setFontSize', attrKey: 'fontSize' },
-      { name: 'fontFamily', setMethod: 'setFontFamily', attrKey: 'fontFamily' },
-      { name: 'lineHeight', setMethod: 'setLineHeight', attrKey: 'lineHeight' },
-      { name: 'textColor', setMethod: 'setColor', attrKey: 'color' },
-      { name: 'backgroundColor', setMethod: 'setBackgroundColor', attrKey: 'backgroundColor' }
+      { name: 'fontSize', setMethod: 'setFontSize', attrKey: 'fontSize', valueIsTitle: true },
+      { name: 'lineHeight', setMethod: 'setLineHeight', attrKey: 'lineHeight', valueIsTitle: true },
+      { name: 'textColor', setMethod: 'setColor', attrKey: 'color', valueIsTitle: false },
+      {
+        name: 'backgroundColor',
+        setMethod: 'setBackgroundColor',
+        attrKey: 'backgroundColor',
+        valueIsTitle: false
+      }
     ] as const
 
-    for (const { name, setMethod, attrKey } of dropdownActions) {
+    for (const { name, setMethod, attrKey, valueIsTitle } of dropdownActions) {
       describe(name, () => {
-        it('is a dropdown with non-empty options', () => {
+        it('has non-empty childActions', () => {
           const action = actions[name]()
-          expect(action.isDropdown).toBe(true)
-          expect(action.dropdownOptions!.length).toBeGreaterThan(0)
+          expect(action.childActions!.length).toBeGreaterThan(0)
         })
 
-        it('currentValue reads from editor.getAttributes("textStyle")', () => {
-          const editor = createMockEditor({
-            attributes: { textStyle: { [attrKey]: 'test-value' } }
+        if (valueIsTitle) {
+          it('child isActive reads from editor.getAttributes("textStyle")', () => {
+            const child = actions[name]().childActions![0]
+            const editor = createMockEditor({
+              attributes: { textStyle: { [attrKey]: child.title } }
+            })
+            expect(child.isActive!(editor)).toBe(true)
           })
-          expect(actions[name]().currentValue!(editor)).toBe('test-value')
-          expect(editor.getAttributes).toHaveBeenCalledWith('textStyle')
-        })
+        }
 
-        it('toolbarAction passes value to the set command', () => {
+        it('child toolbarAction passes value to the set command', () => {
           const editor = createMockEditor()
-          actions[name]().toolbarAction!(editor, 'my-value')
-          expect(editor._chain[setMethod]).toHaveBeenCalledWith('my-value')
+          actions[name]().childActions![0].toolbarAction!(editor)
+          expect(editor._chain[setMethod]).toHaveBeenCalled()
         })
 
         it('is hidden from slash commands', () => {
@@ -158,15 +161,51 @@ describe('useEditorActions', () => {
     }
   })
 
-  describe('block actions', () => {
+  describe('heading', () => {
     const blockActions: ReadonlyArray<{
-      name: 'heading1' | 'heading2' | 'heading3' | 'blockquote' | 'codeBlock'
+      name: 'heading1' | 'heading2' | 'heading3' | 'heading4'
       markName: string
       markAttrs?: Record<string, unknown>
     }> = [
       { name: 'heading1', markName: 'heading', markAttrs: { level: 1 } },
       { name: 'heading2', markName: 'heading', markAttrs: { level: 2 } },
       { name: 'heading3', markName: 'heading', markAttrs: { level: 3 } },
+      { name: 'heading4', markName: 'heading', markAttrs: { level: 4 } }
+    ]
+
+    for (const { name, markName, markAttrs } of blockActions) {
+      describe(name, () => {
+        it('slashCommandAction deletes range then sets node', () => {
+          const editor = createMockEditor()
+          actions[name]().slashCommandAction!({ editor, range: mockRange })
+          expect(editor._chain.deleteRange).toHaveBeenCalledWith(mockRange)
+          expect(editor._chain.run).toHaveBeenCalled()
+        })
+
+        it('isActive checks the correct node type', () => {
+          const editor = createMockEditor({
+            isActive: (type, attrs) => {
+              if (type !== markName) {
+                return false
+              }
+              if (markAttrs) {
+                return JSON.stringify(attrs) === JSON.stringify(markAttrs)
+              }
+              return true
+            }
+          })
+          expect(actions[name]().isActive!(editor)).toBe(true)
+        })
+      })
+    }
+  })
+
+  describe('block actions', () => {
+    const blockActions: ReadonlyArray<{
+      name: 'blockquote' | 'codeBlock'
+      markName: string
+      markAttrs?: Record<string, unknown>
+    }> = [
       { name: 'blockquote', markName: 'blockquote' },
       { name: 'codeBlock', markName: 'codeBlock' }
     ]
@@ -196,19 +235,10 @@ describe('useEditorActions', () => {
         })
       })
     }
+  })
 
-    it('paragraph: slashCommandAction deletes range then sets paragraph node', () => {
-      const editor = createMockEditor()
-      actions.paragraph().slashCommandAction!({ editor, range: mockRange })
-      expect(editor._chain.deleteRange).toHaveBeenCalledWith(mockRange)
-      expect(editor._chain.setNode).toHaveBeenCalledWith('paragraph')
-    })
-
-    it('paragraph: is hidden from toolbar', () => {
-      expect(actions.paragraph().showInToolbar).toBe(false)
-    })
-
-    it('horizontalRule: isActive always returns false', () => {
+  describe('horizontalRule', () => {
+    it('isActive always returns false', () => {
       const editor = createMockEditor()
       expect(actions.horizontalRule().isActive!(editor)).toBe(false)
     })
@@ -273,7 +303,7 @@ describe('useEditorActions', () => {
   describe('table', () => {
     it('toolbarAction inserts 3x3 table with header row', () => {
       const editor = createMockEditor()
-      actions.table().toolbarAction!(editor)
+      actions.createTable().toolbarAction!(editor)
       expect(editor._chain.insertTable).toHaveBeenCalledWith({
         rows: 3,
         cols: 3,
@@ -283,7 +313,7 @@ describe('useEditorActions', () => {
 
     it('slashCommandAction deletes range then inserts table', () => {
       const editor = createMockEditor()
-      actions.table().slashCommandAction!({ editor, range: mockRange })
+      actions.createTable().slashCommandAction!({ editor, range: mockRange })
       expect(editor._chain.deleteRange).toHaveBeenCalledWith(mockRange)
       expect(editor._chain.insertTable).toHaveBeenCalledWith({
         rows: 3,
@@ -382,7 +412,7 @@ describe('useEditorActions', () => {
   describe('imageUrl', () => {
     it('toolbarAction dispatches a modal with input', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const { dispatchModal } = useModals()
       expect(dispatchModal).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -395,7 +425,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm inserts image when a valid https URL is entered', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('https://example.com/photo.png')
@@ -404,7 +434,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm inserts image when a valid http URL is entered', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('http://example.com/photo.png')
@@ -413,7 +443,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm trims whitespace from URL', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('  https://example.com/photo.png  ')
@@ -422,7 +452,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm does nothing when URL is empty', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('   ')
@@ -431,7 +461,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onConfirm rejects URLs without http(s) protocol', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       modal.onConfirm('javascript:alert(1)')
@@ -440,7 +470,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onInput sets error for invalid protocol', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       const setError = vi.fn()
@@ -450,7 +480,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction onInput clears error for valid URL', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'url')
+      actions.imageUrl().toolbarAction!(editor, 'url')
       const store = useModals()
       const modal = store.modals[0]
       const setError = vi.fn()
@@ -515,7 +545,7 @@ describe('useEditorActions', () => {
 
     it('toolbarAction creates a file input with image accept type', () => {
       const editor = createMockEditor()
-      actions.image().toolbarAction!(editor, 'file')
+      actions.imageUpload().toolbarAction!(editor, 'file')
       expect(mockInput.type).toBe('file')
       expect(mockInput.accept).toBe('image/*')
       expect(mockInput.click).toHaveBeenCalled()
@@ -540,7 +570,7 @@ describe('useEditorActions', () => {
         Object.assign(this as object, mockReaderInstance)
       } as unknown as () => FileReader)
 
-      actions.image().toolbarAction!(editor, 'file')
+      actions.imageUpload().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'
@@ -566,7 +596,7 @@ describe('useEditorActions', () => {
         Object.assign(this as object, mockReaderInstance)
       } as unknown as () => FileReader)
 
-      actions.image().toolbarAction!(editor, 'file')
+      actions.imageUpload().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'
@@ -588,7 +618,7 @@ describe('useEditorActions', () => {
         Object.assign(this as object, mockReaderInstance)
       } as unknown as () => FileReader)
 
-      actions.image().toolbarAction!(editor, 'file')
+      actions.imageUpload().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'
@@ -606,7 +636,7 @@ describe('useEditorActions', () => {
     it('toolbarAction does nothing when no file is selected', () => {
       const editor = createMockEditor()
 
-      actions.image().toolbarAction!(editor, 'file')
+      actions.imageUpload().toolbarAction!(editor, 'file')
 
       const changeHandler = mockInput.addEventListener.mock.calls.find(
         (call: unknown[]) => call[0] === 'change'

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -37,7 +37,7 @@ describe('useStrategyHtml', () => {
       const allIds = strategy.editorActionGroups().flatMap((g) => g.actions.map((a) => a.id))
       expect(allIds).toContain('underline')
       expect(allIds).toContain('bold')
-      expect(allIds).toContain('table')
+      expect(allIds).toContain('table-menu')
       expect(allIds).toContain('font-size')
     })
   })

--- a/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
@@ -51,9 +51,10 @@ describe('useStrategyMarkdown', () => {
     it('returns expected group structure', () => {
       const strategy = createStrategy()
       const groupIds = strategy.editorActionGroups().map((g) => g.id)
-      expect(groupIds).toContain('basic-blocks')
+      expect(groupIds).toContain('formatting')
       expect(groupIds).toContain('lists')
-      expect(groupIds).toContain('advanced')
+      expect(groupIds).toContain('blocks')
+      expect(groupIds).toContain('insert')
     })
   })
 


### PR DESCRIPTION
- reorders the elements in the toolbar
- puts some actions into parent menus (headline, table)
- adds icons to the dropdown menus
- fix the active state in dropdown menus
- remove unnecessary actions (font family, paragraph)

works towards https://github.com/opencloud-eu/web/issues/2455