### PR TITLE
feat: retrieve extensions by their id

### DIFF
--- a/packages/web-pkg/src/composables/actions/types.ts
+++ b/packages/web-pkg/src/composables/actions/types.ts
@@ -20,12 +20,15 @@ export interface Action<T = ActionOptions> {
   name: string
   /**
    * Determines where an action will be displayed in the resource context menu.
+   * Doesn't have an effect on actions that are not shown in the context menu.
    *
    * Categories:
    * - primary: action will appear in primary action sections.
    * - secondary: action will appear in secondary action sections.
    * - tertiary: action will appear in tertiary action sections.
    * - quaternary:  action will appear in quaternary action sections.
+   *
+   * @default tertiary
    */
   category?: ActionCategory
   /**

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -31,6 +31,12 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
     ) as T[]
   }
 
+  const getExtensionById = <T extends Extension>(id: string): T | undefined => {
+    return unref(extensions)
+      .flatMap((e) => unref(e))
+      .find((e) => e.id === id) as T | undefined
+  }
+
   const extensionPoints = ref<Ref<ExtensionPoint<Extension>[]>[]>([])
   const registerExtensionPoints = <T extends Extension>(e: Ref<ExtensionPoint<T>[]>) => {
     extensionPoints.value.push(e)
@@ -67,7 +73,8 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
     extensionPoints,
     registerExtensionPoints,
     unregisterExtensionPoints,
-    getExtensionPoints
+    getExtensionPoints,
+    getExtensionById
   }
 })
 


### PR DESCRIPTION
With the recent move of file- and space-actions to the files app, we should provide an easy way to retrieve an extension by its id.