### PR TITLE
fix: prevent 'keep both' conflict handling from losing files

### DIFF
--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -190,21 +190,21 @@ export class UploadResourceConflict extends ConflictDialog {
           `/${newFolderName}/`
         )
         file.meta.tusEndpoint = file.meta.tusEndpoint.replace(
-          new RegExp(`/${encodeURIComponent(folder)}$`),
-          `/${encodeURIComponent(newFolderName)}`
+          new RegExp(`/${encodeURIComponent(folder)}(/|$)`),
+          `/${encodeURIComponent(newFolderName)}$1`
         )
         if (file.xhrUpload?.endpoint) {
           file.xhrUpload.endpoint = file.xhrUpload.endpoint
             .toString()
             .replace(
-              new RegExp(`/${encodeURIComponent(folder)}$`),
-              `/${encodeURIComponent(newFolderName)}`
+              new RegExp(`/${encodeURIComponent(folder)}(/|$)`),
+              `/${encodeURIComponent(newFolderName)}$1`
             )
         }
         if (file.tus?.endpoint) {
           file.tus.endpoint = file.tus.endpoint.replace(
-            new RegExp(`/${encodeURIComponent(folder)}$`),
-            `/${encodeURIComponent(newFolderName)}`
+            new RegExp(`/${encodeURIComponent(folder)}(/|$)`),
+            `/${encodeURIComponent(newFolderName)}$1`
           )
         }
       }

--- a/packages/web-app-files/tests/unit/helpers/resource/actions/upload.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/actions/upload.spec.ts
@@ -98,6 +98,56 @@ describe('upload helper', () => {
 
       expect(resolveFileConflictMethod).toHaveBeenCalledTimes(1)
     })
+    it('should update endpoints of files nested inside a renamed folder when keeping both', async () => {
+      const folderName = 'test'
+      const currentFiles = [mockDeep<Resource>({ name: folderName })]
+
+      const imageFile = {
+        id: 'image',
+        name: 'image.jpg',
+        type: 'image/jpeg',
+        meta: {
+          relativeFolder: '/test',
+          relativePath: '/test/image.jpg',
+          tusEndpoint: 'https://example.com/dav/test'
+        }
+      } as unknown as OcUppyFile
+
+      const nestedImageFile = {
+        id: 'nested-image',
+        name: 'image2.jpg',
+        type: 'image/jpeg',
+        meta: {
+          relativeFolder: '/test/folderInside',
+          relativePath: '/test/folderInside/image2.jpg',
+          tusEndpoint: 'https://example.com/dav/test/folderInside'
+        }
+      } as unknown as OcUppyFile
+
+      const conflict = { name: folderName, type: 'folder' }
+
+      const instance = getResourceConflictInstance({ currentFiles })
+      instance.resolveFileExists = vi.fn(() =>
+        Promise.resolve({ strategy: ResolveStrategy.KEEP_BOTH, doForAllConflicts: false })
+      )
+
+      const result = await instance.displayOverwriteDialog([imageFile, nestedImageFile], [conflict])
+
+      expect(result.length).toBe(2)
+
+      const newFolderName = `test (1)`
+      const encodedNewFolderName = encodeURIComponent(newFolderName)
+
+      const resultImage = result.find((f) => f.name === 'image.jpg')
+      expect(resultImage.meta.relativeFolder).toBe(`/${newFolderName}`)
+      expect(resultImage.meta.tusEndpoint).toBe(`https://example.com/dav/${encodedNewFolderName}`)
+
+      const resultNested = result.find((f) => f.name === 'image2.jpg')
+      expect(resultNested.meta.relativeFolder).toBe(`/${newFolderName}/folderInside`)
+      expect(resultNested.meta.tusEndpoint).toBe(
+        `https://example.com/dav/${encodedNewFolderName}/folderInside`
+      )
+    })
     it('should show dialog twice if do for all conflicts is ticked and folders and files are uploaded', async () => {
       const OcUppyFileOne = mockDeep<OcUppyFile>({ name: 'test' })
       const OcUppyFileTwo = mockDeep<OcUppyFile>({ name: 'folder' })


### PR DESCRIPTION
The 'Keep both' option when handling a file name conflict previously lost files that were nested deeper than the root level because the upload path was not adjusted properly to the new name.

Fixes this issue by respecting the new name in the upload path.

fixes https://github.com/opencloud-eu/web/issues/2420