### PR TITLE
fix: align space action permissions with backend abilities

### DIFF
--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -214,21 +214,21 @@ export function buildSpace(
       if (!this.disabled) {
         return false
       }
-      if (ability?.can('delete-all', 'Drive')) {
+      if (ability?.can('delete-all', 'Drive') || ability?.can('create-all', 'Drive')) {
         return true
       }
       // FIXME: server permissions are a mess currently: https://github.com/opencloud-eu/opencloud/issues/10
       return this.graphPermissions?.includes(GraphSharePermission.deletePermissions)
     },
     canRename: function ({ ability }: { user?: User; ability?: Ability } = {}) {
-      if (ability?.can('update-all', 'Drive')) {
+      if (ability?.can('update-all', 'Drive') || ability?.can('create-all', 'Drive')) {
         return true
       }
       // FIXME: server permissions are a mess currently: https://github.com/opencloud-eu/opencloud/issues/10
       return this.graphPermissions?.includes(GraphSharePermission.deletePermissions)
     },
     canEditDescription: function ({ ability }: { user?: User; ability?: Ability } = {}) {
-      if (ability?.can('update-all', 'Drive')) {
+      if (ability?.can('update-all', 'Drive') || ability?.can('create-all', 'Drive')) {
         return true
       }
       // FIXME: server permissions are a mess currently: https://github.com/opencloud-eu/opencloud/issues/10
@@ -238,7 +238,7 @@ export function buildSpace(
       if (!this.disabled) {
         return false
       }
-      if (ability?.can('update-all', 'Drive')) {
+      if (ability?.can('update-all', 'Drive') || ability?.can('create-all', 'Drive')) {
         return true
       }
       // FIXME: server permissions are a mess currently: https://github.com/opencloud-eu/opencloud/issues/10

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -221,14 +221,14 @@ export function buildSpace(
       return this.graphPermissions?.includes(GraphSharePermission.deletePermissions)
     },
     canRename: function ({ ability }: { user?: User; ability?: Ability } = {}) {
-      if (ability?.can('update-all', 'Drive') || ability?.can('create-all', 'Drive')) {
+      if (ability?.can('update-all', 'Drive')) {
         return true
       }
       // FIXME: server permissions are a mess currently: https://github.com/opencloud-eu/opencloud/issues/10
       return this.graphPermissions?.includes(GraphSharePermission.deletePermissions)
     },
     canEditDescription: function ({ ability }: { user?: User; ability?: Ability } = {}) {
-      if (ability?.can('update-all', 'Drive') || ability?.can('create-all', 'Drive')) {
+      if (ability?.can('update-all', 'Drive')) {
         return true
       }
       // FIXME: server permissions are a mess currently: https://github.com/opencloud-eu/opencloud/issues/10

--- a/packages/web-client/tests/unit/helpers/space/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/space/functions.spec.ts
@@ -34,33 +34,39 @@ describe('buildSpace', () => {
   describe('canBeDeleted', () => {
     it.each([
       {
-        userCan: false,
+        abilities: [],
         permissions: [GraphSharePermission.deletePermissions],
         disabled: true,
         expectedResult: true
       },
       {
-        userCan: false,
+        abilities: [],
         permissions: [],
         disabled: true,
         expectedResult: false
       },
       {
-        userCan: true,
+        abilities: ['delete-all'],
         permissions: [],
         disabled: true,
         expectedResult: true
       },
       {
-        userCan: true,
+        abilities: ['create-all'],
+        permissions: [],
+        disabled: true,
+        expectedResult: true
+      },
+      {
+        abilities: ['delete-all'],
         permissions: [],
         disabled: false,
         expectedResult: false
       }
     ])(
       'behaves accordingly to the given permissions, abilities and disabled state',
-      ({ permissions, expectedResult, userCan, disabled }) => {
-        const ability = mock<Ability>({ can: () => userCan })
+      ({ permissions, expectedResult, abilities, disabled }) => {
+        const ability = mock<Ability>({ can: (action) => abilities.includes(action) })
         const space = getSpace({ permissions })
         space.disabled = disabled
         expect(space.canBeDeleted({ user: mock<User>({ id, memberOf: [] }), ability })).toBe(
@@ -73,24 +79,29 @@ describe('buildSpace', () => {
   describe('canRename', () => {
     it.each([
       {
-        userCan: false,
+        abilities: [],
         permissions: [GraphSharePermission.deletePermissions],
         expectedResult: true
       },
       {
-        userCan: false,
+        abilities: [],
         permissions: [],
         expectedResult: false
       },
       {
-        userCan: true,
+        abilities: ['update-all'],
+        permissions: [],
+        expectedResult: true
+      },
+      {
+        abilities: ['create-all'],
         permissions: [],
         expectedResult: true
       }
     ])(
       'behaves accordingly to the given role, permissions and abilities',
-      ({ permissions, expectedResult, userCan }) => {
-        const ability = mock<Ability>({ can: () => userCan })
+      ({ permissions, expectedResult, abilities }) => {
+        const ability = mock<Ability>({ can: (action) => abilities.includes(action) })
         const space = getSpace({ permissions })
         expect(space.canRename({ user: mock<User>({ id, memberOf: [] }), ability })).toBe(
           expectedResult
@@ -102,24 +113,29 @@ describe('buildSpace', () => {
   describe('canEditDescription', () => {
     it.each([
       {
-        userCan: false,
+        abilities: [],
         permissions: [GraphSharePermission.deletePermissions],
         expectedResult: true
       },
       {
-        userCan: false,
+        abilities: [],
         permissions: [],
         expectedResult: false
       },
       {
-        userCan: true,
+        abilities: ['update-all'],
+        permissions: [],
+        expectedResult: true
+      },
+      {
+        abilities: ['create-all'],
         permissions: [],
         expectedResult: true
       }
     ])(
       'behaves accordingly to the given role, permissions and abilities',
-      ({ permissions, expectedResult, userCan }) => {
-        const ability = mock<Ability>({ can: () => userCan })
+      ({ permissions, expectedResult, abilities }) => {
+        const ability = mock<Ability>({ can: (action) => abilities.includes(action) })
         const space = getSpace({ permissions })
         expect(space.canEditDescription({ user: mock<User>({ id, memberOf: [] }), ability })).toBe(
           expectedResult
@@ -147,33 +163,39 @@ describe('buildSpace', () => {
   describe('canRestore', () => {
     it.each([
       {
-        userCan: false,
+        abilities: [],
         permissions: [GraphSharePermission.deletePermissions],
         disabled: true,
         expectedResult: true
       },
       {
-        userCan: false,
+        abilities: [],
         permissions: [],
         disabled: true,
         expectedResult: false
       },
       {
-        userCan: true,
+        abilities: ['update-all'],
         permissions: [],
         disabled: true,
         expectedResult: true
       },
       {
-        userCan: true,
+        abilities: ['create-all'],
+        permissions: [],
+        disabled: true,
+        expectedResult: true
+      },
+      {
+        abilities: ['update-all'],
         permissions: [],
         disabled: false,
         expectedResult: false
       }
     ])(
       'behaves accordingly to the given role, permissions, abilities and disabled state',
-      ({ permissions, expectedResult, userCan, disabled }) => {
-        const ability = mock<Ability>({ can: () => userCan })
+      ({ permissions, expectedResult, abilities, disabled }) => {
+        const ability = mock<Ability>({ can: (action) => abilities.includes(action) })
         const space = getSpace({ permissions })
         space.disabled = disabled
         expect(space.canRestore({ user: mock<User>({ id, memberOf: [] }), ability })).toBe(


### PR DESCRIPTION
## Description

Space actions (`canBeDeleted`, `canRename`, `canEditDescription`, `canRestore`)
now honour the abilities reported by the backend when user has "create-all" permission.

According to 
https://github.com/opencloud-eu/reva/blob/main/pkg/storage/utils/decomposedfs/spaces.go#L1115-L1116
The User should be able to disable/restore and delete its managed spaces.

Backend Permission for `create-all` frontend permission.
```
{
        "id": "79e13b30-3e22-11eb-bc51-0b9f0bad9a58",
        "name": "Drives.Create",
        "displayName": "Create Space",
        "description": "This permission allows creating new spaces.",
        "permissionValue": {
          "operation": "OPERATION_READWRITE",
          "constraint": "CONSTRAINT_ALL"
        },
        "resource": {
          "type": "TYPE_SYSTEM"
        }
      },
```

Although it won't fix the underlaying issue that the owner of a space (User role) should be able to disable/delete/restore via the frontend. Currently, only disable is possible. Restoring or deleting a space as manager of that space with the User role is still not possible.

The comment in the functions.ts suggest problem with the permission model
https://github.com/opencloud-eu/web/blob/main/packages/web-client/src/helpers/space/functions.ts#L244

At least this honour `Drives.Create` with `CONSTRAINT_ALL`

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes 
https://github.com/opencloud-eu/opencloud/issues/1799

## How Has This Been Tested?

- test environment: local dev setup (`pnpm vite` against a local OpenCloud backend via `docker-compose up -d`)
- test case 1: unit tests in `packages/web-client/tests/unit/helpers/space/functions.spec.ts` updated/added to assert action-specific permission handling for `canBeDeleted`, `canRename`, `canEditDescription`, and `canRestore` (verified with `pnpm test:unit --run packages/web-client/tests/unit/helpers/space/functions.spec.ts`)
- test case 2: manual check in the UI for a disabled space — restore/delete/rename/edit-description actions only appear when the backend grants the corresponding ability
- test case 3: `pnpm check:all` passes (types, lint, format, unit tests)

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)