### PR TITLE
[e2e-tests] upload folder with different options

### DIFF
--- a/tests/e2e/cucumber/features/search/search.feature
+++ b/tests/e2e/cucumber/features/search/search.feature
@@ -61,9 +61,9 @@ Feature: Search
     # subfolder search
     And "Alice" searches "child" using the global search and the "all files" filter
     Then following resources should be displayed in the search list for user "Alice"
-      | resource            |
-      | FolDer/child-one    |
-      | child-one/child-two |
+      | resource              |
+      | FolDer/child-one      |
+      | …/child-one/child-two |
     But following resources should not be displayed in the search list for user "Alice"
       | resource             |
       | folder               |
@@ -138,13 +138,13 @@ Feature: Search
       | resource                                  |
       | exampleInsideThePersonalSpace.txt         |
       | mainFolder/exampleInsideTheMainFolder.txt |
-      | subFolder/exampleInsideTheSubFolder.txt   |
+      | …/subFolder/exampleInsideTheSubFolder.txt |
 
     When "Alice" searches "example" using the global search and the "current folder" filter
     Then following resources should be displayed in the search list for user "Alice"
-      | resource                                           |
-      | mainFolder/exampleInsideTheMainFolder.txt          |
-      | mainFolder/subFolder/exampleInsideTheSubFolder.txt |
+      | resource                                  |
+      | mainFolder/exampleInsideTheMainFolder.txt |
+      | …/subFolder/exampleInsideTheSubFolder.txt |
     But following resources should not be displayed in the search list for user "Alice"
       | resource                          |
       | exampleInsideThePersonalSpace.txt |

--- a/tests/e2e/cucumber/features/search/search.feature
+++ b/tests/e2e/cucumber/features/search/search.feature
@@ -61,9 +61,9 @@ Feature: Search
     # subfolder search
     And "Alice" searches "child" using the global search and the "all files" filter
     Then following resources should be displayed in the search list for user "Alice"
-      | resource                   |
-      | FolDer/child-one           |
-      | FolDer/child-one/child-two |
+      | resource            |
+      | FolDer/child-one    |
+      | child-one/child-two |
     But following resources should not be displayed in the search list for user "Alice"
       | resource             |
       | folder               |
@@ -135,10 +135,10 @@ Feature: Search
     When "Alice" opens folder "mainFolder"
     And "Alice" searches "example" using the global search and the "all files" filter
     Then following resources should be displayed in the search list for user "Alice"
-      | resource                                           |
-      | exampleInsideThePersonalSpace.txt                  |
-      | mainFolder/exampleInsideTheMainFolder.txt          |
-      | mainFolder/subFolder/exampleInsideTheSubFolder.txt |
+      | resource                                  |
+      | exampleInsideThePersonalSpace.txt         |
+      | mainFolder/exampleInsideTheMainFolder.txt |
+      | subFolder/exampleInsideTheSubFolder.txt   |
 
     When "Alice" searches "example" using the global search and the "current folder" filter
     Then following resources should be displayed in the search list for user "Alice"

--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -88,6 +88,7 @@ Feature: Upload
     Then following resources should not be displayed in the files list for user "Alice"
       | resource      |
       | lorem-big.txt |
+    And "Alice" logs out
 
 
   Scenario: upload resource from clipboard
@@ -98,5 +99,61 @@ Feature: Upload
     And "Alice" opens the following file in mediaviewer
       | resource  |
       | image.png |
+    And "Alice" closes the file viewer
+    And "Alice" logs out
+
+
+  Scenario: upload folder using different options
+     Given "Alice" creates the following folder in personal space using API
+      | name   |
+      | CHILD  |
+    Given "Alice" creates the following folder in personal space using API
+      | name   |
+      | PARENT |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile      | content      |
+      | PARENT/test.txt | some content |
+    
+    # keep both option
+    And "Alice" uploads the following resources
+      | resource  | type   | option    |
+      | PARENT    | folder | keep both |
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource   |
+      | PARENT     |
+      | PARENT (1) |
+    And "Alice" opens folder "PARENT"
+    And following resources should be displayed in the files list for user "Alice"
+      | resource  |
+      | test.txt  |
+    And "Alice" opens the "files" app
+    And "Alice" opens folder "PARENT (1)"
+    And following resources should be displayed in the files list for user "Alice"
+      | resource   |
+      | parent.txt |
+    And "Alice" opens folder "CHILD"
+    And following resources should be displayed in the files list for user "Alice"
+      | resource  |
+      | child.txt |
+    
+    # replace option
+    Given "Alice" creates the following files into personal space using API
+      | pathToFile        | content      |
+      | PARENT/parent.txt | some content |
+    When "Alice" opens the "files" app
+    And "Alice" uploads the following resources
+      | resource  | type   | option |
+      | PARENT    | folder | merge  |
+    And "Alice" opens folder "PARENT"
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource   |
+      | parent.txt |
+      | test.txt   |
+      | CHILD      |
+    # check that parent.txt content is replaced
+    And "Alice" opens the following file in texteditor
+      | resource   |
+      | parent.txt |
+    And "Alice" should see the content "OpenCloud test text file parent" in editor "TextEditor"
     And "Alice" closes the file viewer
     And "Alice" logs out

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -383,9 +383,9 @@ Then(
           timeout: config.timeout * 1000
         })
         await waitProcessingToFinish(page, info.resource)
-        return
+      } else {
+        await expect(resourceObject.getResourceLocator(info.resource)).not.toBeVisible()
       }
-      await expect(resourceObject.getResourceLocator(info.resource)).not.toBeVisible()
     }
   }
 )
@@ -403,9 +403,9 @@ Then(
     for (const info of stepTable.hashes()) {
       if (actionType === 'should') {
         await expect(resourceObject.getResourceSearchItemLocator(info.resource)).toBeVisible()
-        return
+      } else {
+        await expect(resourceObject.getResourceSearchItemLocator(info.resource)).not.toBeVisible()
       }
-      await expect(resourceObject.getResourceSearchItemLocator(info.resource)).not.toBeVisible()
     }
   }
 )

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -539,6 +539,11 @@ export const openAndGetContentOfDocument = async ({
   page: Page
   editorToOpen: string
 }): Promise<string> => {
+  if (editorToOpen === 'TextEditor') {
+    const editor = page.locator('.tiptap.ProseMirror')
+    await expect(editor).toBeVisible()
+    return await editor.innerText()
+  }
   await page.waitForLoadState()
   await page.waitForURL(/.*\/external-.*/)
   const editorMainFrame = page.frameLocator(externalEditorIframe)


### PR DESCRIPTION
Added e2e test coverage for folder upload conflict handling:

- **Keep both** — uploaded folder is renamed with an index suffix (e.g. `PARENT (1)`), original is preserved with its contents intact
- **Merge** — uploaded folder is merged into the existing one; existing files are replaced, unique files are kept



- found bug https://github.com/opencloud-eu/web/issues/2484