### PR TITLE
fix: prevent modal title actions from wrapping

### DIFF
--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -15,7 +15,7 @@
         @keydown.esc.stop="cancelModalAction"
       >
         <div
-          class="oc-modal-title flex items-center flex-row flex-wrap justify-between py-3 px-4 rounded-t-xl"
+          class="oc-modal-title flex items-center flex-row justify-between py-3 px-4 rounded-t-xl"
         >
           <h2 id="oc-modal-title" class="truncate m-0 text-base" v-text="title" />
           <div class="flex items-center gap-1">

--- a/packages/design-system/src/components/OcModal/__snapshots__/OcModal.spec.ts.snap
+++ b/packages/design-system/src/components/OcModal/__snapshots__/OcModal.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`OcModal > displays input 1`] = `
 "<div class="oc-modal-background fixed left-0 top-0 z-[var(--z-index-modal)] bg-black/40 flex items-center justify-center flex-row flex-wrap size-full">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
     <div class="oc-modal bg-role-surface z-[calc(var(--z-index-modal)+1)] rounded-xl focus:outline-0 w-full max-w-xl max-h-[90vh] overflow-auto shadow-2xl" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
-      <div class="oc-modal-title flex items-center flex-row flex-wrap justify-between py-3 px-4 rounded-t-xl">
+      <div class="oc-modal-title flex items-center flex-row justify-between py-3 px-4 rounded-t-xl">
         <h2 id="oc-modal-title" class="truncate m-0 text-base">Create new folder</h2>
         <div class="flex items-center gap-1">
           <oc-button-stub arialabel="Cancel" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" class="oc-modal-title-actions-cancel">
@@ -31,7 +31,7 @@ exports[`OcModal > displays loading state 1`] = `
 "<div class="oc-modal-background fixed left-0 top-0 z-[var(--z-index-modal)] bg-black/40 flex items-center justify-center flex-row flex-wrap size-full">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
     <div class="oc-modal bg-role-surface z-[calc(var(--z-index-modal)+1)] rounded-xl focus:outline-0 w-full max-w-xl max-h-[90vh] overflow-auto shadow-2xl" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
-      <div class="oc-modal-title flex items-center flex-row flex-wrap justify-between py-3 px-4 rounded-t-xl">
+      <div class="oc-modal-title flex items-center flex-row justify-between py-3 px-4 rounded-t-xl">
         <h2 id="oc-modal-title" class="truncate m-0 text-base">Example title</h2>
         <div class="flex items-center gap-1"> <button type="button" disabled="" aria-label="Cancel" class="oc-button-secondary oc-button-raw oc-button-secondary-raw gap-2 justify-center text-base min-h-4 oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default oc-modal-title-actions-cancel">
             <!--v-if-->
@@ -63,7 +63,7 @@ exports[`OcModal > matches snapshot 1`] = `
 "<div class="oc-modal-background fixed left-0 top-0 z-[var(--z-index-modal)] bg-black/40 flex items-center justify-center flex-row flex-wrap size-full">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
     <div class="oc-modal bg-role-surface z-[calc(var(--z-index-modal)+1)] rounded-xl focus:outline-0 w-full max-w-xl max-h-[90vh] overflow-auto shadow-2xl" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
-      <div class="oc-modal-title flex items-center flex-row flex-wrap justify-between py-3 px-4 rounded-t-xl">
+      <div class="oc-modal-title flex items-center flex-row justify-between py-3 px-4 rounded-t-xl">
         <h2 id="oc-modal-title" class="truncate m-0 text-base">Example title</h2>
         <div class="flex items-center gap-1">
           <oc-button-stub arialabel="Cancel" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" class="oc-modal-title-actions-cancel">
@@ -90,7 +90,7 @@ exports[`OcModal > overrides props message with slot 1`] = `
 "<div class="oc-modal-background fixed left-0 top-0 z-[var(--z-index-modal)] bg-black/40 flex items-center justify-center flex-row flex-wrap size-full">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
     <div class="oc-modal bg-role-surface z-[calc(var(--z-index-modal)+1)] rounded-xl focus:outline-0 w-full max-w-xl max-h-[90vh] overflow-auto shadow-2xl" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
-      <div class="oc-modal-title flex items-center flex-row flex-wrap justify-between py-3 px-4 rounded-t-xl">
+      <div class="oc-modal-title flex items-center flex-row justify-between py-3 px-4 rounded-t-xl">
         <h2 id="oc-modal-title" class="truncate m-0 text-base">Example title</h2>
         <div class="flex items-center gap-1">
           <oc-button-stub arialabel="Cancel" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" class="oc-modal-title-actions-cancel">


### PR DESCRIPTION
This fixes "Modal header breaks into 2 lines"
 https://github.com/opencloud-eu/web/issues/2210
