### PR TITLE
fix(editor): missing content

### DIFF
--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -104,7 +104,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, nextTick, onMounted, ref, unref, useTemplateRef, watch } from 'vue'
+import { computed, inject, nextTick, onMounted, ref, unref, useTemplateRef } from 'vue'
 import type { TextEditorInstance } from '../types'
 import { EditorAction } from '../composables'
 
@@ -140,32 +140,7 @@ const visible = computed(() => {
   return !!unref(textEditor.editor)
 })
 
-// Track editor state changes to trigger reactivity
-const editorStateKey = ref(0)
-
-watch(
-  () => unref(textEditor.editor),
-  (editor, oldEditor) => {
-    if (oldEditor) {
-      oldEditor.off('selectionUpdate', updateEditorState)
-      oldEditor.off('transaction', updateEditorState)
-    }
-    if (editor) {
-      editor.on('selectionUpdate', updateEditorState)
-      editor.on('transaction', updateEditorState)
-    }
-  },
-  { immediate: true }
-)
-
-const updateEditorState = () => {
-  editorStateKey.value++
-}
-
 const isItemEnabled = (item: EditorAction) => {
-  // Access editorStateKey to make this reactive to editor state changes
-  editorStateKey.value
-
   const editor = unref(textEditor.editor)
   if (!editor) {
     return false
@@ -178,9 +153,6 @@ const isItemEnabled = (item: EditorAction) => {
 }
 
 const isItemActive = (item: EditorAction) => {
-  // Access editorStateKey to make this reactive to editor state changes
-  editorStateKey.value
-
   const editor = unref(textEditor.editor)
   if (!editor) {
     return false
@@ -193,9 +165,6 @@ const isItemActive = (item: EditorAction) => {
 }
 
 const getActiveIcon = (item: EditorAction) => {
-  // Access editorStateKey to make this reactive to editor state changes
-  editorStateKey.value
-
   const editor = unref(textEditor.editor)
   if (editor && item.activeIcon) {
     const active = item.activeIcon(editor)

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -1,4 +1,4 @@
-import { ref, computed, onBeforeUnmount, watch, unref, onMounted } from 'vue'
+import { ref, computed, onBeforeUnmount, watch, unref, onMounted, triggerRef } from 'vue'
 import { useEditor } from '@tiptap/vue-3'
 import type { ShallowRef } from 'vue'
 import type { Editor } from '@tiptap/vue-3'
@@ -37,7 +37,7 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
   }
 
   watch(options.modelValue, (content) => {
-    if (!unref(editor) || unref(editor).options.editable) {
+    if (!unref(editor) || unref(editor)?.isFocused) {
       return
     }
     setContent(content)
@@ -108,13 +108,19 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
     editor.value = null
   }
 
+  const triggerEditorUpdate = () => triggerRef(editor)
+
   onMounted(() => {
+    editor.value?.on('selectionUpdate', triggerEditorUpdate)
+    editor.value?.on('transaction', triggerEditorUpdate)
     if (!unref(readonly)) {
       focus()
     }
   })
 
   onBeforeUnmount(() => {
+    editor.value?.off('selectionUpdate', triggerEditorUpdate)
+    editor.value?.off('transaction', triggerEditorUpdate)
     destroy()
   })
 


### PR DESCRIPTION
Fixes an issue where the tiptap editor would not show content if it's not available on mount. Also, simplifies the toolbar active highlight handling a bit be removing the watcher.

fixes an issue that https://github.com/opencloud-eu/web-extensions/pull/440 surfaced