### PR TITLE
fix: service announcement order

### DIFF
--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -93,6 +93,14 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
   registerSharedModules(federation)
   announceLoadingService({ app })
   announceArchiverService({ app, configStore, userStore, capabilityStore })
+  announcePreviewService({
+    app,
+    configStore,
+    userStore,
+    authStore
+  })
+  announcePasswordPolicyService({ app })
+  announceUppyService({ app })
 
   const [coreTranslations, customTranslations] = await Promise.all([
     loadTranslations(),
@@ -123,14 +131,6 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
     })
   }
 
-  announcePreviewService({
-    app,
-    configStore,
-    userStore,
-    authStore
-  })
-  announcePasswordPolicyService({ app })
-  announceUppyService({ app })
   announceTranslations({ appsStore, gettext, coreTranslations, customTranslations })
   startSentry(configStore, app)
   announceCustomStyles({ configStore })


### PR DESCRIPTION
Announce services before initializing apps. Otherwise, these services might not be available for the apps.

Fixes an issue that https://github.com/opencloud-eu/web-extensions/pull/440 surfaced