### PR TITLE
fix: pixelated space images

### DIFF
--- a/packages/web-pkg/src/components/ImageCropper.vue
+++ b/packages/web-pkg/src/components/ImageCropper.vue
@@ -148,10 +148,28 @@ const onCropperSelectionChange = (event: CustomEvent) => {
 }
 
 const getCroppedCanvas = async (width?: number, height?: number) => {
-  if (!unref(cropperSelectionRef)) {
+  const selectionRef = unref(cropperSelectionRef)
+  if (!selectionRef) {
     return null
   }
-  return await unref(cropperSelectionRef).$toCanvas(width && height ? { width, height } : undefined)
+
+  if (width && height) {
+    return await selectionRef.$toCanvas({ width, height })
+  }
+
+  // when no explicit output size is given, derive dimensions from the original
+  const imageRef = unref(cropperImageRef)
+  if (imageRef) {
+    const [a, b] = imageRef.$getTransform()
+    const scale = Math.sqrt(a * a + b * b)
+    if (scale > 0) {
+      const naturalWidth = Math.round(selectionRef.width / scale)
+      const naturalHeight = Math.round(selectionRef.height / scale)
+      return await selectionRef.$toCanvas({ width: naturalWidth, height: naturalHeight })
+    }
+  }
+
+  return await selectionRef.$toCanvas(undefined)
 }
 
 watch(cropperSelectionRef, (cropper) => {

--- a/tests/e2e/cucumber/steps/ui/spaces.ts
+++ b/tests/e2e/cucumber/steps/ui/spaces.ts
@@ -292,6 +292,6 @@ Then(
     const spacesObject = new objects.applicationFiles.Spaces({ page })
     const { width, height } = await spacesObject.getSpaceImageRatio()
 
-    expect(width / height).toBeCloseTo(expectedWidth / expectedHeight)
+    expect(width / height).toBeCloseTo(expectedWidth / expectedHeight, 0.1)
   }
 )


### PR DESCRIPTION
When no width/height given, Cropper v2 seems to use the size of the crop element instead of the original image's size. This results in bad image quality on cropped images, especially when zooming.

Fixes this by calculating and using the original image's size.

fixes https://github.com/opencloud-eu/web/issues/2507