### PR TITLE
fix: skip upload conflict check when uploads target a non-current folder

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -105,6 +105,16 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
     return this.resourcesStore.currentFolder
   }
 
+  isCurrentFolder(uploadFolder?: Resource): boolean {
+    const currentFolder = this.resourcesStore.currentFolder
+    if (!uploadFolder || !currentFolder) {
+      return false
+    }
+    return (
+      uploadFolder.storageId === currentFolder.storageId && uploadFolder.path === currentFolder.path
+    )
+  }
+
   /**
    * Converts the input files type UppyResources and updates the uppy upload queue
    */
@@ -435,8 +445,11 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
       }
     }
 
-    // name conflict handling
-    if (this.conflictHandlingEnabled) {
+    // name conflict handling. skipped when uploads target a folder other than the
+    // user's current one (caller used setUploadFolder, e.g. unzip extracting into a
+    // fresh folder). getConflicts only checks the current folder and would fire
+    // false positives in that case.
+    if (this.conflictHandlingEnabled && this.isCurrentFolder(uploadFolder)) {
       const conflictHandler = new UploadResourceConflict(this.resourcesStore, this.language)
       const conflicts = conflictHandler.getConflicts(filesToUpload)
       if (conflicts.length) {

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -266,6 +266,24 @@ describe('HandleUpload', () => {
         await instance.handleUpload([mock<OcUppyFile>({ name: 'name' })])
         expect(getConflictsMock).not.toHaveBeenCalled()
       })
+      it('does not check for conflicts if uploads target a non-current folder', async () => {
+        // setUploadFolder was used to redirect uploads to a folder other than the
+        // user's current one. getConflicts can only check the current folder, so
+        // running it here would only produce false positives.
+        const { instance } = getWrapper({
+          uploadFolderForId: {
+            'upload-1': mock<Resource>({ path: '/elsewhere', storageId: 'space-1' })
+          }
+        })
+        // relativePath empty so prepareFiles' dirname() call short-circuits via
+        // the `!relativeFilePath` branch instead of crashing on a Mock value.
+        const file = mock<OcUppyFile>({
+          name: 'name',
+          meta: { uploadId: 'upload-1', relativePath: '' }
+        })
+        await instance.handleUpload([file])
+        expect(getConflictsMock).not.toHaveBeenCalled()
+      })
       it('does not start upload if all files were skipped in conflict handling', async () => {
         const { instance, mocks } = getWrapper({ conflicts: [{}], conflictHandlerResult: [] })
         const removeFilesFromUploadSpy = vi.spyOn(instance, 'removeFilesFromUpload')
@@ -308,7 +326,8 @@ const getWrapper = ({
   quotaCheckEnabled = true,
   conflicts = [],
   conflictHandlerResult = [],
-  spaces = []
+  spaces = [],
+  uploadFolderForId = {} as Record<string, Resource>
 } = {}) => {
   getConflictsMock = vi.fn(() => conflicts)
   displayOverwriteDialogMock = vi.fn().mockResolvedValue(conflictHandlerResult)
@@ -327,6 +346,8 @@ const getWrapper = ({
     }
   })
 
+  const uppyService = mock<UppyService>({ uploadFolderMap: uploadFolderForId })
+
   const opts = {
     clientService: mockDeep<ClientService>(),
     language: mock<Language>({ current: 'en' }),
@@ -336,7 +357,7 @@ const getWrapper = ({
     spacesStore: useSpacesStore(),
     resourcesStore: useResourcesStore(),
     space: ref(mock<SpaceResource>()),
-    uppyService: mock<UppyService>(),
+    uppyService,
     conflictHandlingEnabled,
     directoryTreeCreateEnabled,
     quotaCheckEnabled


### PR DESCRIPTION
## Description

`UploadResourceConflict.getConflicts` compares uploads against `resourcesStore.resources`, the resources of the user's **current folder**. When a caller redirects an upload via `setUploadFolder` (e.g. the unzip extension extracting into a freshly created folder), the actual destination is *not* the current folder, so that check produces false positives whenever the upload's first path segment happens to match a resource in the current folder.

Concrete example: extracting `data.zip` (which contains a top-level `data/` directory) in the user's personal root. The unzip extension creates `<personal>/data/` as the extraction target via `setUploadFolder`. Every extracted file has `relativePath = "/data/..."`, so `getConflicts` takes the first segment (`data`), finds the freshly created `data` folder in the current folder's resources, and pops up a *"Folder already exists"* dialog, even though the real upload target is `<personal>/data/data/...` and nothing actually collides.

This PR adds an `isCurrentFolder(uploadFolder)` helper that compares `storageId + path` of the upload target against `resourcesStore.currentFolder`, and only runs the conflict check when they match.

### Known limitation, follow-up needed

This change **suppresses the false positive** but does **not** actually perform conflict detection for non-current target folders. The current `getConflicts` is synchronous and depends on `resourcesStore.resources`, which only ever holds the current folder's contents.

A real conflict check for a non-current upload target would need to:
- async-list the target folder over webdav, and
- reshape `getConflicts` / call site to handle the async result.

That's out of scope for this PR. For now, **callers that use `setUploadFolder` own their own conflict resolution**. The unzip extension already does this (it deduplicates the archive-name folder via `resolveFileNameDuplicate` before creating it). Other future callers should be aware.

## Related Issue

Surfaced while fixing https://github.com/opencloud-eu/web-extensions/issues/293. Extracting a zip that wraps its content in a top-level folder matching the archive name triggered the false-positive dialog.

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)