### PR TITLE
fix: upload overlay when merging folders

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -296,7 +296,8 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
    */
   async createDirectoryTree(
     filesToUpload: OcUppyFile[],
-    uploadFolder: Resource
+    uploadFolder: Resource,
+    mergedFolders: string[] = []
   ): Promise<{ filesToUpload: OcUppyFile[]; folderFiles: OcUppyFile[] }> {
     const { webdav } = this.clientService
     const space = unref(this.space)
@@ -378,6 +379,9 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
             console.error(error)
             failedFolders.push(path)
             this.uppyService.publish('uploadError', { file: uppyFile, error })
+          } else if (isRoot && mergedFolders.includes(basename(path))) {
+            // top-level folder already exists because the user chose to merge - count it as uploaded
+            this.uppyService.publish('uploadSuccess', { ...uppyFile })
           }
         }
       }
@@ -449,6 +453,7 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
     // user's current one (caller used setUploadFolder, e.g. unzip extracting into a
     // fresh folder). getConflicts only checks the current folder and would fire
     // false positives in that case.
+    let mergedFolders: string[] = []
     if (this.conflictHandlingEnabled && this.isCurrentFolder(uploadFolder)) {
       const conflictHandler = new UploadResourceConflict(this.resourcesStore, this.language)
       const conflicts = conflictHandler.getConflicts(filesToUpload)
@@ -459,13 +464,14 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
         }
 
         const result = await conflictHandler.displayOverwriteDialog(filesToUpload, conflicts)
-        if (result.length === 0) {
+        if (result.files.length === 0) {
           this.removeFilesFromUpload(filesToUpload)
           return this.uppyService.clearInputs()
         }
 
-        filesToUpload = result
-        const conflictMap = result.reduce<Record<string, OcUppyFile>>((acc, file) => {
+        filesToUpload = result.files
+        mergedFolders = result.mergedFolders
+        const conflictMap = result.files.reduce<Record<string, OcUppyFile>>((acc, file) => {
           acc[file.id] = file
           return acc
         }, {})
@@ -476,7 +482,7 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
     this.uppyService.publish('uploadStarted')
     let folderFiles: OcUppyFile[] = []
     if (this.directoryTreeCreateEnabled) {
-      const result = await this.createDirectoryTree(filesToUpload, uploadFolder)
+      const result = await this.createDirectoryTree(filesToUpload, uploadFolder, mergedFolders)
       filesToUpload = result.filesToUpload
       folderFiles = result.folderFiles
     }

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -88,7 +88,7 @@ export class UploadResourceConflict extends ConflictDialog {
   async displayOverwriteDialog(
     files: OcUppyFile[],
     conflicts: ConflictedResource[]
-  ): Promise<OcUppyFile[]> {
+  ): Promise<{ files: OcUppyFile[]; mergedFolders: string[] }> {
     let fileCount = 0
     let folderCount = 0
     const resolvedFileConflicts: { name: string; strategy: ResolveStrategy }[] = []
@@ -143,6 +143,10 @@ export class UploadResourceConflict extends ConflictDialog {
         strategy: resolvedConflict.strategy
       })
     }
+    const mergedFolders = resolvedFolderConflicts
+      .filter((e) => e.strategy === ResolveStrategy.MERGE)
+      .map((e) => e.name)
+
     const filesToSkip = resolvedFileConflicts
       .filter((e) => e.strategy === ResolveStrategy.SKIP)
       .map((e) => e.name)
@@ -209,6 +213,6 @@ export class UploadResourceConflict extends ConflictDialog {
         }
       }
     }
-    return files
+    return { files, mergedFolders }
   }
 }

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -143,6 +143,50 @@ describe('HandleUpload', () => {
       expect(mocks.uppy.removeFile).toHaveBeenCalled()
       expect(filesToUpload.length).toBe(0)
     })
+    it('emits uploadSuccess for a folder that already exists (merge scenario)', async () => {
+      const { instance, mocks } = getWrapper()
+      mocks.uppy.getPlugin.mockReturnValue(mock<UppyPlugin>())
+      const folderName = 'relativeFolder'
+      const relativeFolder = `/${folderName}`
+      const fileToUpload = mock<OcUppyFile>({ name: 'name', meta: { relativeFolder } })
+      mocks.opts.clientService.webdav.createFolder.mockRejectedValue({ statusCode: 405 })
+
+      const uploadFolder = mock<Resource>({ id: '1', path: '/' })
+      const { filesToUpload } = await instance.createDirectoryTree([fileToUpload], uploadFolder, [
+        folderName
+      ])
+
+      expect(mocks.opts.uppyService.publish).toHaveBeenCalledWith(
+        'uploadSuccess',
+        expect.objectContaining({
+          name: folderName,
+          type: 'folder',
+          meta: expect.objectContaining({ isFolder: true })
+        })
+      )
+      expect(mocks.opts.uppyService.publish).not.toHaveBeenCalledWith(
+        'uploadError',
+        expect.anything()
+      )
+      expect(filesToUpload.length).toBe(1)
+    })
+    it('does not emit uploadSuccess for a folder that exists but was not merged by the user', async () => {
+      const { instance, mocks } = getWrapper()
+      mocks.uppy.getPlugin.mockReturnValue(mock<UppyPlugin>())
+      const relativeFolder = '/relativeFolder'
+      const fileToUpload = mock<OcUppyFile>({ name: 'name', meta: { relativeFolder } })
+      mocks.opts.clientService.webdav.createFolder.mockRejectedValue({ statusCode: 405 })
+
+      const uploadFolder = mock<Resource>({ id: '1', path: '/' })
+      // mergedFolders is empty - user did not choose merge
+      const { filesToUpload } = await instance.createDirectoryTree([fileToUpload], uploadFolder, [])
+
+      expect(mocks.opts.uppyService.publish).not.toHaveBeenCalledWith(
+        'uploadSuccess',
+        expect.anything()
+      )
+      expect(filesToUpload.length).toBe(1)
+    })
     it('returns folder files and removes them from the uppy upload files', async () => {
       const { instance, mocks } = getWrapper()
       mocks.uppy.getPlugin.mockReturnValue(mock<UppyPlugin>())
@@ -326,11 +370,14 @@ const getWrapper = ({
   quotaCheckEnabled = true,
   conflicts = [],
   conflictHandlerResult = [],
+  mergedFolders = [] as string[],
   spaces = [],
   uploadFolderForId = {} as Record<string, Resource>
 } = {}) => {
   getConflictsMock = vi.fn(() => conflicts)
-  displayOverwriteDialogMock = vi.fn().mockResolvedValue(conflictHandlerResult)
+  displayOverwriteDialogMock = vi
+    .fn()
+    .mockResolvedValue({ files: conflictHandlerResult, mergedFolders })
 
   const route = mock<RouteLocationNormalizedLoaded>()
   route.params.driveAliasAndItem = '1'

--- a/packages/web-app-files/tests/unit/helpers/resource/actions/upload.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/actions/upload.spec.ts
@@ -61,8 +61,8 @@ describe('upload helper', () => {
         instance.resolveFileExists = resolveFileConflictMethod
 
         const result = await instance.displayOverwriteDialog([OcUppyFile], [conflict])
-        expect(result.length).toBe(1)
-        expect(result).toEqual([OcUppyFile])
+        expect(result.files.length).toBe(1)
+        expect(result.files).toEqual([OcUppyFile])
       }
     )
     it('should return no files if user chooses skip for all', async () => {
@@ -77,7 +77,7 @@ describe('upload helper', () => {
       instance.resolveFileExists = resolveFileConflictMethod
 
       const result = await instance.displayOverwriteDialog([OcUppyFile], [conflict])
-      expect(result.length).toBe(0)
+      expect(result.files.length).toBe(0)
     })
     it('should show dialog once if do for all conflicts is ticked', async () => {
       const OcUppyFileOne = mockDeep<OcUppyFile>({ name: 'test' })
@@ -133,20 +133,37 @@ describe('upload helper', () => {
 
       const result = await instance.displayOverwriteDialog([imageFile, nestedImageFile], [conflict])
 
-      expect(result.length).toBe(2)
+      expect(result.files.length).toBe(2)
 
       const newFolderName = `test (1)`
       const encodedNewFolderName = encodeURIComponent(newFolderName)
 
-      const resultImage = result.find((f) => f.name === 'image.jpg')
+      const resultImage = result.files.find((f) => f.name === 'image.jpg')
       expect(resultImage.meta.relativeFolder).toBe(`/${newFolderName}`)
       expect(resultImage.meta.tusEndpoint).toBe(`https://example.com/dav/${encodedNewFolderName}`)
 
-      const resultNested = result.find((f) => f.name === 'image2.jpg')
+      const resultNested = result.files.find((f) => f.name === 'image2.jpg')
       expect(resultNested.meta.relativeFolder).toBe(`/${newFolderName}/folderInside`)
       expect(resultNested.meta.tusEndpoint).toBe(
         `https://example.com/dav/${encodedNewFolderName}/folderInside`
       )
+    })
+    it('should return merged folder names when user chooses merge', async () => {
+      const folderName = 'someFolder'
+      const fileInFolder = mockDeep<OcUppyFile>({
+        name: 'file.txt',
+        meta: { relativeFolder: `/${folderName}` }
+      })
+      const conflict = { name: folderName, type: 'folder' }
+
+      const instance = getResourceConflictInstance()
+      instance.resolveFileExists = vi.fn(() =>
+        Promise.resolve({ strategy: ResolveStrategy.MERGE, doForAllConflicts: false })
+      )
+
+      const result = await instance.displayOverwriteDialog([fileInFolder], [conflict])
+      expect(result.mergedFolders).toEqual([folderName])
+      expect(result.files.length).toBe(1)
     })
     it('should show dialog twice if do for all conflicts is ticked and folders and files are uploaded', async () => {
       const OcUppyFileOne = mockDeep<OcUppyFile>({ name: 'test' })


### PR DESCRIPTION
Properly display the amount of merged folders when using the "Merge" option in the conflict dialog.

fixes https://github.com/opencloud-eu/web/issues/2484