### PR TITLE
fix: prevents unsightly line breaks

### DIFF
--- a/packages/web-app-mail/src/components/MailList.vue
+++ b/packages/web-app-mail/src/components/MailList.vue
@@ -14,7 +14,7 @@
 
       <no-content-message
         v-if="!mails || !mails.length"
-        class="mail-list-empty"
+        class="mail-list-empty min-w-[306px]"
         img-src="/images/empty-states/empty-mails.svg"
       >
         <template #message>
@@ -22,7 +22,7 @@
         </template>
       </no-content-message>
 
-      <oc-list v-else class="mail-list">
+      <oc-list v-else class="mail-list min-w-[306px]">
         <li
           v-for="mail in mails"
           :id="`mail-list-item-${mail.id}`"

--- a/packages/web-app-mail/src/components/MailListItem.vue
+++ b/packages/web-app-mail/src/components/MailListItem.vue
@@ -17,7 +17,7 @@
       <div class="mail-list-item-header">
         <div class="mail-list-item-sender flex items-center justify-between gap-2">
           <span class="font-bold text-lg truncate flex-1" v-text="fromText"></span>
-          <span class="mail-list-item-received-at" v-text="receivedAtRelativeDate" />
+          <span class="mail-list-item-received-at whitespace-nowrap" v-text="receivedAtRelativeDate" />
         </div>
       </div>
       <div class="mail-list-item-subject mt-1 flex justify-between items-center">

--- a/packages/web-app-mail/src/components/MailListItem.vue
+++ b/packages/web-app-mail/src/components/MailListItem.vue
@@ -17,7 +17,10 @@
       <div class="mail-list-item-header">
         <div class="mail-list-item-sender flex items-center justify-between gap-2">
           <span class="font-bold text-lg truncate flex-1" v-text="fromText"></span>
-          <span class="mail-list-item-received-at whitespace-nowrap" v-text="receivedAtRelativeDate" />
+          <span
+            class="mail-list-item-received-at whitespace-nowrap"
+            v-text="receivedAtRelativeDate"
+          />
         </div>
       </div>
       <div class="mail-list-item-subject mt-1 flex justify-between items-center">

--- a/packages/web-app-mail/src/views/Inbox.vue
+++ b/packages/web-app-mail/src/views/Inbox.vue
@@ -3,7 +3,7 @@
   <template v-else>
     <div class="flex h-full">
       <div
-        class="md:border-r-2 overflow-y-auto min-w-0 w-full md:w-1/4 px-4 md:px-0"
+        class="md:border-r-2 overflow-y-auto min-w-0 md:min-w-[306px] w-full md:w-1/4 px-4 md:px-0"
         :class="{
           'hidden md:block': currentMail || !currentMailbox
         }"
@@ -11,7 +11,7 @@
         <MailList />
       </div>
       <div
-        class="overflow-y-auto min-w-0 w-full md:w-3/4 px-4 pt-4 md:pt-0"
+        class="overflow-y-auto min-w-0 md:min-w-[306px] w-full md:w-3/4 px-4 pt-4 md:pt-0"
         :class="{
           'hidden md:block': !currentMail
         }"


### PR DESCRIPTION
Prevents the list from wrapping when the available space is too narrow and applies a minimum width of 306px to stay consistent with Contacts.