### PR TITLE
fix(client): dedupe search results

### DIFF
--- a/packages/web-client/src/webdav/search.ts
+++ b/packages/web-client/src/webdav/search.ts
@@ -27,11 +27,16 @@ export const SearchFactory = (dav: DAV, options: WebDavOptions) => {
         ...opts
       })
 
+      const mappedResources = results.map((r) => ({
+        ...buildResource(r, dav.extraProps),
+        highlights: r.props[DavProperty.Highlights] || ''
+      }))
+
       return {
-        resources: results.map((r) => ({
-          ...buildResource(r, dav.extraProps),
-          highlights: r.props[DavProperty.Highlights] || ''
-        })),
+        resources: mappedResources.filter(
+          // dedupe results based on id to avoid duplicates in file list
+          (r, index, self) => self.findIndex((t) => t.id === r.id) === index
+        ),
         totalResults: range ? parseInt(range?.split('/')[1]) : null
       }
     }


### PR DESCRIPTION
Dedupe search results by id to avoid having one resource being listed multiple times in the file list. This happened e.g. when one resource got shared directly as well as indirectly via its parent folder with a user and then, as that user, searching for this file.

This was causing weird UI glitches.

fixes https://github.com/opencloud-eu/web/issues/2364