### PR TITLE
fix(design-system): silence OcDrop attr-inheritance warning storm

### DIFF
--- a/packages/design-system/src/components/OcDrop/OcDrop.vue
+++ b/packages/design-system/src/components/OcDrop/OcDrop.vue
@@ -17,6 +17,7 @@
       <Teleport :disabled="!teleport" :to="teleport ? teleport : undefined">
         <div
           v-if="isOpen"
+          v-bind="attrs"
           :id="dropId"
           ref="drop"
           class="oc-drop shadow-sm/10 rounded-xl bg-role-surface border border-role-surface-container-highest"
@@ -155,6 +156,12 @@ const {
 
 const emit = defineEmits<Emits>()
 defineSlots<Slots>()
+
+// Suppress Vue's auto-inheritance — OcDrop's root is a fragment
+// (oc-mobile-drop OR Transition+Teleport). Without this, every parent
+// pass-through (class, role, ...) flushes a console.warn per render.
+// `attrs.class` is forwarded manually to the inner div below.
+defineOptions({ inheritAttrs: false })
 
 const attrs = useAttrs()
 const { registerEventListener, unregisterEventListeners } = useEventListeners()

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`SpaceHeader > should add the "squashed"-class when the sidebar is opene
 			return svg;
 		}" aria-hidden="true" focusable="false" class="size-5"></svg></span>
         </button>
-        <transition-stub name="oc-drop" appear="false" persisted="false" css="true" options="[object Object]">
+        <transition-stub name="oc-drop" appear="false" persisted="false" css="true">
           <!--teleport start-->
           <!--v-if-->
           <!--teleport end-->
@@ -61,7 +61,7 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
 			return svg;
 		}" aria-hidden="true" focusable="false" class="size-5"></svg></span>
         </button>
-        <transition-stub name="oc-drop" appear="false" persisted="false" css="true" options="[object Object]">
+        <transition-stub name="oc-drop" appear="false" persisted="false" css="true">
           <!--teleport start-->
           <!--v-if-->
           <!--teleport end-->
@@ -106,7 +106,7 @@ exports[`SpaceHeader > space image > should show the set image 1`] = `
 			return svg;
 		}" aria-hidden="true" focusable="false" class="size-5"></svg></span>
         </button>
-        <transition-stub name="oc-drop" appear="false" persisted="false" css="true" options="[object Object]">
+        <transition-stub name="oc-drop" appear="false" persisted="false" css="true">
           <!--teleport start-->
           <!--v-if-->
           <!--teleport end-->

--- a/packages/web-pkg/tests/unit/components/ContextActions/__snapshots__/ContextActionMenu.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/ContextActions/__snapshots__/ContextActionMenu.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`ContextActionMenu component > renders the menu with drop menu items 1`]
 			return svg;
 		}" aria-hidden="true" focusable="false" class="size-4"></svg></span>
       </button>
-      <transition-stub name="oc-drop" appear="false" persisted="false" css="true" class="w-3xs oc-files-context-action-drop">
+      <transition-stub name="oc-drop" appear="false" persisted="false" css="true">
         <!--teleport start-->
         <!--teleport end-->
       </transition-stub>
@@ -63,7 +63,7 @@ exports[`ContextActionMenu component > renders the menu with drop menu items 1`]
 			return svg;
 		}" aria-hidden="true" focusable="false" class="size-4"></svg></span>
       </button>
-      <transition-stub name="oc-drop" appear="false" persisted="false" css="true" class="w-3xs oc-files-context-action-drop">
+      <transition-stub name="oc-drop" appear="false" persisted="false" css="true">
         <!--teleport start-->
         <!--teleport end-->
       </transition-stub>
@@ -88,7 +88,7 @@ exports[`ContextActionMenu component > renders the menu with drop menu items 1`]
 			return svg;
 		}" aria-hidden="true" focusable="false" class="size-4"></svg></span>
       </button>
-      <transition-stub name="oc-drop" appear="false" persisted="false" css="true" class="w-3xs oc-files-context-action-drop">
+      <transition-stub name="oc-drop" appear="false" persisted="false" css="true">
         <!--teleport start-->
         <!--teleport end-->
       </transition-stub>


### PR DESCRIPTION
## Summary

- `OcDrop`'s template root is a fragment (mobile drawer OR `Transition + Teleport`), so Vue's default attr auto-inheritance can't pick a single root and falls through to a console warning: `Extraneous non-props attributes (class, options) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes`.
- In a typical session the TopBar mounts at least four `OcDrop` instances (notifications, app switcher, user menu, and most file-action menus). Each one fires the warning every render. In dev the console floods with hundreds of these per page interaction and the tab gets visibly sluggish.
- Switching to `inheritAttrs: false` + explicit `v-bind="attrs"` on the inner drop div silences the warning without changing the rendered HTML for any existing caller — `attrs.class` was already forwarded manually, and Vue merges the `v-bind`-supplied class with the static one.