### PR TITLE
fix: prevent csp error logs in browser console

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,9 @@
       <div class="splash-banner"><h3>Please enable JavaScript</h3></div>
     </noscript>
     <script>
+      // Disable Zod's JIT compilation probe to prevent CSP 'unsafe-eval' console errors.
+      globalThis.__zod_globalConfig = { jitless: true }
+
       function runtimeLoaded() {}
 
       var loader = document.getElementById('splash-loading')

--- a/packages/web-client/src/sse/index.ts
+++ b/packages/web-client/src/sse/index.ts
@@ -79,7 +79,7 @@ export class SSEAdapter implements EventSource {
         throw new RetriableError()
       },
       onerror: (err) => {
-        console.error(err)
+        console.warn('SSE connection error, reconnecting...', err)
         const event = new CustomEvent('error', { detail: err })
         this.onerror?.bind(this)(event)
 


### PR DESCRIPTION
Configure `zod` with `jitless: true` to prevent browsers from logging csp errors in their console. These errors didn't affect us, however they were still annoying and misleading.

fixes https://github.com/opencloud-eu/web/issues/2550