### PR TITLE
fix: upload overlay wording

### DIFF
--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -295,12 +295,38 @@ export default defineComponent({
           { uploads: count.toString(), errors: Object.keys(this.errors).length.toString() }
         )
       }
-      return this.$ngettext(
-        '%{ successfulUploads } item uploaded',
-        '%{ successfulUploads } items uploaded',
-        this.successful.length,
-        { successfulUploads: this.successful.length.toString() }
-      )
+
+      const folderCount = this.successful.filter(
+        (id: string) => this.uploads[id]?.meta?.isFolder
+      ).length
+      const fileCount = this.successful.length - folderCount
+
+      const parts: string[] = []
+      if (fileCount > 0) {
+        parts.push(
+          this.$ngettext('%{ fileCount } file', '%{ fileCount } files', fileCount, {
+            fileCount: fileCount.toString()
+          })
+        )
+      }
+      if (folderCount > 0) {
+        parts.push(
+          this.$ngettext('%{ folderCount } folder', '%{ folderCount } folders', folderCount, {
+            folderCount: folderCount.toString()
+          })
+        )
+      }
+
+      if (!parts.length) {
+        return this.$ngettext(
+          '%{ successfulUploads } item uploaded',
+          '%{ successfulUploads } items uploaded',
+          this.successful.length,
+          { successfulUploads: this.successful.length.toString() }
+        )
+      }
+
+      return this.$gettext('%{ items } uploaded', { items: parts.join(', ') })
     },
     uploadsPausable() {
       return this.uppyService.tusActive()

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
@@ -103,14 +103,44 @@ describe('UploadInfo component', () => {
     })
   })
   describe('info', () => {
-    it('should show the number of successful items', async () => {
+    it('should show the number of successful files', async () => {
       const { wrapper } = getShallowWrapper()
       wrapper.vm.showInfo = true
+      wrapper.vm.uploads = {
+        '1': { meta: { isFolder: false } } as OcUppyFile,
+        '2': { meta: { isFolder: false } } as OcUppyFile
+      }
       wrapper.vm.successful = ['1', '2']
       await nextTick()
 
       const info = wrapper.find(selectors.success).text()
-      expect(info).toBe('2 items uploaded')
+      expect(info).toBe('2 files uploaded')
+    })
+    it('should show the number of successful folders', async () => {
+      const { wrapper } = getShallowWrapper()
+      wrapper.vm.showInfo = true
+      wrapper.vm.uploads = {
+        '1': { meta: { isFolder: true } } as OcUppyFile,
+        '2': { meta: { isFolder: true } } as OcUppyFile
+      }
+      wrapper.vm.successful = ['1', '2']
+      await nextTick()
+
+      const info = wrapper.find(selectors.success).text()
+      expect(info).toBe('2 folders uploaded')
+    })
+    it('should show both files and folders when mixed', async () => {
+      const { wrapper } = getShallowWrapper()
+      wrapper.vm.showInfo = true
+      wrapper.vm.uploads = {
+        '1': { meta: { isFolder: false } } as OcUppyFile,
+        '2': { meta: { isFolder: true } } as OcUppyFile
+      }
+      wrapper.vm.successful = ['1', '2']
+      await nextTick()
+
+      const info = wrapper.find(selectors.success).text()
+      expect(info).toBe('1 file, 1 folder uploaded')
     })
     it('should show the number of failed items', async () => {
       const { wrapper } = getShallowWrapper()

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -692,7 +692,7 @@ export const uploadLargeNumberOfResources = async (args: uploadResourceArgs): Pr
   await performUpload(args)
   await page.locator(uploadInfoCloseButton).waitFor()
   await expect(page.locator(uploadInfoSuccessLabelSelector)).toHaveText(
-    `${resources.length} items uploaded`,
+    `${resources.length} files uploaded`,
     { timeout: config.timeout * 1000 }
   )
 }


### PR DESCRIPTION
Fixes the upload overlay wording by distinguishing between uploaded files and folders.

<img width="405" height="116" alt="image" src="https://github.com/user-attachments/assets/f8278c39-d1ff-4224-9da1-0288a19f965c" />

fixes https://github.com/opencloud-eu/web/issues/2552