### PR TITLE
fix: cancel generic space folder loading 

### DIFF
--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -405,7 +405,7 @@ export default defineComponent({
       fileId?: string | number
     ) => {
       if (resourcesViewDefaults.loadResourcesTask.isRunning) {
-        return
+        resourcesViewDefaults.loadResourcesTask.cancelAll()
       }
 
       const options: FolderLoaderOptions = { loadShares: !isPublicSpaceResource(unref(space)) }

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -31,7 +31,7 @@
           :class="{ 'h-[40vh]': isSpaceFrontpage }"
         />
         <template v-else>
-          <space-header v-if="hasSpaceHeader" :space="space" class="px-4 mt-2" />
+          <space-header v-if="isSpaceFrontpage" :space="space" class="px-4 mt-2" />
           <no-content-message
             v-if="isCurrentFolderEmpty"
             id="files-space-empty"
@@ -47,7 +47,7 @@
           </no-content-message>
           <template v-else>
             <list-header
-              v-if="readmeFile && !hasSpaceHeader"
+              v-if="readmeFile && !isSpaceFrontpage"
               :space="space"
               :readme-file="readmeFile"
               class="mx-4 my-2"
@@ -104,10 +104,10 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { omit, last } from 'lodash-es'
 import { basename } from 'path'
-import { computed, defineComponent, PropType, onBeforeUnmount, onMounted, unref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { Resource } from '@opencloud-eu/web-client'
 import {
@@ -121,7 +121,6 @@ import {
 import {
   ResourceTransfer,
   TransferType,
-  useConfigStore,
   useFileActions,
   useLoadPreview,
   usePasteWorker,
@@ -134,7 +133,6 @@ import {
   FileSideBar,
   NoContentMessage,
   Pagination,
-  ResourceTable,
   createFileRouteOptions,
   createLocationPublic,
   createLocationSpaces,
@@ -153,7 +151,6 @@ import ListInfo from '../../components/FilesList/ListInfo.vue'
 import NotFoundMessage from '../../components/FilesList/NotFoundMessage.vue'
 import QuickActions from '../../components/FilesList/QuickActions.vue'
 import ResourceDetails from '../../components/FilesList/ResourceDetails.vue'
-import { ResourceTiles } from '@opencloud-eu/web-pkg'
 import SpaceHeader from '../../components/Spaces/SpaceHeader.vue'
 import WhitespaceContextMenu from '../../components/Spaces/WhitespaceContextMenu.vue'
 import { eventBus } from '@opencloud-eu/web-pkg'
@@ -165,415 +162,343 @@ import {
   useKeyboardFileNavigation,
   useKeyboardFileSpaceActions
 } from '../../composables/keyboardActions'
-import { useFileActionsCreateNewFolder } from '../../composables'
 import { storeToRefs } from 'pinia'
 import { folderViewsFolderExtensionPoint } from '../../extensionPoints'
 import ListHeader from '../../components/FilesList/ListHeader.vue'
 
-export default defineComponent({
-  name: 'GenericSpace',
+const props = defineProps<{
+  space?: SpaceResource
+  item?: string
+  itemId?: string
+}>()
 
-  components: {
-    AppBar,
-    AppLoadingSpinner,
-    ContextActions,
-    CreateAndUpload,
-    FileSideBar,
-    FilesViewWrapper,
-    ListInfo,
-    NoContentMessage,
-    NotFoundMessage,
-    Pagination,
-    QuickActions,
-    ResourceDetails,
-    ResourceTable,
-    ResourceTiles,
-    SpaceHeader,
-    WhitespaceContextMenu,
-    ListHeader
-  },
-  props: {
-    space: {
-      type: Object as PropType<SpaceResource>,
-      required: false,
-      default: null
-    },
-    item: {
-      type: String,
-      required: false,
-      default: null
-    },
-    itemId: {
-      type: String,
-      required: false,
-      default: null
-    }
-  },
+const router = useRouter()
+const userStore = useUserStore()
+const { $gettext, $ngettext } = useGettext()
+const openWithDefaultAppQuery = useRouteQuery('openWithDefaultApp')
+const clientService = useClientService()
+const { startWorker } = usePasteWorker()
+const { breadcrumbsFromPath, concatBreadcrumbs } = useBreadcrumbsFromPath()
+const { openWithDefaultApp } = useOpenWithDefaultApp()
+const { triggerDefaultAction } = useFileActions()
 
-  setup(props) {
-    const router = useRouter()
-    const userStore = useUserStore()
-    const { $gettext, $ngettext } = useGettext()
-    const openWithDefaultAppQuery = useRouteQuery('openWithDefaultApp')
-    const clientService = useClientService()
-    const { startWorker } = usePasteWorker()
-    const { breadcrumbsFromPath, concatBreadcrumbs } = useBreadcrumbsFromPath()
-    const { openWithDefaultApp } = useOpenWithDefaultApp()
+const space = computed(() => props.space)
 
-    const space = computed(() => props.space)
+const resourcesStore = useResourcesStore()
+const { removeResources, resetSelection } = resourcesStore
+const { currentFolder, totalResourcesCount, ancestorMetaData } = storeToRefs(resourcesStore)
 
-    const { actions: createNewFolder } = useFileActionsCreateNewFolder({ space })
+let loadResourcesEventToken: string
 
-    const configStore = useConfigStore()
-    const { options: configOptions } = storeToRefs(configStore)
+const canUpload = computed(() => {
+  return unref(currentFolder)?.canUpload({ user: userStore.user })
+})
 
-    const resourcesStore = useResourcesStore()
-    const { removeResources, resetSelection } = resourcesStore
-    const { currentFolder, totalResourcesCount, areHiddenFilesShown, ancestorMetaData } =
-      storeToRefs(resourcesStore)
+const folderNotFound = computed(() => unref(currentFolder) === null)
+const isCurrentFolderEmpty = computed(() => unref(paginatedResources).length < 1)
 
-    let loadResourcesEventToken: string
+const titleSegments = computed(() => {
+  const spaceResource = unref(space)
+  let title = spaceResource.name
+  if (isPublicSpaceResource(spaceResource)) {
+    title =
+      spaceResource.publicLinkType === 'ocm' ? $gettext('OCM share') : $gettext('Public files')
+  }
 
-    const canUpload = computed(() => {
-      return unref(currentFolder)?.canUpload({ user: userStore.user })
+  const segments = [title]
+  if (props.item !== '/') {
+    segments.unshift(basename(props.item))
+  }
+
+  return segments
+})
+useDocumentTitle({ titleSegments })
+
+const route = useRoute()
+const breadcrumbs = computed(() => {
+  const rootBreadcrumbItems: BreadcrumbItem[] = []
+  if (isProjectSpaceResource(unref(space))) {
+    rootBreadcrumbItems.push({
+      id: uuidV4(),
+      text: $gettext('Spaces'),
+      to: createLocationSpaces('files-spaces-projects'),
+      isStaticNav: true
     })
-
-    const hasSpaceHeader = computed(() => {
-      // for now the space header is only available in the root of a project space.
-      return unref(space).driveType === 'project' && props.item === '/'
-    })
-
-    const folderNotFound = computed(() => unref(currentFolder) === null)
-
-    const isCurrentFolderEmpty = computed(
-      () => unref(resourcesViewDefaults.paginatedResources).length < 1
+  } else if (isShareSpaceResource(unref(space))) {
+    rootBreadcrumbItems.push(
+      {
+        id: uuidV4(),
+        text: $gettext('Shares'),
+        to: { path: '/files/shares' },
+        isStaticNav: true
+      },
+      {
+        id: uuidV4(),
+        text: $gettext('Shared with me'),
+        to: { path: '/files/shares/with-me' },
+        isStaticNav: true
+      }
     )
+  }
 
-    const titleSegments = computed(() => {
-      const spaceResource = unref(space)
-      let title = spaceResource.name
-      if (isPublicSpaceResource(spaceResource)) {
-        title =
-          spaceResource.publicLinkType === 'ocm' ? $gettext('OCM share') : $gettext('Public files')
-      }
-
-      const segments = [title]
-      if (props.item !== '/') {
-        segments.unshift(basename(props.item))
-      }
-
-      return segments
-    })
-    useDocumentTitle({ titleSegments })
-
-    const route = useRoute()
-    const breadcrumbs = computed(() => {
-      const rootBreadcrumbItems: BreadcrumbItem[] = []
-      if (isProjectSpaceResource(unref(space))) {
-        rootBreadcrumbItems.push({
-          id: uuidV4(),
-          text: $gettext('Spaces'),
-          to: createLocationSpaces('files-spaces-projects'),
-          isStaticNav: true
+  let spaceBreadcrumbItem: BreadcrumbItem
+  let { params, query } = createFileRouteOptions(unref(space), { fileId: unref(space).fileId })
+  query = omit({ ...unref(route).query, ...query }, 'page')
+  if (isPersonalSpaceResource(unref(space))) {
+    spaceBreadcrumbItem = {
+      id: uuidV4(),
+      text: unref(space).name,
+      ...(unref(space).isOwner(userStore.user) && {
+        to: createLocationSpaces('files-spaces-generic', {
+          params,
+          query
         })
-      } else if (isShareSpaceResource(unref(space))) {
-        rootBreadcrumbItems.push(
-          {
-            id: uuidV4(),
-            text: $gettext('Shares'),
-            to: { path: '/files/shares' },
-            isStaticNav: true
-          },
-          {
-            id: uuidV4(),
-            text: $gettext('Shared with me'),
-            to: { path: '/files/shares/with-me' },
-            isStaticNav: true
-          }
-        )
-      }
-
-      let spaceBreadcrumbItem: BreadcrumbItem
-      let { params, query } = createFileRouteOptions(unref(space), { fileId: unref(space).fileId })
-      query = omit({ ...unref(route).query, ...query }, 'page')
-      if (isPersonalSpaceResource(unref(space))) {
-        spaceBreadcrumbItem = {
-          id: uuidV4(),
-          text: unref(space).name,
-          ...(unref(space).isOwner(userStore.user) && {
-            to: createLocationSpaces('files-spaces-generic', {
-              params,
-              query
-            })
-          })
-        }
-      } else if (isShareSpaceResource(unref(space))) {
-        spaceBreadcrumbItem = {
-          id: uuidV4(),
-          allowContextActions: true,
-          text: unref(space).name,
-          to: createLocationSpaces('files-spaces-generic', {
-            params,
-            query: omit(query, 'fileId')
-          })
-        }
-      } else if (isPublicSpaceResource(unref(space))) {
-        spaceBreadcrumbItem = {
-          id: uuidV4(),
-          text: $gettext('Public link'),
-          to: createLocationPublic('files-public-link', {
-            params,
-            query
-          }),
-          isStaticNav: true
-        }
-      } else {
-        spaceBreadcrumbItem = {
-          id: uuidV4(),
-          allowContextActions: !unref(hasSpaceHeader),
-          text: unref(space).name,
-          to: createLocationSpaces('files-spaces-generic', {
-            params,
-            query
-          })
-        }
-      }
-
-      return concatBreadcrumbs(
-        ...rootBreadcrumbItems,
-        spaceBreadcrumbItem,
-        ...breadcrumbsFromPath({
-          route: unref(route),
-          resourcePath: props.item,
-          ...ancestorMetaData
-        })
-      )
-    })
-
-    const focusAndAnnounceBreadcrumb = (sameRoute: boolean) => {
-      const breadcrumbEl = document.getElementById('files-breadcrumb')
-      if (!breadcrumbEl) {
-        return
-      }
-      const activeBreadcrumb = last(breadcrumbEl.children[0].children)
-      const activeBreadcrumbItem = activeBreadcrumb.getElementsByTagName('button')[0]
-      if (!activeBreadcrumbItem) {
-        return
-      }
-
-      const totalFilesCount = unref(totalResourcesCount)
-      const itemCount = totalFilesCount.files + totalFilesCount.folders
-
-      const announcement = $ngettext(
-        'This folder contains %{ amount } item.',
-        'This folder contains %{ amount } items.',
-        itemCount,
-        { amount: itemCount.toString() }
-      )
-
-      const translatedHint = itemCount > 0 ? announcement : $gettext('This folder has no content.')
-
-      document.querySelectorAll('.oc-breadcrumb-sr').forEach((el) => el.remove())
-
-      const invisibleHint = document.createElement('p')
-      invisibleHint.className = 'sr-only oc-breadcrumb-sr'
-      invisibleHint.innerHTML = translatedHint
-
-      activeBreadcrumb.append(invisibleHint)
-      if (sameRoute) {
-        activeBreadcrumbItem.focus()
-      }
-    }
-
-    const resourcesViewDefaults = useResourcesViewDefaults<Resource, any, any[]>({
-      folderViewExtensionPoint: folderViewsFolderExtensionPoint
-    })
-    const { loadPreview } = useLoadPreview(resourcesViewDefaults.viewMode)
-
-    const keyActions = useKeyboardActions()
-    useKeyboardFileNavigation(
-      keyActions,
-      resourcesViewDefaults.paginatedResources,
-      resourcesViewDefaults.viewMode
-    )
-    useKeyboardFileMouseActions(keyActions, resourcesViewDefaults.viewMode)
-    useKeyboardFileSpaceActions(keyActions, space)
-
-    const performLoaderTask = async (
-      sameRoute: boolean,
-      path?: string,
-      fileId?: string | number
-    ) => {
-      if (resourcesViewDefaults.loadResourcesTask.isRunning) {
-        resourcesViewDefaults.loadResourcesTask.cancelAll()
-      }
-
-      const options: FolderLoaderOptions = { loadShares: !isPublicSpaceResource(unref(space)) }
-
-      try {
-        await resourcesViewDefaults.loadResourcesTask.perform(
-          unref(space),
-          path || props.item,
-          fileId || props.itemId,
-          options
-        )
-      } catch (e) {
-        console.error(e)
-      }
-
-      resourcesViewDefaults.scrollToResourceFromRoute(
-        [unref(currentFolder), ...unref(resourcesViewDefaults.paginatedResources)],
-        'files-app-bar'
-      )
-      resourcesViewDefaults.refreshFileListHeaderPosition()
-      focusAndAnnounceBreadcrumb(sameRoute)
-
-      if (unref(openWithDefaultAppQuery) === 'true') {
-        openWithDefaultApp({
-          space: unref(space),
-          resource: unref(resourcesViewDefaults.selectedResources)[0]
-        })
-      }
-    }
-
-    const readmeFile = computed(() => {
-      return resourcesStore.resources.find((item) =>
-        ['readme.md', '.readme.md'].includes(item.name.toLowerCase())
-      )
-    })
-
-    onMounted(() => {
-      performLoaderTask(false)
-      loadResourcesEventToken = eventBus.subscribe(
-        'app.files.list.load',
-        (path?: string, fileId?: string | number) => {
-          performLoaderTask(true, path, fileId)
-        }
-      )
-    })
-
-    onBeforeUnmount(() => {
-      eventBus.unsubscribe('app.files.list.load', loadResourcesEventToken)
-      resourcesStore.setCurrentFolder(null)
-    })
-
-    const createNewFolderAction = computed(() => unref(createNewFolder)[0].handler)
-
-    const fileDropped = async (fileTarget: string | { name: string; path: string }) => {
-      const selectedResources = unref(resourcesViewDefaults.selectedResources)
-      const paginatedResources = unref(resourcesViewDefaults.paginatedResources)
-
-      const selected = [...selectedResources]
-      let targetFolder: Resource = null
-      if (typeof fileTarget === 'string') {
-        targetFolder = paginatedResources.find((e) => e.id === fileTarget)
-        const isTargetSelected = selected.some((e) => e.id === fileTarget)
-        if (isTargetSelected) {
-          return
-        }
-      } else if (fileTarget instanceof Object) {
-        const spaceRootRoutePath = router.resolve(
-          createLocationSpaces('files-spaces-generic', {
-            params: {
-              driveAliasAndItem: unref(space).driveAlias
-            }
-          })
-        ).path
-
-        const splitIndex = fileTarget.path.indexOf(spaceRootRoutePath) + spaceRootRoutePath.length
-        const path = decodeURIComponent(fileTarget.path.slice(splitIndex, fileTarget.path.length))
-
-        try {
-          targetFolder = await clientService.webdav.getFileInfo(unref(space), { path })
-        } catch (e) {
-          console.error(e)
-          return
-        }
-      }
-
-      if (!targetFolder || targetFolder.type !== 'folder') {
-        return
-      }
-
-      const resourceTransfer = new ResourceTransfer(
-        unref(space),
-        selected,
-        unref(space),
-        targetFolder,
-        currentFolder,
-        clientService,
-        $gettext,
-        $ngettext
-      )
-
-      const transferData = await resourceTransfer.getTransferData(TransferType.MOVE)
-
-      startWorker(transferData, ({ successful }) => {
-        removeResources(successful)
-        resetSelection()
       })
     }
-
-    return {
-      ...useFileActions(),
-      ...resourcesViewDefaults,
-      configOptions,
-      canUpload,
-      breadcrumbs,
-      folderNotFound,
-      hasSpaceHeader,
-      isCurrentFolderEmpty,
-      performLoaderTask,
-      uploadHint: computed(() =>
-        $gettext('Drag files and folders here or use the "New" button to add files')
-      ),
-      createNewFolderAction,
-      currentFolder,
-      totalResourcesCount,
-      areHiddenFilesShown,
-      fileDropped,
-      loadPreview,
-      readmeFile
+  } else if (isShareSpaceResource(unref(space))) {
+    spaceBreadcrumbItem = {
+      id: uuidV4(),
+      allowContextActions: true,
+      text: unref(space).name,
+      to: createLocationSpaces('files-spaces-generic', {
+        params,
+        query: omit(query, 'fileId')
+      })
     }
-  },
-
-  computed: {
-    displayFullAppBar() {
-      return !this.displayResourceAsSingleResource
-    },
-
-    displayResourceAsSingleResource() {
-      if (this.paginatedResources.length !== 1) {
-        return false
-      }
-
-      if (this.paginatedResources[0].isFolder) {
-        return false
-      }
-
-      if (isPublicSpaceResource(this.space) && !this.currentFolder?.fileId) {
-        return true
-      }
-
-      return false
-    },
-
-    isSpaceFrontpage() {
-      return isProjectSpaceResource(this.space) && this.item === '/'
+  } else if (isPublicSpaceResource(unref(space))) {
+    spaceBreadcrumbItem = {
+      id: uuidV4(),
+      text: $gettext('Public link'),
+      to: createLocationPublic('files-public-link', {
+        params,
+        query
+      }),
+      isStaticNav: true
     }
-  },
-
-  watch: {
-    item: {
-      handler: function () {
-        this.performLoaderTask(true)
-      }
-    },
-    space: {
-      handler: function () {
-        this.performLoaderTask(true)
-      }
+  } else {
+    spaceBreadcrumbItem = {
+      id: uuidV4(),
+      allowContextActions: !unref(isSpaceFrontpage),
+      text: unref(space).name,
+      to: createLocationSpaces('files-spaces-generic', {
+        params,
+        query
+      })
     }
   }
+
+  return concatBreadcrumbs(
+    ...rootBreadcrumbItems,
+    spaceBreadcrumbItem,
+    ...breadcrumbsFromPath({
+      route: unref(route),
+      resourcePath: props.item,
+      ...ancestorMetaData
+    })
+  )
 })
+
+const focusAndAnnounceBreadcrumb = (sameRoute: boolean) => {
+  const breadcrumbEl = document.getElementById('files-breadcrumb')
+  if (!breadcrumbEl) {
+    return
+  }
+  const activeBreadcrumb = last(breadcrumbEl.children[0].children)
+  const activeBreadcrumbItem = activeBreadcrumb.getElementsByTagName('button')[0]
+  if (!activeBreadcrumbItem) {
+    return
+  }
+
+  const totalFilesCount = unref(totalResourcesCount)
+  const itemCount = totalFilesCount.files + totalFilesCount.folders
+
+  const announcement = $ngettext(
+    'This folder contains %{ amount } item.',
+    'This folder contains %{ amount } items.',
+    itemCount,
+    { amount: itemCount.toString() }
+  )
+
+  const translatedHint = itemCount > 0 ? announcement : $gettext('This folder has no content.')
+
+  document.querySelectorAll('.oc-breadcrumb-sr').forEach((el) => el.remove())
+
+  const invisibleHint = document.createElement('p')
+  invisibleHint.className = 'sr-only oc-breadcrumb-sr'
+  invisibleHint.innerHTML = translatedHint
+
+  activeBreadcrumb.append(invisibleHint)
+  if (sameRoute) {
+    activeBreadcrumbItem.focus()
+  }
+}
+
+const {
+  paginationPage,
+  paginationPages,
+  areResourcesLoading,
+  folderView,
+  fileListHeaderY,
+  selectedResourcesIds,
+  sortBy,
+  sortDir,
+  sortFields,
+  viewSize,
+  handleSort,
+  paginatedResources,
+  viewMode,
+  viewModes,
+  loadResourcesTask,
+  selectedResources,
+  refreshFileListHeaderPosition,
+  isResourceInSelection,
+  scrollToResourceFromRoute
+} = useResourcesViewDefaults<Resource, any, any[]>({
+  folderViewExtensionPoint: folderViewsFolderExtensionPoint
+})
+
+const { loadPreview } = useLoadPreview(viewMode)
+
+const keyActions = useKeyboardActions()
+useKeyboardFileNavigation(keyActions, paginatedResources, viewMode)
+useKeyboardFileMouseActions(keyActions, viewMode)
+useKeyboardFileSpaceActions(keyActions, space)
+
+const performLoaderTask = async (sameRoute: boolean, path?: string, fileId?: string) => {
+  if (loadResourcesTask.isRunning) {
+    loadResourcesTask.cancelAll()
+  }
+
+  const options: FolderLoaderOptions = { loadShares: !isPublicSpaceResource(unref(space)) }
+
+  try {
+    await loadResourcesTask.perform(
+      unref(space),
+      path || props.item,
+      fileId || props.itemId,
+      options
+    )
+  } catch (e) {
+    console.error(e)
+  }
+
+  scrollToResourceFromRoute([unref(currentFolder), ...unref(paginatedResources)], 'files-app-bar')
+  refreshFileListHeaderPosition()
+  focusAndAnnounceBreadcrumb(sameRoute)
+
+  if (unref(openWithDefaultAppQuery) === 'true') {
+    openWithDefaultApp({
+      space: unref(space),
+      resource: unref(selectedResources)[0]
+    })
+  }
+}
+
+const readmeFile = computed(() => {
+  return resourcesStore.resources.find((item) =>
+    ['readme.md', '.readme.md'].includes(item.name.toLowerCase())
+  )
+})
+
+onMounted(() => {
+  performLoaderTask(false)
+  loadResourcesEventToken = eventBus.subscribe(
+    'app.files.list.load',
+    (path?: string, fileId?: string) => {
+      performLoaderTask(true, path, fileId)
+    }
+  )
+})
+
+onBeforeUnmount(() => {
+  eventBus.unsubscribe('app.files.list.load', loadResourcesEventToken)
+  resourcesStore.setCurrentFolder(null)
+})
+
+const fileDropped = async (fileTarget: string | { name: string; path: string }) => {
+  const selected = [...unref(selectedResources)]
+  let targetFolder: Resource = null
+  if (typeof fileTarget === 'string') {
+    targetFolder = unref(paginatedResources).find((e) => e.id === fileTarget)
+    const isTargetSelected = selected.some((e) => e.id === fileTarget)
+    if (isTargetSelected) {
+      return
+    }
+  } else if (fileTarget instanceof Object) {
+    const spaceRootRoutePath = router.resolve(
+      createLocationSpaces('files-spaces-generic', {
+        params: {
+          driveAliasAndItem: unref(space).driveAlias
+        }
+      })
+    ).path
+
+    const splitIndex = fileTarget.path.indexOf(spaceRootRoutePath) + spaceRootRoutePath.length
+    const path = decodeURIComponent(fileTarget.path.slice(splitIndex, fileTarget.path.length))
+
+    try {
+      targetFolder = await clientService.webdav.getFileInfo(unref(space), { path })
+    } catch (e) {
+      console.error(e)
+      return
+    }
+  }
+
+  if (!targetFolder || targetFolder.type !== 'folder') {
+    return
+  }
+
+  const resourceTransfer = new ResourceTransfer(
+    unref(space),
+    selected,
+    unref(space),
+    targetFolder,
+    currentFolder,
+    clientService,
+    $gettext,
+    $ngettext
+  )
+
+  const transferData = await resourceTransfer.getTransferData(TransferType.MOVE)
+
+  startWorker(transferData, ({ successful }) => {
+    removeResources(successful)
+    resetSelection()
+  })
+}
+
+const uploadHint = computed(() =>
+  $gettext('Drag files and folders here or use the "New" button to add files')
+)
+
+const displayResourceAsSingleResource = computed(() => {
+  if (unref(paginatedResources).length !== 1) {
+    return false
+  }
+
+  if (unref(paginatedResources)[0].isFolder) {
+    return false
+  }
+
+  if (isPublicSpaceResource(unref(space)) && !unref(currentFolder)?.fileId) {
+    return true
+  }
+
+  return false
+})
+
+const displayFullAppBar = computed(() => {
+  return !unref(displayResourceAsSingleResource)
+})
+
+const isSpaceFrontpage = computed(() => {
+  return isProjectSpaceResource(unref(space)) && props.item === '/'
+})
+
+watch(
+  () => [props.item, props.space?.id],
+  () => {
+    performLoaderTask(true)
+  }
+)
 </script>

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -16,6 +16,7 @@ import {
 import { AppBar, useBreadcrumbsFromPath } from '@opencloud-eu/web-pkg'
 import { useBreadcrumbsFromPathMock } from '../../../mocks/useBreadcrumbsFromPathMock'
 import { BreadcrumbItem } from '@opencloud-eu/design-system/helpers'
+import { flushPromises } from '@vue/test-utils'
 
 const mockCreateFolder = vi.fn()
 const mockUseEmbedMode = vi.fn().mockReturnValue({ isEnabled: computed(() => false) })
@@ -136,18 +137,18 @@ describe('GenericSpace view', () => {
   describe('loader task', () => {
     it('re-loads the resources on item change', async () => {
       const { wrapper, mocks } = getMountedWrapper()
-      await wrapper.vm.loadResourcesTask.last
+      await flushPromises()
       expect(mocks.refreshFileListHeaderPosition).toHaveBeenCalledTimes(1)
       await wrapper.setProps({ item: 'newItem' })
-      await wrapper.vm.loadResourcesTask.last
+      await flushPromises()
       expect(mocks.refreshFileListHeaderPosition).toHaveBeenCalledTimes(2)
     })
     it('re-loads the resources on space change', async () => {
       const { wrapper, mocks } = getMountedWrapper()
-      await wrapper.vm.loadResourcesTask.last
+      await flushPromises()
       expect(mocks.refreshFileListHeaderPosition).toHaveBeenCalledTimes(1)
       await wrapper.setProps({ space: mockDeep<SpaceResource>() })
-      await wrapper.vm.loadResourcesTask.last
+      await flushPromises()
       expect(mocks.refreshFileListHeaderPosition).toHaveBeenCalledTimes(2)
     })
   })


### PR DESCRIPTION
Cancel any potential ongoing folder load task before starting a new one. Previously, a task just didn't run at all when there was still another task running. This resulted in edge cases where a folder would show contents of the previously loaded folder.

Refactors `GenericSpace` to script setup while at it. See https://github.com/opencloud-eu/web/pull/2567/changes/aa2fd08556b9a08e734bbb5b3699785713a960ad for the actual fix.

fixes https://github.com/opencloud-eu/web/issues/2477