### PR TITLE
fix(editor): slash menu scroll

### DIFF
--- a/packages/web-pkg/src/editor/components/SlashCommandMenu.vue
+++ b/packages/web-pkg/src/editor/components/SlashCommandMenu.vue
@@ -124,7 +124,7 @@ const onKeyDown = (event: KeyboardEvent): boolean => {
 
 watch(selectedIndex, async () => {
   await nextTick()
-  const el = dropRef.value?.$el?.querySelector('.text-editor-slash-menu__item--selected')
+  const el = document.querySelector('.text-editor-slash-menu__item--selected')
   el?.scrollIntoView({ block: 'nearest' })
 })
 


### PR DESCRIPTION
Fixes the issue with the editor slash menu not scrolling active items into the viewport.

fixes https://github.com/opencloud-eu/web/issues/2557