### PR TITLE
fix(editor): json rendering, plaintext serialization

### DIFF
--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -49,9 +49,6 @@ const parsedContentType = computed<ContentType>(() => {
   if (ext === 'html' || ext === 'htm' || mimeType === 'text/html') {
     return 'html'
   }
-  if (ext === 'json' || mimeType === 'application/json') {
-    return 'tiptap-json'
-  }
   return 'plain-text'
 })
 

--- a/packages/web-pkg/src/editor/composables/strategies/plainText.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/plainText.ts
@@ -14,7 +14,7 @@ export const useStrategyPlainText = (editorState: TextEditorState): ContentTypeS
   }
 
   const serialize = (editor: Editor): string => {
-    return editor.getText()
+    return editor.getText({ blockSeparator: '\n' })
   }
 
   const deserialize = (content: string): Record<string, unknown> => {

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -17,6 +17,7 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
   const readonly = ref(options.readonly ?? false)
   const strategy = resolveStrategy(options.contentType, state)
 
+  // Debounce onUpdate to avoid firing on every keystroke while typing.
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
   const extensions = strategy.extensions()
@@ -73,6 +74,7 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
         clearTimeout(debounceTimer)
       }
       debounceTimer = setTimeout(() => {
+        debounceTimer = null
         options.onUpdate!(strategy.serialize(e as unknown as Editor))
       }, 250)
     }

--- a/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
@@ -131,5 +131,17 @@ describe('useTextEditor', () => {
       result.destroy()
       expect(onUpdate).not.toHaveBeenCalled()
     })
+
+    it('does not call onUpdate on destroy after the debounce already fired', () => {
+      const onUpdate = vi.fn()
+      const { result } = createEditor({ onUpdate })
+
+      result.editor.value!.commands.insertContent('x')
+      vi.advanceTimersByTime(250)
+      expect(onUpdate).toHaveBeenCalledTimes(1)
+
+      result.destroy()
+      expect(onUpdate).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/web-pkg/tests/unit/editor/strategies/plainText.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/plainText.spec.ts
@@ -30,11 +30,11 @@ describe('useStrategyPlainText', () => {
   })
 
   describe('serialize', () => {
-    it('calls getText on editor', () => {
+    it('calls getText with \\n block separator', () => {
       const strategy = createStrategy()
       const mockEditor = { getText: vi.fn().mockReturnValue('hello') } as any
       expect(strategy.serialize(mockEditor)).toBe('hello')
-      expect(mockEditor.getText).toHaveBeenCalled()
+      expect(mockEditor.getText).toHaveBeenCalledWith({ blockSeparator: '\n' })
     })
   })
 


### PR DESCRIPTION
Fixes a few issues with the editor:

1. The text editor is not supposed to render tiptap json from any json file. This would mean that the editor doesn't display json files properly. The functionality for rendering tiptap json (= richtext format) is reserved for dedicated apps like the notes app.

2. Fix error when saving and closing plaintext files.

3. Prevent the duplicated blank lines when saving and reloading plaintext files.