### PR TITLE
fix(public-links): rename expiry date label to expiration date

### DIFF
--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -49,7 +49,7 @@
       v-if="isAdvancedMode"
       class="mt-2"
       :min-date="DateTime.now()"
-      :label="$gettext('Expiry date')"
+      :label="$gettext('Expiration date')"
       :is-dark="currentTheme.isDark"
       @date-changed="onExpiryDateChanged"
     />


### PR DESCRIPTION
## Description

The expiration date labels for public links and internal shares are currently different.

Internal shares use "Expiration Date", while public links use "Expiry Date".

This PR renames the public link label to "Expiration Date" to keep the wording consistent.

## Types of changes


- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
