### PR TITLE
test(e2e): do not empty clipboard beforehand

### DIFF
--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -391,9 +391,6 @@ export const copyLinkToClipboard = async (args: copyLinkArgs): Promise<string> =
   await sidebar.open({ page: page, resource: resource })
   await sidebar.openPanel({ page: page, name: 'sharing' })
 
-  // clear the clipboard
-  await page.evaluate(`navigator.clipboard.writeText('')`)
-
   await page.getByLabel('Copy link to clipboard').click()
   return await page.evaluate('navigator.clipboard.readText()')
 }


### PR DESCRIPTION
## Description
Do not do `navigator.clipboard.writeText('')` beforehand. This one line removal makes the flaky the test stabler.

With `writeText('')`:
- runs: 5
- fails: 1-2

Without `writeText('')`:
- runs: 20
- fails: 0

## Related Issue
- Part of: https://github.com/opencloud-eu/web/issues/1733
- Fixes: https://github.com/opencloud-eu/web/issues/1733#issuecomment-4495358844

## How Has This Been Tested?


## Types of changes

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
