### PR TITLE
fix: delete space action showing for space managers

### DIFF
--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsDisable.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsDisable.ts
@@ -63,6 +63,11 @@ export const useSpaceActionsDisable = () => {
               succeeded.length,
               { spaceCount: succeeded.length.toString() }
             )
+      await spacesStore.loadGraphPermissions({
+        ids: spaces.map((s) => s.id),
+        graphClient: client,
+        useCache: false
+      })
       showMessage({ title })
     }
 

--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsDisable.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsDisable.ts
@@ -47,7 +47,7 @@ export const useSpaceActionsDisable = () => {
           space.spaceQuota = { total: space.spaceQuota.total }
         }
         spacesStore.updateSpaceField({ id: space.id, field: 'disabled', value: true })
-        return true
+        return space.id
       })
     )
     const results = await Promise.allSettled(promises)
@@ -63,12 +63,21 @@ export const useSpaceActionsDisable = () => {
               succeeded.length,
               { spaceCount: succeeded.length.toString() }
             )
-      await spacesStore.loadGraphPermissions({
-        ids: spaces.map((s) => s.id),
-        graphClient: client,
-        useCache: false
-      })
       showMessage({ title })
+
+      try {
+        await spacesStore.loadGraphPermissions({
+          ids: succeeded.map(({ value }) => value),
+          graphClient: client,
+          useCache: false
+        })
+      } catch (error) {
+        console.error(error)
+        showErrorMessage({
+          title: $gettext('Failed to update space permissions'),
+          errors: [error]
+        })
+      }
     }
 
     const failed = results.filter(isPromiseRejected)

--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsRestore.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsRestore.ts
@@ -45,20 +45,10 @@ export const useSpaceActionsRestore = () => {
             space.spaceQuota = updatedSpace.spaceQuota
           }
           spacesStore.upsertSpace(updatedSpace)
-          return true
+          return space.id
         })
     )
     const results = await Promise.allSettled(promises)
-
-    try {
-      await spacesStore.loadGraphPermissions({ ids: spaces.map((s) => s.id), graphClient: client })
-    } catch (error) {
-      console.error(error)
-      showErrorMessage({
-        title: $gettext('Failed to update permissions for enabled spaces'),
-        errors: [error]
-      })
-    }
 
     const succeeded = results.filter(isPromiseFulfilled)
     if (succeeded.length) {
@@ -71,12 +61,21 @@ export const useSpaceActionsRestore = () => {
               succeeded.length,
               { spaceCount: succeeded.length.toString() }
             )
-      await spacesStore.loadGraphPermissions({
-        ids: spaces.map((s) => s.id),
-        graphClient: client,
-        useCache: false
-      })
       showMessage({ title })
+
+      try {
+        await spacesStore.loadGraphPermissions({
+          ids: succeeded.map(({ value }) => value),
+          graphClient: client,
+          useCache: false
+        })
+      } catch (error) {
+        console.error(error)
+        showErrorMessage({
+          title: $gettext('Failed to update space permissions'),
+          errors: [error]
+        })
+      }
     }
 
     const failed = results.filter(isPromiseRejected)

--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsRestore.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsRestore.ts
@@ -8,7 +8,6 @@ import {
   isPromiseRejected,
   useAbility,
   useClientService,
-  useLoadingService,
   useMessages,
   useModals,
   useRoute,
@@ -22,7 +21,6 @@ export const useSpaceActionsRestore = () => {
   const { $gettext, $ngettext } = useGettext()
   const ability = useAbility()
   const clientService = useClientService()
-  const loadingService = useLoadingService()
   const route = useRoute()
   const { dispatchModal } = useModals()
   const spacesStore = useSpacesStore()
@@ -73,6 +71,11 @@ export const useSpaceActionsRestore = () => {
               succeeded.length,
               { spaceCount: succeeded.length.toString() }
             )
+      await spacesStore.loadGraphPermissions({
+        ids: spaces.map((s) => s.id),
+        graphClient: client,
+        useCache: false
+      })
       showMessage({ title })
     }
 

--- a/packages/web-runtime/src/container/sse/spaces.ts
+++ b/packages/web-runtime/src/container/sse/spaces.ts
@@ -38,6 +38,12 @@ export const onSSESpaceEnabledEvent = async ({
   const space = await clientService.graphAuthenticated.drives.getDrive(sseData.spaceid)
   spacesStore.upsertSpace(space)
 
+  await spacesStore.loadGraphPermissions({
+    ids: [space.id],
+    graphClient: clientService.graphAuthenticated,
+    useCache: false
+  })
+
   if (!isLocationSpacesActive(router, 'files-spaces-projects')) {
     return
   }
@@ -59,6 +65,12 @@ export const onSSESpaceDisabledEvent = async ({
 
   const space = await clientService.graphAuthenticated.drives.getDrive(sseData.spaceid)
   spacesStore.upsertSpace(space)
+
+  await spacesStore.loadGraphPermissions({
+    ids: [space.id],
+    graphClient: clientService.graphAuthenticated,
+    useCache: false
+  })
 
   if (!isLocationSpacesActive(router, 'files-spaces-projects')) {
     return

--- a/packages/web-runtime/tests/unit/container/sse/spaces.spec.ts
+++ b/packages/web-runtime/tests/unit/container/sse/spaces.spec.ts
@@ -20,7 +20,8 @@ import {
   EventSchemaType,
   onSSESpaceCreatedEvent,
   onSSESpaceDeletedEvent,
-  onSSESpaceDisabledEvent
+  onSSESpaceDisabledEvent,
+  onSSESpaceEnabledEvent
 } from '../../../../src/container/sse'
 import { Resource, SpaceResource } from '@opencloud-eu/web-client'
 import { createTestingPinia, defaultComponentMocks } from '@opencloud-eu/web-test-helpers'
@@ -72,8 +73,56 @@ describe('spaces events', () => {
     })
   })
 
+  describe('onSSESpaceEnabledEvent', () => {
+    it('calls "upsertSpace" and reloads the graph permissions when space has been enabled', async () => {
+      const space = mock<SpaceResource>({ id: 'space1' })
+      const mocks = getMocks()
+      const sseData = mock<EventSchemaType>({ spaceid: space.id })
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
+
+      await onSSESpaceEnabledEvent({ sseData, ...mocks })
+
+      expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalledWith(space.id)
+      expect(mocks.spacesStore.upsertSpace).toHaveBeenCalledWith(space)
+      expect(mocks.spacesStore.loadGraphPermissions).toHaveBeenCalledWith({
+        ids: [space.id],
+        graphClient: mocks.clientService.graphAuthenticated,
+        useCache: false
+      })
+      expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
+    })
+
+    it('calls "upsertResource" when space has been enabled and current route equals "files-spaces-projects"', async () => {
+      const space = mock<SpaceResource>({ id: 'space1' })
+      const mocks = getMocks({ currentRouteFilesSpacesProjects: true })
+      const sseData = mock<EventSchemaType>({ spaceid: space.id })
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
+
+      await onSSESpaceEnabledEvent({ sseData, ...mocks })
+
+      expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalledWith(space.id)
+      expect(mocks.spacesStore.upsertSpace).toHaveBeenCalledWith(space)
+      expect(mocks.resourcesStore.upsertResource).toHaveBeenCalledWith(space)
+    })
+
+    it('does not trigger any action when initiator ids are identical', async () => {
+      const mocks = getMocks()
+      const sseData = mock<EventSchemaType>({
+        spaceid: 'space1',
+        initiatorid: 'local1'
+      })
+
+      await onSSESpaceEnabledEvent({ sseData, ...mocks })
+
+      expect(mocks.clientService.graphAuthenticated.drives.getDrive).not.toHaveBeenCalled()
+      expect(mocks.spacesStore.upsertSpace).not.toHaveBeenCalled()
+      expect(mocks.spacesStore.loadGraphPermissions).not.toHaveBeenCalled()
+      expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
+    })
+  })
+
   describe('onSSESpaceDisabledEvent', () => {
-    it('calls "upsertSpace" when space has been disabled', async () => {
+    it('calls "upsertSpace" and reloads the graph permissions when space has been disabled', async () => {
       const space = mock<SpaceResource>({ id: 'space1' })
       const mocks = getMocks()
       const sseData = mock<EventSchemaType>({ spaceid: space.id })
@@ -83,6 +132,11 @@ describe('spaces events', () => {
 
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalledWith(space.id)
       expect(mocks.spacesStore.upsertSpace).toHaveBeenCalledWith(space)
+      expect(mocks.spacesStore.loadGraphPermissions).toHaveBeenCalledWith({
+        ids: [space.id],
+        graphClient: mocks.clientService.graphAuthenticated,
+        useCache: false
+      })
       expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
     })
 


### PR DESCRIPTION
When a space manager, that is not a (space) admin, disables a space, the UI was previously showing the delete action. While the API should prevent that, the UI should also not show the action.

Fixes this issue by reloading the space permissions after disabling or enabling a space.

However, there are still questions that need clarification in the future:

- The server currently doesn't allow loading permissions for disabled spaces, hence the client defaults to no permissions. Should this be possible? For a solution like described in https://github.com/opencloud-eu/opencloud/issues/1799#issuecomment-4648116407, this needs to be possible.
- The client still has a lot of implicit permission checks in https://github.com/opencloud-eu/web/blob/main/packages/web-client/src/helpers/space/functions.ts#L220 for space actions. This is quite messy and should be cleaned up at some point. Also see https://github.com/opencloud-eu/opencloud/issues/10.

refs https://github.com/opencloud-eu/opencloud/issues/1799