### PR TITLE
fix: listing versions for share receivers

### DIFF
--- a/packages/web-app-office-settings/src/App.vue
+++ b/packages/web-app-office-settings/src/App.vue
@@ -15,7 +15,7 @@
               <div class="flex">
                 <oc-file-input
                   v-model="files"
-                  fileTypes=".ttf,.otf"
+                  file-types=".ttf,.otf"
                   :multiple="true"
                   :label="$gettext('Select font')"
                   class="my-6"

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -202,6 +202,9 @@ export function buildResource(
         this.permissions.indexOf(DavPermission.FolderCreateable) >= 0
       )
     },
+    canListVersions: function () {
+      return !this.isFolder
+    },
     isMounted: function () {
       return this.permissions.indexOf(DavPermission.Mounted) >= 0
     },
@@ -259,6 +262,7 @@ export function buildDeletedResource(resource: WebDavResponseResource): TrashRes
     isReceivedShare: () => false,
     hasPreview: () => false,
     isShareRoot: () => false,
+    canListVersions: () => false,
     getDomSelector: () => extractDomSelector(id)
   }
 }

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -83,6 +83,7 @@ export interface Resource {
   canRename?(args?: { user?: User; ability?: Ability }): boolean
   canBeDeleted?(args?: { user?: User; ability?: Ability }): boolean
   canEditTags?(): boolean
+  canListVersions?(args?: { user?: User }): boolean
 
   getDomSelector?(): string
 

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -163,6 +163,8 @@ export function buildIncomingShareResource({
     canCreate: () => sharePermissions.includes(GraphSharePermission.createChildren),
     canBeDeleted: () => sharePermissions.includes(GraphSharePermission.deleteStandard),
     canEditTags: () => sharePermissions.includes(GraphSharePermission.createUpload),
+    canListVersions: () =>
+      !driveItem.folder && sharePermissions.includes(GraphSharePermission.readVersions),
     isMounted: () => false,
     isReceivedShare: () => true,
     canShare: () => false,
@@ -225,6 +227,7 @@ export function buildOutgoingShareResource({
     canCreate: () => true,
     canBeDeleted: () => true,
     canEditTags: () => true,
+    canListVersions: () => !driveItem.folder,
     isMounted: () => false,
     isShareRoot: () => false,
     isReceivedShare: () => true,

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -116,12 +116,14 @@ export function buildShareSpaceResource({
   driveAliasPrefix,
   id,
   shareName,
-  serverUrl
+  serverUrl,
+  graphPermissions
 }: {
   driveAliasPrefix: 'share' | 'ocm-share'
   id: string
   shareName: string
   serverUrl: string
+  graphPermissions?: GraphSharePermission[]
 }): ShareSpaceResource {
   const space = buildSpace({
     id,
@@ -134,6 +136,10 @@ export function buildShareSpaceResource({
     space.driveAlias = `${driveAliasPrefix}/${newName}`
     space.name = newName
   }
+  if (graphPermissions) {
+    space.graphPermissions = graphPermissions
+  }
+
   return space
 }
 
@@ -281,11 +287,8 @@ export function buildSpace(
       // FIXME: server permissions are a mess currently: https://github.com/opencloud-eu/opencloud/issues/10
       return this.graphPermissions?.includes(GraphSharePermission.deletePermissions)
     },
-    canListVersions: function ({ user }: { user?: User } = {}) {
-      if (isPersonalSpaceResource(this) && this.isOwner(user)) {
-        return true
-      }
-      return this.graphPermissions?.includes(GraphSharePermission.readVersions)
+    canListVersions: function () {
+      return false
     },
     canCreate: function () {
       return true

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -35,7 +35,6 @@ export interface SpaceResource extends Resource {
   canRestore(args?: { user?: User; ability?: Ability }): boolean
   canDeleteFromTrashBin(args?: { user?: User }): boolean
   canRestoreFromTrashbin(args?: { user?: User }): boolean
-  canListVersions(args?: { user?: User }): boolean
 
   getWebDavUrl({ path }: { path: string }): string
   getWebDavTrashUrl({ path }: { path: string }): string

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -89,10 +89,15 @@ import { HttpError } from '@opencloud-eu/web-client'
 import { dirname } from 'path'
 import { useFileActionsOpenWithApp } from '../../composables'
 import { UnsavedChangesModal } from '../Modals'
-import { formatFileSize, getSharedDriveItem } from '../../helpers'
+import {
+  formatFileSize,
+  getSharedDriveItem,
+  setCurrentUserShareSpacePermissions
+} from '../../helpers'
 import toNumber from 'lodash-es/toNumber'
 import { useIsMobile } from '@opencloud-eu/design-system/composables'
 import { storeToRefs } from 'pinia'
+import { DriveItem } from '@opencloud-eu/web-client/graph/generated'
 
 const {
   applicationId,
@@ -301,17 +306,30 @@ const loadResourceTask = useTask(function* (signal) {
       // FIXME: As soon the backend exposes oc-remote-id via webdav, remove the assignment below
       unref(resource).remoteItemId = unref(space).id
 
-      if (unref(resource).id === unref(resource).remoteItemId) {
-        // use graph api to build incoming share resource
-        const sharedDriveItem = yield* call(
+      let sharedDriveItem: DriveItem
+      const resourceIsShareSpaceRoot = unref(resource).id === unref(resource).remoteItemId
+      if (!unref(space).graphPermissions || resourceIsShareSpaceRoot) {
+        // we need to load the driveItem either for the share space permissions if not yet loaded,
+        // or for building the incoming share resource if it is a share space root
+        sharedDriveItem = yield* call(
           getSharedDriveItem({
             graphClient: clientService.graphAuthenticated,
             spacesStore,
             space: unref(space)
           })
         )
+      }
 
-        if (sharedDriveItem) {
+      if (sharedDriveItem) {
+        // set graph permissions on the current share space
+        setCurrentUserShareSpacePermissions({
+          sharesStore,
+          spacesStore,
+          space: unref(space),
+          sharedDriveItem
+        })
+
+        if (resourceIsShareSpaceRoot) {
           resource.value = {
             ...fileInfo,
             ...buildIncomingShareResource({

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -7,7 +7,11 @@ import {
 } from '@opencloud-eu/web-client'
 import { Graph } from '@opencloud-eu/web-client/graph'
 import { isPersonalSpaceResource, isProjectSpaceResource } from '@opencloud-eu/web-client'
-import type { CollaboratorShare, MountPointSpaceResource } from '@opencloud-eu/web-client'
+import type {
+  CollaboratorShare,
+  GraphSharePermission,
+  MountPointSpaceResource
+} from '@opencloud-eu/web-client'
 import { useUserStore } from './user'
 import { useConfigStore } from './config'
 import { useSharesStore } from './shares'
@@ -118,17 +122,20 @@ export const useSpacesStore = defineStore('spaces', () => {
   const createShareSpace = ({
     driveAliasPrefix,
     id,
-    shareName
+    shareName,
+    graphPermissions
   }: {
     driveAliasPrefix: 'share' | 'ocm-share'
     id: string
     shareName: string
+    graphPermissions?: GraphSharePermission[]
   }) => {
     const space = buildShareSpaceResource({
       driveAliasPrefix,
       id,
       shareName,
-      serverUrl: configStore.serverUrl
+      serverUrl: configStore.serverUrl,
+      graphPermissions
     })
     addSpaces([space])
     return space

--- a/packages/web-pkg/src/composables/resources/useCanListVersions.ts
+++ b/packages/web-pkg/src/composables/resources/useCanListVersions.ts
@@ -1,20 +1,20 @@
 import { useUserStore } from '../piniaStores'
-import { isSpaceResource, isTrashResource, Resource, SpaceResource } from '@opencloud-eu/web-client'
+import {
+  GraphSharePermission,
+  isPersonalSpaceResource,
+  Resource,
+  SpaceResource
+} from '@opencloud-eu/web-client'
 
 export const useCanListVersions = () => {
   const userStore = useUserStore()
 
   const canListVersions = ({ space, resource }: { space: SpaceResource; resource: Resource }) => {
-    if (resource.type === 'folder') {
-      return false
-    }
-    if (isSpaceResource(resource)) {
-      return false
-    }
-    if (isTrashResource(resource)) {
-      return false
-    }
-    return space?.canListVersions({ user: userStore.user })
+    const spaceAllowsListingVersions =
+      (isPersonalSpaceResource(space) && space.isOwner(userStore.user)) ||
+      space.graphPermissions?.includes(GraphSharePermission.readVersions)
+
+    return spaceAllowsListingVersions && resource.canListVersions?.({ user: userStore.user })
   }
 
   return {

--- a/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
@@ -62,7 +62,8 @@ export const useGetMatchingSpace = (options?: GetMatchingSpaceOptions) => {
       spacesStore.createShareSpace({
         driveAliasPrefix,
         id: resource.remoteItemId,
-        shareName
+        shareName,
+        graphPermissions: isIncomingShareResource(resource) ? resource.sharePermissions : []
       })
     )
   }

--- a/packages/web-pkg/tests/unit/composables/resources/useCanListVersions.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useCanListVersions.spec.ts
@@ -1,55 +1,75 @@
 import { getComposableWrapper } from '@opencloud-eu/web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { Resource, SpaceResource, TrashResource } from '@opencloud-eu/web-client'
+import { GraphSharePermission, Resource, SpaceResource } from '@opencloud-eu/web-client'
 import { useCanListVersions } from '../../../../src/composables/resources'
 
 describe('useCanListVersions', () => {
   describe('canListVersions', () => {
-    it('returns true for files when user has sufficient permissions in space', () => {
+    it('returns true for a personal space owned by the user', () => {
       getWrapper({
         setup: ({ canListVersions }) => {
-          const space = mock<SpaceResource>({ canListVersions: () => true })
-          const resource = mock<Resource>({ type: 'file' })
+          const space = mock<SpaceResource>({
+            driveType: 'personal',
+            isOwner: () => true,
+            graphPermissions: []
+          })
+          const resource = mock<Resource>({ canListVersions: () => true })
           const canList = canListVersions({ space, resource })
           expect(canList).toBeTruthy()
         }
       })
     })
-    it('returns false for folders', () => {
+    it('returns true when the space grants the readVersions permission', () => {
       getWrapper({
         setup: ({ canListVersions }) => {
-          const space = mock<SpaceResource>({ canListVersions: () => true })
-          const resource = mock<Resource>({ type: 'folder' })
+          const space = mock<SpaceResource>({
+            driveType: 'project',
+            isOwner: () => false,
+            graphPermissions: [GraphSharePermission.readVersions]
+          })
+          const resource = mock<Resource>({ canListVersions: () => true })
+          const canList = canListVersions({ space, resource })
+          expect(canList).toBeTruthy()
+        }
+      })
+    })
+    it('returns false for a personal space not owned by the user', () => {
+      getWrapper({
+        setup: ({ canListVersions }) => {
+          const space = mock<SpaceResource>({
+            driveType: 'personal',
+            isOwner: () => false,
+            graphPermissions: []
+          })
+          const resource = mock<Resource>({ canListVersions: () => true })
           const canList = canListVersions({ space, resource })
           expect(canList).toBeFalsy()
         }
       })
     })
-    it('returns false for space resources', () => {
+    it('returns false when the space does not allow listing versions', () => {
       getWrapper({
         setup: ({ canListVersions }) => {
-          const space = mock<SpaceResource>({ canListVersions: () => true })
-          const resource = mock<SpaceResource>({ type: 'space' })
+          const space = mock<SpaceResource>({
+            driveType: 'project',
+            isOwner: () => false,
+            graphPermissions: []
+          })
+          const resource = mock<Resource>({ canListVersions: () => true })
           const canList = canListVersions({ space, resource })
           expect(canList).toBeFalsy()
         }
       })
     })
-    it('returns false for trash resources', () => {
+    it('returns false when the resource does not allow listing versions', () => {
       getWrapper({
         setup: ({ canListVersions }) => {
-          const space = mock<SpaceResource>({ canListVersions: () => true })
-          const resource = mock<TrashResource>({ type: 'file', ddate: '' })
-          const canList = canListVersions({ space, resource })
-          expect(canList).toBeFalsy()
-        }
-      })
-    })
-    it('returns false when user does not have sufficient permissions in space', () => {
-      getWrapper({
-        setup: ({ canListVersions }) => {
-          const space = mock<SpaceResource>({ canListVersions: () => false })
-          const resource = mock<Resource>({ type: 'file' })
+          const space = mock<SpaceResource>({
+            driveType: 'personal',
+            isOwner: () => true,
+            graphPermissions: [GraphSharePermission.readVersions]
+          })
+          const resource = mock<Resource>({ canListVersions: () => false })
           const canList = canListVersions({ space, resource })
           expect(canList).toBeFalsy()
         }


### PR DESCRIPTION
Fixes an issue where file versions were missing for a share receiver despite the permissions of the share allowing the listing of versions.

The fix moves the `canListVersions` method from the `SpaceResource` to the `Resource` interface since it should be called on a resource. On a space, it will always return `false`, since spaces don't have versions. This fixes some inconsistencies we had before (this method should represent the permissions on the actual space, not its resources).

Also, it makes sure the `graphPermissions` are set properly when creating share spaces and when loading files via the app wrapper. This is a prerequisite for determining of the user is allowed to list versions.