### PR TITLE
fix: version loading on search and favorite pages

### DIFF
--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -5,7 +5,7 @@
     class="files-side-bar z-30"
     :available-panels="availablePanels"
     :panel-context="panelContext"
-    :loading="isLoading"
+    :loading="resourceLoading"
     v-bind="$attrs"
     data-custom-key-bindings-disabled="true"
   >
@@ -44,10 +44,13 @@ import {
   SpaceResource,
   Resource,
   isIncomingShareResource,
-  isOutgoingShareResource
+  isOutgoingShareResource,
+  isShareSpaceResource,
+  call
 } from '@opencloud-eu/web-client'
 import { storeToRefs } from 'pinia'
 import { useTask } from 'vue-concurrency'
+import { getSharedDriveItem, setCurrentUserShareSpacePermissions } from '../../helpers'
 
 const { space = undefined } = defineProps<{
   space?: SpaceResource
@@ -73,11 +76,7 @@ const versions = ref<Resource[]>([])
 
 const { selectedResources } = useSelectedResources()
 
-const sharesLoading = ref(false)
-
-const isLoading = computed(() => {
-  return unref(sharesLoading)
-})
+const resourceLoading = ref(false)
 
 const panelContext = computed<SideBarPanelContext<SpaceResource, Resource, Resource>>(() => {
   if (unref(selectedResources).length === 0) {
@@ -114,117 +113,197 @@ const availablePanels = computed(() =>
     .map((e) => e.panel)
 )
 
+/**
+ * Loads graph permissions for project and share spaces if not yet loaded.
+ * In most cases, they should be already loaded at this point, but there are
+ * edge cases where they might not be, e.g. search result page or favorites.
+ */
+const loadGraphPermissionsTask = useTask(function* (signal) {
+  if (isShareSpaceResource(space)) {
+    const sharedDriveItem = yield* call(
+      getSharedDriveItem({
+        graphClient: clientService.graphAuthenticated,
+        spacesStore,
+        space,
+        signal
+      })
+    )
+    if (sharedDriveItem) {
+      setCurrentUserShareSpacePermissions({
+        sharesStore,
+        spacesStore,
+        space,
+        sharedDriveItem
+      })
+    }
+  }
+
+  if (isProjectSpaceResource(unref(space))) {
+    yield spacesStore.loadGraphPermissions({
+      ids: [unref(space).id],
+      graphClient: clientService.graphAuthenticated
+    })
+  }
+})
+
 const loadVersionsTask = useTask(function* (signal, resource: Resource) {
   versions.value = yield clientService.webdav.listFileVersions(resource.id, { signal })
 })
 
 const currentResourceMtime = ref<string>() // used to check if we need to load new versions
+const loadedVersionsResourceId = ref<string>()
+const loadedSharesResourceId = ref<string>()
+
+function loadVersions(resource: Resource) {
+  if (
+    resource.id === unref(loadedVersionsResourceId) &&
+    resource.mdate === unref(currentResourceMtime)
+  ) {
+    // don't load versions if the content of the resource didn't change
+    return
+  }
+
+  loadedVersionsResourceId.value = resource.id
+  currentResourceMtime.value = resource.mdate
+
+  if (!canListVersions({ space, resource })) {
+    return
+  }
+
+  if (loadVersionsTask.isRunning) {
+    loadVersionsTask.cancelAll()
+  }
+
+  try {
+    loadVersionsTask.perform(resource)
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+function loadShares(resource: Resource) {
+  if (resource.id === unref(loadedSharesResourceId)) {
+    // don't load shares if already loaded
+    return
+  }
+
+  loadedSharesResourceId.value = resource.id
+
+  if (!canListShares({ space, resource })) {
+    return
+  }
+
+  if (loadSharesTask.isRunning) {
+    loadSharesTask.cancelAll()
+  }
+
+  try {
+    loadSharesTask.perform({ space, resource })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+/**
+ * Sets the loaded resource that gets injected into the sidebar panels.
+ */
+async function setLoadedResource(resource: Resource) {
+  if (unref(loadedResource)?.id === resource.id) {
+    // resource has already been loaded, no need to load it again. this can happen
+    // when e.g. adding/removing shares for a resource
+    return
+  }
+
+  if (!isOutgoingShareResource(resource) && !isIncomingShareResource(resource)) {
+    loadedResource.value = resource
+    return
+  }
+
+  // shared resources look different, hence we need to fetch the actual resource here
+  try {
+    const webDavResource = await clientService.webdav.getFileInfo(space, {
+      path: resource.path
+    })
+
+    // make sure props from the share (= resource) are available on the merged resource
+    loadedResource.value = {
+      ...webDavResource,
+      ...resource,
+      tags: webDavResource.tags // tags are always [] in Graph API, hence take them from webdav
+    }
+  } catch (error) {
+    loadedResource.value = resource
+    console.error(error)
+  }
+}
+
+function resetSidebarResource() {
+  currentResourceMtime.value = undefined
+  loadedSharesResourceId.value = undefined
+  loadedVersionsResourceId.value = undefined
+  versions.value = []
+  sharesStore.pruneShares()
+  loadedResource.value = null
+}
+
+// watch key on the selection identity (id) and content version (mdate).
+// deep-watching the full resource objects would re-fire the watcher whenever a loader
+// mutates them (e.g. lazy-loaded space `graphPermissions`), causing redundant runs.
+const panelItemKeys = computed(() =>
+  unref(panelContext)
+    .items.map((item) => `${item.id}:${item.mdate}`)
+    .join(',')
+)
+
 watch(
-  () => [...unref(panelContext).items, isOpen],
-  async (newValue, oldValue) => {
-    if (unref(panelContext).items?.length !== 1) {
+  () => [unref(panelItemKeys), unref(isOpen)],
+  async () => {
+    if (!unref(isOpen) || !unref(panelContext).items?.length) {
+      resetSidebarResource()
       return
     }
 
-    if (!unref(isOpen)) {
-      currentResourceMtime.value = undefined
-      versions.value = []
-      return
-    }
-
-    const res1 = newValue?.[0] as Resource
-    const res2 = oldValue?.[0] as Resource
-    if (res1?.id === res2?.id && res1?.mdate === unref(currentResourceMtime)) {
-      // don't load versions if the content of the resource didn't change
+    if (unref(panelContext).items.length !== 1) {
+      // don't load additional metadata for multi-select contexts
       return
     }
 
     const resource = unref(panelContext).items[0]
-    currentResourceMtime.value = resource.mdate
 
-    if (loadVersionsTask.isRunning) {
-      loadVersionsTask.cancelAll()
+    // only show the loading state (which unmounts/remounts the panels) when the
+    // selected resource actually changed. for same-resource events like adding or
+    // removing a share, all loaders below early-return, so a loading toggle would
+    // needlessly remount the panel content.
+    const resourceChanged = unref(loadedResource)?.id !== resource.id
+    if (resourceChanged) {
+      resourceLoading.value = true
     }
 
-    if (!canListVersions({ space, resource })) {
-      return
+    if (loadGraphPermissionsTask.isRunning) {
+      loadGraphPermissionsTask.cancelAll()
     }
 
     try {
-      await loadVersionsTask.perform(resource)
+      if (
+        !space.graphPermissions &&
+        (isShareSpaceResource(space) || isProjectSpaceResource(space))
+      ) {
+        await loadGraphPermissionsTask.perform()
+      }
     } catch (e) {
       console.error(e)
     }
-  },
-  { immediate: true, deep: true }
-)
 
-const panelItemIds = computed(() => unref(panelContext).items.map((item) => item.id))
+    loadVersions(resource)
+    loadShares(resource)
 
-watch(
-  () => [panelItemIds, isOpen],
-  async () => {
-    if (!unref(isOpen) || !unref(panelContext).items?.length) {
-      sharesStore.pruneShares()
-      loadedResource.value = null
-      return
-    }
-    if (unref(panelContext).items?.length !== 1) {
-      // don't load additional metadata for empty or multi-select contexts
-      return
-    }
-
-    const resource = unref(panelContext).items[0]
-    sharesLoading.value = true
-
-    if (isProjectSpaceResource(resource)) {
-      await spacesStore.loadGraphPermissions({
-        ids: [resource.id],
-        graphClient: clientService.graphAuthenticated
-      })
-    }
-
-    if (canListShares({ space, resource })) {
-      try {
-        if (loadSharesTask.isRunning) {
-          loadSharesTask.cancelAll()
-        }
-
-        loadSharesTask.perform({ space, resource })
-      } catch (e) {
-        console.error(e)
-      }
-    }
-
-    if (!isOutgoingShareResource(resource) && !isIncomingShareResource(resource)) {
-      loadedResource.value = resource
-      sharesLoading.value = false
-      return
-    }
-
-    // shared resources look different, hence we need to fetch the actual resource here
     try {
-      const webDavResource = await clientService.webdav.getFileInfo(space, {
-        path: resource.path
-      })
-
-      // make sure props from the share (=resource) are available on the merged resource
-      const mergedResource = {
-        ...webDavResource,
-        ...resource,
-        tags: webDavResource.tags // tags are always [] in Graph API, hence take them from webdav
-      }
-      loadedResource.value = mergedResource
-    } catch (error) {
-      loadedResource.value = resource
-      console.error(error)
+      await setLoadedResource(resource)
+    } finally {
+      resourceLoading.value = false
     }
-    sharesLoading.value = false
   },
-  {
-    deep: true,
-    immediate: true
-  }
+  { immediate: true }
 )
 
 provide('resource', readonly(loadedResource))

--- a/packages/web-pkg/src/composables/resources/useCanListVersions.ts
+++ b/packages/web-pkg/src/composables/resources/useCanListVersions.ts
@@ -9,6 +9,11 @@ import {
 export const useCanListVersions = () => {
   const userStore = useUserStore()
 
+  /**
+   * Checks if the versions of a resource can be listed.
+   * Make sure that the graph permissions of the space are loaded before calling this function,
+   * otherwise it might return false even if the user has the required permissions.
+   */
   const canListVersions = ({ space, resource }: { space: SpaceResource; resource: Resource }) => {
     const spaceAllowsListingVersions =
       (isPersonalSpaceResource(space) && space.isOwner(userStore.user)) ||

--- a/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
@@ -63,7 +63,7 @@ export const useGetMatchingSpace = (options?: GetMatchingSpaceOptions) => {
         driveAliasPrefix,
         id: resource.remoteItemId,
         shareName,
-        graphPermissions: isIncomingShareResource(resource) ? resource.sharePermissions : []
+        graphPermissions: isIncomingShareResource(resource) ? resource.sharePermissions : undefined
       })
     )
   }


### PR DESCRIPTION
Fixes listing of versions for shared and space resources on search and favorite pages. It now loads the missing graph permissions in the sidebar in these situations. For that, I needed to combine the 2 watchers in the `FileSideBar` component into one, because loading graph permissions is a prerequisite for both of them and we shouldn't load them twice. That means there is now one watcher taking care of everything: loading versions & shares, setting the resource that then gets injected into the panels.