### PR TITLE
fix: don't query contacts for space members

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -168,7 +168,8 @@ import {
   CollaboratorShare,
   ShareRole,
   ShareTypes,
-  call
+  call,
+  isSpaceResource
 } from '@opencloud-eu/web-client'
 import {
   useCapabilityStore,
@@ -370,9 +371,12 @@ export default defineComponent({
         shareType: ShareTypes.group.value
       })) as CollaboratorAutoCompleteItem[]
 
-      const guests = (yield* call(
-        searchOpenXchangeContacts(query, signal)
-      )) as CollaboratorAutoCompleteItem[]
+      const isSpace = !unref(resource) || isSpaceResource(unref(resource))
+      const guests = isSpace
+        ? []
+        : ((yield* call(
+            searchOpenXchangeContacts(query, signal)
+          )) as CollaboratorAutoCompleteItem[])
 
       autocompleteResults.value = [...users, ...groups, ...guests].filter(
         (collaborator: CollaboratorAutoCompleteItem) => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -136,6 +136,17 @@ describe('InviteCollaboratorForm', () => {
       )
       expect(contact?.mail).toBe('jane@example.com')
     })
+    it('does not query Open-Xchange when the resource is a space', async () => {
+      const { wrapper, mocks } = getWrapper({
+        users: [{ id: '2' } as User],
+        openXchange: true,
+        openXchangeContacts: [{ id: '10', displayName: 'Jane', email: 'jane@example.com' }],
+        resource: mock<SpaceResource>(spaceMock)
+      })
+      await wrapper.vm.fetchRecipientsTask.last
+
+      expect(mocks.$clientService.ox.autocompleteContacts).not.toHaveBeenCalled()
+    })
   })
   describe('share action', () => {
     it('creates a public link and emails the contact for address book contact recipients', async () => {


### PR DESCRIPTION
## Description

contacts were queried for space resources (i.e. when searching for additional space members). that's wrong.

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
