### PR TITLE
fix: add sender to ox send mail

### DIFF
--- a/packages/web-app-files/src/composables/openXchange/useInviteContactViaEmail.ts
+++ b/packages/web-app-files/src/composables/openXchange/useInviteContactViaEmail.ts
@@ -1,10 +1,12 @@
 import { unref } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useGettext } from 'vue3-gettext'
 import {
   useClientService,
   useLinkTypes,
   usePasswordPolicyService,
-  useSharesStore
+  useSharesStore,
+  useUserStore
 } from '@opencloud-eu/web-pkg'
 import { CollaboratorAutoCompleteItem, Resource, SpaceResource } from '@opencloud-eu/web-client'
 import { renderContactShareEmail } from './renderContactShareEmail'
@@ -23,6 +25,7 @@ export const useInviteContactViaEmail = () => {
   const { defaultLinkType, isPasswordEnforcedForLinkType } = useLinkTypes()
   const passwordPolicyService = usePasswordPolicyService()
   const { addLink } = useSharesStore()
+  const { user } = storeToRefs(useUserStore())
 
   const inviteContact = async ({
     space,
@@ -59,6 +62,7 @@ export const useInviteContactViaEmail = () => {
     )
 
     await clientService.ox.sendMail({
+      from: { name: unref(user)?.displayName, email: unref(user)?.mail },
       to: { name: contact.displayName, email },
       subject,
       htmlContent: html

--- a/packages/web-app-files/tests/unit/composables/openXchange/useInviteContactViaEmail.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/openXchange/useInviteContactViaEmail.spec.ts
@@ -5,6 +5,7 @@ import {
   Resource,
   SpaceResource
 } from '@opencloud-eu/web-client'
+import { User } from '@opencloud-eu/web-client/graph/generated'
 import { defaultComponentMocks, getComposableWrapper } from '@opencloud-eu/web-test-helpers'
 import { useSharesStore } from '@opencloud-eu/web-pkg'
 import { useInviteContactViaEmail } from '../../../../src/composables/openXchange/useInviteContactViaEmail'
@@ -32,6 +33,7 @@ describe('useInviteContactViaEmail', () => {
 
     expect(mocks.$clientService.ox.sendMail).toHaveBeenCalledWith(
       expect.objectContaining({
+        from: { name: 'Admin User', email: 'admin@example.com' },
         to: { name: 'Contact', email: 'contact@example.com' },
         subject: '«Report.pdf» was shared with you'
       })
@@ -75,6 +77,9 @@ function getWrapper({ enforcePassword = false }: { enforcePassword?: boolean } =
       provide: mocks,
       pluginOptions: {
         piniaOptions: {
+          userState: {
+            user: mock<User>({ displayName: 'Admin User', mail: 'admin@example.com' })
+          },
           capabilityState: {
             capabilities: {
               files_sharing: {

--- a/packages/web-client/src/ox/index.ts
+++ b/packages/web-client/src/ox/index.ts
@@ -22,6 +22,7 @@ export interface OXMailRecipient {
 export interface OX {
   autocompleteContacts(args: { query: string; signal?: AbortSignal }): Promise<Contact[]>
   sendMail(args: {
+    from: OXMailRecipient
     to: OXMailRecipient
     subject: string
     htmlContent: string
@@ -60,7 +61,7 @@ export const ox = (axiosClient: AxiosInstance, getApiUrl: () => string | undefin
       return z.array(ContactSchema).parse(contacts)
     },
 
-    async sendMail({ to, subject, htmlContent, signal }) {
+    async sendMail({ from, to, subject, htmlContent, signal }) {
       const apiUrl = getApiUrl()
       if (!apiUrl) {
         throw new Error('Open-Xchange API url is not configured')
@@ -73,11 +74,16 @@ export const ox = (axiosClient: AxiosInstance, getApiUrl: () => string | undefin
       })
       const { data: space } = OxComposeSpaceResponseSchema.parse(openData)
 
-      // 2. send the message (recipients are [displayName, email] tuples per the OX Address schema)
+      // 2. send the message. Addresses are [displayName, email] tuples per the OX Address schema.
+      // A `type=new` composition space has no default `from`/`sender`, so we must set them
+      // explicitly: the middleware rejects the send with a "missing field: from" error otherwise.
+      const sender: [string, string] = [from.name ?? '', from.email]
       const formData = new FormData()
       formData.append(
         'JSON',
         JSON.stringify({
+          from: sender,
+          sender,
           to: [[to.name ?? '', to.email]],
           subject,
           content: htmlContent,

--- a/packages/web-client/tests/unit/ox/ox.spec.ts
+++ b/packages/web-client/tests/unit/ox/ox.spec.ts
@@ -76,17 +76,23 @@ describe('ox client', () => {
     it('throws when no api url is configured', async () => {
       const { client, axiosClient } = getClient('')
       await expect(
-        client.sendMail({ to: { email: 'guest@example.com' }, subject: 's', htmlContent: '<p/>' })
+        client.sendMail({
+          from: { name: 'Admin User', email: 'admin@example.com' },
+          to: { email: 'guest@example.com' },
+          subject: 's',
+          htmlContent: '<p/>'
+        })
       ).rejects.toThrow()
       expect(axiosClient.post).not.toHaveBeenCalled()
     })
 
-    it('opens a composition space and sends the message', async () => {
+    it('opens a composition space and sends the message including the sender as from', async () => {
       const { client, axiosClient } = getClient()
       axiosClient.post.mockResolvedValueOnce({ data: { data: { id: 'space-1' } } })
       axiosClient.post.mockResolvedValueOnce({ data: { success: true } })
 
       await client.sendMail({
+        from: { name: 'Admin User', email: 'admin@example.com' },
         to: { name: 'Jane Doe', email: 'jane@example.com' },
         subject: '«Report.pdf» was shared with you',
         htmlContent: '<p>hello</p>'
@@ -105,6 +111,8 @@ describe('ox client', () => {
       expect(url).toBe('https://ox.example.com/api/mail/compose/space-1/send')
       expect(body).toBeInstanceOf(FormData)
       expect(JSON.parse((body as FormData).get('JSON') as string)).toEqual({
+        from: ['Admin User', 'admin@example.com'],
+        sender: ['Admin User', 'admin@example.com'],
         to: [['Jane Doe', 'jane@example.com']],
         subject: '«Report.pdf» was shared with you',
         content: '<p>hello</p>',


### PR DESCRIPTION
## Description

Adds the `sender` and `from` fields to OX mail compose.

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
