### PR TITLE
fix: lock- and unlock vault action on shared with me page

### DIFF
--- a/packages/web-app-files/src/composables/actions/files/useFileActionsVaultLock.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsVaultLock.ts
@@ -13,6 +13,7 @@ import {
   useFolderVaultStore,
   useGetMatchingSpace,
   useMessages,
+  useResourcesStore,
   useRouter
 } from '@opencloud-eu/web-pkg'
 
@@ -42,6 +43,7 @@ export const useFileActionsLockVault = (): { actions: Ref<FileAction[]> } => {
   const extensionRegistry = useExtensionRegistry()
   const { showMessage } = useMessages()
   const { getMatchingSpace } = useGetMatchingSpace()
+  const resourcesStore = useResourcesStore()
   const router = useRouter()
 
   const actions = computed((): FileAction[] => [
@@ -58,7 +60,7 @@ export const useFileActionsLockVault = (): { actions: Ref<FileAction[]> } => {
           return
         }
         const vaultRoot = resource.path
-        vaultStore.clearEngine(resource.storageId, vaultRoot)
+        vaultStore.clearEngine(space.id, vaultRoot)
         showMessage({
           title: $gettext('»%{vault}« was locked', { vault: resource.name })
         })
@@ -76,7 +78,9 @@ export const useFileActionsLockVault = (): { actions: Ref<FileAction[]> } => {
             ? driveAliasAndItem.slice(space.driveAlias.length)
             : driveAliasAndItem
           ).replace(/^\/+/, '')
-        const insideVault = itemPath === vaultRoot || itemPath.startsWith(`${vaultRoot}/`)
+        const insideVault =
+          (itemPath === vaultRoot || itemPath.startsWith(`${vaultRoot}/`)) &&
+          resourcesStore.currentFolder
         if (insideVault) {
           router.push(createFileRouteOptions(space, { path: dirname(vaultRoot) }))
         }
@@ -87,7 +91,7 @@ export const useFileActionsLockVault = (): { actions: Ref<FileAction[]> } => {
         if (!claimForRoot(extensionRegistry, space, resource)) {
           return false
         }
-        return vaultStore.isUnlocked(resource.storageId, resource.path)
+        return vaultStore.isUnlocked(space.id, resource.path)
       },
       class: 'oc-files-actions-lock-vault'
     }
@@ -135,7 +139,7 @@ export const useFileActionsUnlockVault = (): { actions: Ref<FileAction[]> } => {
         if (!claim?.unlockRoute) {
           return false
         }
-        return !vaultStore.isUnlocked(resource.storageId, resource.path)
+        return !vaultStore.isUnlocked(space.id, resource.path)
       },
       class: 'oc-files-actions-unlock-vault'
     }

--- a/packages/web-app-files/tests/unit/composables/actions/files/useFileActionsVaultLock.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/actions/files/useFileActionsVaultLock.spec.ts
@@ -13,6 +13,7 @@ let unlocked = false
 let claim: any = null
 let matchedSpace: any = { id: 'space-1', driveAlias: 'personal/admin' }
 let routeParams: Record<string, unknown> = {}
+let currentFolder: any = { id: '1' }
 
 vi.mock('@opencloud-eu/web-pkg', () => ({
   createFileRouteOptions: vi.fn(() => ({ name: 'files-spaces-generic' })),
@@ -21,6 +22,7 @@ vi.mock('@opencloud-eu/web-pkg', () => ({
   useFolderVaultStore: () => ({ clearEngine, isUnlocked: () => unlocked }),
   useGetMatchingSpace: () => ({ getMatchingSpace: () => matchedSpace }),
   useMessages: () => ({ showMessage }),
+  useResourcesStore: () => ({ currentFolder }),
   useRouter: () => ({
     currentRoute: { fullPath: '/back', params: routeParams },
     push
@@ -38,6 +40,7 @@ beforeEach(() => {
   claim = { vaultRoot, unlockRoute: { name: 'unlock', query: { spaceId: 'space-1', vaultRoot } } }
   matchedSpace = { id: 'space-1', driveAlias: 'personal/admin' }
   routeParams = {}
+  currentFolder = { id: '1' }
 })
 
 describe('lock-vault action', () => {
@@ -81,6 +84,18 @@ describe('lock-vault action', () => {
     // `/my.vault-notes` merely starts with `/my.vault`; a naive substring match
     // would wrongly bounce the user out. The segment-wise compare must not.
     routeParams = { driveAliasAndItem: 'personal/admin/my.vault-notes' }
+    const { actions } = useFileActionsLockVault()
+    unref(actions)[0].handler({ resources: [rootResource()] } as any)
+    expect(clearEngine).toHaveBeenCalledWith('space-1', vaultRoot)
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect when there is no current folder (e.g. shared-with-me listing)', () => {
+    // The path matches the vault root, but a flat listing like "Shared with me"
+    // has no `currentFolder` - the user isn't actually sitting inside the vault,
+    // so locking it must not bounce them anywhere.
+    routeParams = { driveAliasAndItem: 'personal/admin/my.vault' }
+    currentFolder = null
     const { actions } = useFileActionsLockVault()
     unref(actions)[0].handler({ resources: [rootResource()] } as any)
     expect(clearEngine).toHaveBeenCalledWith('space-1', vaultRoot)


### PR DESCRIPTION
Fixes an issue where the lock- and unlock-actions of a vault would not display properly on the "Shared with me"-page.