### PR TITLE
fix: vault route guard for share spaces

### DIFF
--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -1,5 +1,6 @@
 import { loadDesignSystem, pages, loadTranslations, supportedLanguages } from './defaults'
 import { router } from './router'
+import { setupVaultUnlockGuard } from './router/setupVaultUnlockGuard'
 import { abilitiesPlugin } from '@casl/vue'
 import { createMongoAbility } from '@casl/ability'
 
@@ -73,6 +74,13 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
   const gettext = announceGettext({ app, availableLanguages: supportedLanguages })
 
   const clientService = announceClientService({ app, configStore, authStore })
+
+  // Registered here (not at router module load) so the guard can receive the
+  // `clientService` it needs to lazy-load mount-point spaces. Registering it
+  // after `setupAuthGuard` keeps the guard order intact: auth context (and
+  // thus the access token) is ready before the vault guard runs.
+  setupVaultUnlockGuard(router, clientService)
+
   announceAuthService({
     app,
     configStore,

--- a/packages/web-runtime/src/router/index.ts
+++ b/packages/web-runtime/src/router/index.ts
@@ -7,7 +7,6 @@ import ResolvePublicLinkPage from '../pages/resolvePublicLink.vue'
 import ResolvePrivateLinkPage from '../pages/resolvePrivateLink.vue'
 import { setupRouterHooks } from './setupRouter'
 import { setupAuthGuard } from './setupAuthGuard'
-import { setupVaultUnlockGuard } from './setupVaultUnlockGuard'
 import { patchRouter } from './patchCleanPath'
 import { routeNames } from './names'
 import {
@@ -173,4 +172,3 @@ export const router = patchRouter(
 
 setupRouterHooks(router)
 setupAuthGuard(router)
-setupVaultUnlockGuard(router)

--- a/packages/web-runtime/src/router/setupVaultUnlockGuard.ts
+++ b/packages/web-runtime/src/router/setupVaultUnlockGuard.ts
@@ -1,6 +1,7 @@
 import { Router } from 'vue-router'
 import { watch } from 'vue'
 import {
+  ClientService,
   getVaultClaim,
   resolveFolderVault,
   useExtensionRegistry,
@@ -18,8 +19,12 @@ import {
  * route that doesn't need user-context anyway - public links etc. resolve
  * their own context first, and the vault guard kicks in afterwards if the
  * target lives inside a vault).
+ *
+ * Receives the `clientService` because the guard runs outside of a component
+ * setup context (so `useClientService()`'s `inject` wouldn't resolve). It's
+ * needed to lazy-load mount-point (share) spaces, see below.
  */
-export const setupVaultUnlockGuard = (router: Router) => {
+export const setupVaultUnlockGuard = (router: Router, clientService: ClientService) => {
   router.beforeEach(async (to) => {
     const driveAliasAndItem = to.params?.driveAliasAndItem as string | undefined
     if (!driveAliasAndItem) return true
@@ -47,9 +52,36 @@ export const setupVaultUnlockGuard = (router: Router) => {
       })
     }
 
-    const space = spacesStore.spaces.find(
+    let space = spacesStore.spaces.find(
       (s) => driveAliasAndItem === s.driveAlias || driveAliasAndItem.startsWith(`${s.driveAlias}/`)
     )
+
+    const isShareSpace =
+      driveAliasAndItem.startsWith('share/') || driveAliasAndItem.startsWith('ocm-share/')
+
+    if (!space && isShareSpace && to.query?.shareId) {
+      // Share spaces are loaded as mount-point spaces, which we only fetch on
+      // demand (it's expensive). `spacesInitialized` doesn't cover them, so we
+      // trigger the lazy load explicitly here. `loadMountPoints` is idempotent
+      // and early-returns once `mountPointsInitialized` is set.
+      if (!spacesStore.mountPointsInitialized) {
+        await spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
+      }
+
+      // Find a matching mount point for the given share id and create a share space.
+      const mountPoint = spacesStore.spaces.find((s) => s.root?.remoteItem?.id === to.query.shareId)
+      if (!mountPoint) {
+        return true
+      }
+
+      const driveAliasPrefix = driveAliasAndItem.startsWith('ocm-share/') ? 'ocm-share' : 'share'
+      space = spacesStore.createShareSpace({
+        driveAliasPrefix,
+        id: mountPoint.root?.remoteItem?.id,
+        shareName: mountPoint.name
+      })
+    }
+
     if (!space) return true
     const path = '/' + driveAliasAndItem.slice(space.driveAlias.length).replace(/^\/+/, '')
 

--- a/packages/web-runtime/tests/unit/router/setupVaultUnlockGuard.spec.ts
+++ b/packages/web-runtime/tests/unit/router/setupVaultUnlockGuard.spec.ts
@@ -17,18 +17,31 @@ const unlockRoute = {
 
 type Guard = (to: any) => Promise<unknown>
 
+const loadMountPoints = vi.fn()
+const createShareSpace = vi.fn()
+
 function installGuard({
   spaces = [] as any[],
   claim = null as any,
-  engine = null as any
+  engine = null as any,
+  spacesInitialized = true,
+  mountPointsInitialized = true
 } = {}): Guard {
-  vi.mocked(useSpacesStore).mockReturnValue({ spaces, spacesInitialized: true } as any)
+  vi.mocked(useSpacesStore).mockReturnValue({
+    spaces,
+    spacesInitialized,
+    mountPointsInitialized,
+    loadMountPoints,
+    createShareSpace
+  } as any)
   vi.mocked(getVaultClaim).mockReturnValue(claim)
   vi.mocked(resolveFolderVault).mockResolvedValue(engine)
 
+  const clientService = { graphAuthenticated: {} } as any
+
   let guard: Guard
   const router = { beforeEach: (fn: Guard) => (guard = fn) } as unknown as Router
-  setupVaultUnlockGuard(router)
+  setupVaultUnlockGuard(router, clientService)
   return guard
 }
 
@@ -128,5 +141,94 @@ describe('setupVaultUnlockGuard', () => {
       name: 'rclone-crypt-unlock',
       query: { spaceId: 's1', vaultRoot: '/', redirectUrl: '/files/spaces/share/myvault.vault' }
     })
+  })
+
+  it('lazy-loads mount-points and builds the share space, then redirects a locked vault', async () => {
+    // On a hard reload into a share space, the share space isn't in the store
+    // yet (mount-point spaces are fetched on demand). Given the `shareId` query,
+    // the guard loads the mount points, finds the matching one, builds a share
+    // space from it, and only then gates the vault - otherwise a locked vault
+    // would slip through unguarded.
+    const mountPoint = {
+      id: 'mp1',
+      name: 'myvault.vault',
+      root: { remoteItem: { id: 'share-123' } }
+    }
+    const builtShareSpace = { id: 'share-123', driveAlias: 'share/myvault.vault' }
+    const spaces: any[] = []
+    loadMountPoints.mockImplementation(() => {
+      // simulate the store getting populated once the load resolves
+      spaces.push(mountPoint)
+    })
+    createShareSpace.mockReturnValue(builtShareSpace)
+
+    const guard = installGuard({
+      spaces,
+      mountPointsInitialized: false,
+      claim: {
+        vaultRoot: '/',
+        unlockRoute: {
+          name: 'rclone-crypt-unlock',
+          query: { spaceId: 'share-123', vaultRoot: '/' }
+        }
+      },
+      engine: null
+    })
+
+    const result = await guard({
+      params: { driveAliasAndItem: 'share/myvault.vault' },
+      query: { shareId: 'share-123' },
+      fullPath: '/files/spaces/share/myvault.vault'
+    })
+
+    expect(loadMountPoints).toHaveBeenCalledWith({ graphClient: expect.anything() })
+    expect(createShareSpace).toHaveBeenCalledWith({
+      driveAliasPrefix: 'share',
+      id: 'share-123',
+      shareName: 'myvault.vault'
+    })
+    expect(result).toEqual({
+      name: 'rclone-crypt-unlock',
+      query: {
+        spaceId: 'share-123',
+        vaultRoot: '/',
+        redirectUrl: '/files/spaces/share/myvault.vault'
+      }
+    })
+  })
+
+  it('does not build a share space when no mount point matches the share id', async () => {
+    const guard = installGuard({
+      spaces: [{ id: 'other', root: { remoteItem: { id: 'different' } } }],
+      mountPointsInitialized: true
+    })
+
+    const result = await guard({
+      params: { driveAliasAndItem: 'share/myvault.vault' },
+      query: { shareId: 'share-123' },
+      fullPath: '/x'
+    })
+
+    expect(result).toBe(true)
+    expect(createShareSpace).not.toHaveBeenCalled()
+    expect(getVaultClaim).not.toHaveBeenCalled()
+  })
+
+  it('skips the mount-point lazy load when the share space is already in the store', async () => {
+    const shareSpace = { id: 's1', driveAlias: 'share/myvault.vault' }
+    const guard = installGuard({
+      spaces: [shareSpace],
+      mountPointsInitialized: false,
+      claim: null
+    })
+
+    await guard({
+      params: { driveAliasAndItem: 'share/myvault.vault' },
+      query: { shareId: 'share-123' },
+      fullPath: '/x'
+    })
+
+    expect(loadMountPoints).not.toHaveBeenCalled()
+    expect(createShareSpace).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes an issue where reloading a vault as a share receiver would not redirect the user to the unlock vault page.

This happened because share spaces get created via mount points, which are not yet loaded when the `setupVaultUnlockGuard` runs. Hence we need to trigger and await the loading of mount points, fetch the correct one for the given `shareId` and create a share space from that.