### PR TITLE
fix: new menu entries for external apps in vaults

### DIFF
--- a/packages/web-app-files/src/components/CreateOrUploadMenu.vue
+++ b/packages/web-app-files/src/components/CreateOrUploadMenu.vue
@@ -75,12 +75,18 @@
       <li
         v-for="(fileAction, fileActionIndex) in group"
         :key="`file-creation-item-${groupIndex}-${fileActionIndex}`"
+        v-oc-tooltip="
+          isActionDisabled(fileAction) && fileAction.disabledTooltip
+            ? fileAction.disabledTooltip()
+            : null
+        "
       >
         <oc-button
           appearance="raw"
           class="w-full"
           justify-content="left"
           :class="['new-file-btn-' + fileAction.ext]"
+          :disabled="isActionDisabled(fileAction)"
           @click="() => fileAction.handler()"
         >
           <resource-icon
@@ -163,13 +169,21 @@ const extensionActions = computed(() => {
   return extensionRegistry.requestExtensions(uploadMenuExtensionPoint).map((e) => e.action)
 })
 
+const visibleCreateNewFileActions = computed(() => {
+  return unref(createNewFileActions).filter((action) =>
+    action.isVisible({ space: unref(currentSpace) })
+  )
+})
+
 const createFileActionsGroups = computed((): FileAction[][] => {
   const result: FileAction[][] = []
-  const externalFileActions = unref(createNewFileActions).filter(({ isExternal }) => isExternal)
+  const externalFileActions = unref(visibleCreateNewFileActions).filter(
+    ({ isExternal }) => isExternal
+  )
   if (externalFileActions.length) {
     result.push(externalFileActions)
   }
-  const appFileActions = unref(createNewFileActions).filter(({ isExternal }) => !isExternal)
+  const appFileActions = unref(visibleCreateNewFileActions).filter(({ isExternal }) => !isExternal)
   if (appFileActions.length) {
     result.push(appFileActions)
   }
@@ -191,7 +205,7 @@ const canUpload = computed(() => {
 })
 
 const isActionDisabled = (action: Action) => {
-  return action.isDisabled ? action.isDisabled() : false
+  return action.isDisabled ? action.isDisabled({ space: unref(currentSpace) }) : false
 }
 
 const getActionIcon = (action: Action) => {

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsCreateNewFile.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsCreateNewFile.ts
@@ -177,6 +177,12 @@ export const useFileActionsCreateNewFile = ({ space }: { space?: Ref<SpaceResour
     }
 
     for (const [, appFileExtension] of Object.entries(defaultMapping)) {
+      // Actions for external editor apps (Collabora, …) need to be disabled in vaults
+      // because those apps load the file server-side via the WOPI bridge - they'd see the
+      // encrypted blob, not the cleartext the user expects.
+      const isExternalActionInVault =
+        appFileExtension.app?.startsWith('external-') && unref(currentFolder)?.isInVault
+
       actions.push({
         name: 'create-new-file',
         icon: 'add',
@@ -193,6 +199,18 @@ export const useFileActionsCreateNewFile = ({ space }: { space?: Ref<SpaceResour
             return false
           }
           return true
+        },
+        isDisabled: () => {
+          if (isExternalActionInVault) {
+            return true
+          }
+          return false
+        },
+        disabledTooltip: () => {
+          if (isExternalActionInVault) {
+            return $gettext('This file type cannot be created inside vaults')
+          }
+          return undefined
         },
         class: 'oc-files-actions-create-new-file',
         ext: appFileExtension.extension,

--- a/packages/web-app-files/tests/unit/components/CreateOrUploadMenu.spec.ts
+++ b/packages/web-app-files/tests/unit/components/CreateOrUploadMenu.spec.ts
@@ -49,6 +49,47 @@ describe('CreateOrUploadMenu component', () => {
       const { wrapper } = getWrapper()
       expect(wrapper.html()).toMatchSnapshot()
     })
+
+    it('should only show new file handlers that are visible', () => {
+      const { wrapper } = getWrapper({
+        createActions: [
+          mock<FileAction>({
+            label: () => 'Plain text file',
+            ext: 'txt',
+            isExternal: false,
+            isVisible: () => true,
+            isDisabled: () => false
+          }),
+          mock<FileAction>({
+            label: () => 'Vault',
+            ext: 'vault',
+            isExternal: false,
+            isVisible: () => false,
+            isDisabled: () => false
+          })
+        ]
+      })
+      expect(wrapper.find('.new-file-btn-txt').exists()).toBeTruthy()
+      expect(wrapper.find('.new-file-btn-vault').exists()).toBeFalsy()
+    })
+
+    it('should disable new file handlers that are disabled', () => {
+      const { wrapper } = getWrapper({
+        createActions: [
+          mock<FileAction>({
+            label: () => 'Collabora document',
+            ext: 'odt',
+            isExternal: true,
+            isVisible: () => true,
+            isDisabled: () => true,
+            disabledTooltip: () => 'External apps cannot create files inside vaults'
+          })
+        ]
+      })
+      const button = wrapper.find('.new-file-btn-odt')
+      expect(button.exists()).toBeTruthy()
+      expect(button.attributes('disabled')).toBe('true')
+    })
   })
 })
 
@@ -56,8 +97,20 @@ function getWrapper({
   currentFolder = mock<Resource>({ canUpload: () => true }),
   areFileExtensionsShown = false,
   createActions = [
-    mock<FileAction>({ label: () => 'Plain text file', ext: 'txt', isExternal: false }),
-    mock<FileAction>({ label: () => 'Mark-down file', ext: 'md', isExternal: false })
+    mock<FileAction>({
+      label: () => 'Plain text file',
+      ext: 'txt',
+      isExternal: false,
+      isVisible: () => true,
+      isDisabled: () => false
+    }),
+    mock<FileAction>({
+      label: () => 'Mark-down file',
+      ext: 'md',
+      isExternal: false,
+      isVisible: () => true,
+      isDisabled: () => false
+    })
   ],
   extensionActions = [],
   createFolderHandler = vi.fn(),

--- a/packages/web-app-files/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
@@ -48,15 +48,86 @@ describe('useFileActionsCreateNewFile', () => {
       })
     })
   })
+
+  describe('isDisabled / disabledTooltip', () => {
+    it('disables external editor app actions inside a vault', () => {
+      const space = mock<SpaceResource>({ id: '1' })
+      getWrapper({
+        space,
+        currentFolder: mock<Resource>({ id: '1', path: '/', isInVault: true }),
+        fileExtensions: [
+          mock<ApplicationFileExtension>({
+            app: 'external-collabora',
+            extension: '.odt',
+            newFileMenu: { menuTitle: vi.fn() }
+          })
+        ],
+        setup: ({ actions }) => {
+          const action = unref(actions)[0]
+          expect(action.isDisabled()).toBe(true)
+        }
+      })
+    })
+
+    it('does not disable external editor app actions outside of a vault', () => {
+      const space = mock<SpaceResource>({ id: '1' })
+      getWrapper({
+        space,
+        currentFolder: mock<Resource>({ id: '1', path: '/', isInVault: false }),
+        fileExtensions: [
+          mock<ApplicationFileExtension>({
+            app: 'external-collabora',
+            extension: '.odt',
+            newFileMenu: { menuTitle: vi.fn() }
+          })
+        ],
+        setup: ({ actions }) => {
+          const action = unref(actions)[0]
+          expect(action.isDisabled()).toBe(false)
+          expect(action.disabledTooltip()).toBeUndefined()
+        }
+      })
+    })
+
+    it('does not disable non-external app actions inside a vault', () => {
+      const space = mock<SpaceResource>({ id: '1' })
+      getWrapper({
+        space,
+        currentFolder: mock<Resource>({ id: '1', path: '/', isInVault: true }),
+        fileExtensions: [
+          mock<ApplicationFileExtension>({
+            app: 'text-editor',
+            extension: '.txt',
+            newFileMenu: { menuTitle: vi.fn() }
+          })
+        ],
+        setup: ({ actions }) => {
+          const action = unref(actions)[0]
+          expect(action.isDisabled()).toBe(false)
+          expect(action.disabledTooltip()).toBeUndefined()
+        }
+      })
+    })
+  })
 })
 
 function getWrapper({
   resolveCreateFile = true,
   space = undefined,
+  currentFolder = mock<Resource>({ id: '1', path: '/' }),
+  fileExtensions = [
+    mock<ApplicationFileExtension>({
+      app: 'text-editor',
+      extension: '.txt',
+      newFileMenu: { menuTitle: vi.fn() }
+    })
+  ],
   setup
 }: {
   resolveCreateFile?: boolean
   space?: SpaceResource
+  currentFolder?: Resource
+  fileExtensions?: ApplicationFileExtension[]
   setup: (instance: ReturnType<typeof useFileActionsCreateNewFile>) => void
 }) {
   const mocks = {
@@ -77,8 +148,6 @@ function getWrapper({
     return Promise.reject('error')
   })
 
-  const currentFolder = mock<Resource>({ id: '1', path: '/' })
-
   return {
     wrapper: getComposableWrapper(
       () => {
@@ -91,13 +160,7 @@ function getWrapper({
         pluginOptions: {
           piniaOptions: {
             appsState: {
-              fileExtensions: [
-                mock<ApplicationFileExtension>({
-                  app: 'text-editor',
-                  extension: '.txt',
-                  newFileMenu: { menuTitle: vi.fn() }
-                })
-              ]
+              fileExtensions
             },
             resourcesStore: { currentFolder }
           }

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -285,7 +285,7 @@ watch(
 
     try {
       if (
-        !space.graphPermissions &&
+        !space?.graphPermissions &&
         (isShareSpaceResource(space) || isProjectSpaceResource(space))
       ) {
         await loadGraphPermissionsTask.perform()


### PR DESCRIPTION
Disable entries from external apps in the "New"-menu inside vaults. This feature currently isn't supported.

<img width="452" height="576" alt="image" src="https://github.com/user-attachments/assets/0d57dc73-cefc-4e99-8efb-e54783c0c635" />
