### PR TITLE
fix: reduce fields in Upload-Metadata header

### DIFF
--- a/packages/web-pkg/src/services/uppy/uppyService.ts
+++ b/packages/web-pkg/src/services/uppy/uppyService.ts
@@ -68,6 +68,11 @@ export type OcUppyMeta = {
   isFolder: boolean
 }
 export type OcUppyBody = Body
+
+// Meta fields safe to put in the tus `Upload-Metadata` header. This should
+// only include fields that are part of the TUS spec.
+export const TUS_ALLOWED_META_FIELDS: (keyof OcUppyMeta)[] = ['name', 'mtime']
+
 export type OcUppyFile = UppyFile<OcUppyMeta, OcUppyBody>
 type OcUppyPlugin = typeof BasePlugin<any, OcUppyMeta, OcUppyBody>
 export type OcMinimalUppyFile = MinimalRequiredUppyFile<OcUppyMeta, OcUppyBody>
@@ -164,6 +169,7 @@ export class UppyService {
       retryDelays: [0, 500, 1000],
       uploadDataDuringCreation,
       limit: 5,
+      allowedMetaFields: TUS_ALLOWED_META_FIELDS,
       headers,
       onBeforeRequest,
       onShouldRetry: (err, retryAttempt, options, next) => {


### PR DESCRIPTION
Cherry-pick ee913fb1e7f540c808373f3fc079565bcd7e2bff to `stable-7.1`: Reduce the fields in the `Upload-Metadata` header to only send the ones that are part of the TUS spec. This is `name` and `mtime`. The rest of the fields doesn't get used by the server, hence no need to send them.
