### PR TITLE
[stable-7.1] fix: after disabling and enabling space user cannot create resources/share space or recources (#2687)

### DIFF
--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsRestore.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsRestore.ts
@@ -46,7 +46,7 @@ export const useSpaceActionsRestore = () => {
             space.disabled = false
             space.spaceQuota = updatedSpace.spaceQuota
           }
-          spacesStore.updateSpaceField({ id: space.id, field: 'disabled', value: false })
+          spacesStore.upsertSpace(updatedSpace)
           return true
         })
     )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-7.1`:
 - [fix: after disabling and enabling space user cannot create resources/share space or recources (#2687)](https://github.com/opencloud-eu/web/pull/2687)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)