### PR TITLE
perf(test): use threads pool for unit tests

### DIFF
--- a/tests/unit/config/vitest.config.ts
+++ b/tests/unit/config/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     clearMocks: true,
+    pool: 'threads',
     include: ['**/*.spec.ts'],
     setupFiles: ['tests/unit/config/vitest.init.ts', '@vitest/web-worker'],
     exclude: [


### PR DESCRIPTION
Switch Vitest from the default `forks` pool to `threads`, which has lower per-file worker overhead. Cuts full unit suite runtime by ~19% (~47s to ~38s) with all tests still passing.

Note: a larger speedup is possible via `isolate: false`, but the suite currently has cross-file global-state leakage (74 files fail when the environment is shared). That requires a dedicated cleanup effort before isolation can be disabled.