### PR TITLE
feat(files): add space header extension point

### DIFF
--- a/packages/web-app-files/src/extensionPoints.ts
+++ b/packages/web-app-files/src/extensionPoints.ts
@@ -97,8 +97,8 @@ export const folderViewsSearchExtensionPoint: ExtensionPoint<FolderViewExtension
   extensionType: 'folderView'
 }
 
-export const spaceHeaderExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
-  id: 'app.files.space-header',
+export const genericSpaceHeaderExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
+  id: 'app.files.generic-space-header',
   extensionType: 'customComponent'
 }
 
@@ -138,7 +138,7 @@ export const extensionPoints = () => {
       folderViewsSharedViaLinkExtensionPoint,
       folderViewsSharedWithOthersExtensionPoint,
       folderViewsSearchExtensionPoint,
-      spaceHeaderExtensionPoint,
+      genericSpaceHeaderExtensionPoint,
       floatingActionButtonExtension,
       fileSideBarFileDetailsTableExtensionPoint,
       fileSideBarSharesPanelSharedWithTopExtensionPoint,

--- a/packages/web-app-files/src/extensionPoints.ts
+++ b/packages/web-app-files/src/extensionPoints.ts
@@ -97,6 +97,11 @@ export const folderViewsSearchExtensionPoint: ExtensionPoint<FolderViewExtension
   extensionType: 'folderView'
 }
 
+export const spaceHeaderExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
+  id: 'app.files.space-header',
+  extensionType: 'customComponent'
+}
+
 export const fileSideBarFileDetailsTableExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
   id: 'app.files.sidebar.file-details.table',
   extensionType: 'customComponent'
@@ -133,6 +138,7 @@ export const extensionPoints = () => {
       folderViewsSharedViaLinkExtensionPoint,
       folderViewsSharedWithOthersExtensionPoint,
       folderViewsSearchExtensionPoint,
+      spaceHeaderExtensionPoint,
       floatingActionButtonExtension,
       fileSideBarFileDetailsTableExtensionPoint,
       fileSideBarSharesPanelSharedWithTopExtensionPoint,

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -34,9 +34,17 @@
           <custom-component-target
             v-if="hasGenericSpaceHeaderExtension"
             :extension-point="genericSpaceHeaderExtensionPoint"
-          />
+          >
+            <template #fallback>
+              <space-header
+                v-if="isSpaceFrontpage"
+                :space="space"
+                class="px-4"
+              />
+            </template>
+          </custom-component-target>
           <space-header
-            v-if="isSpaceFrontpage"
+            v-else-if="isSpaceFrontpage"
             :space="space"
             class="px-4"
           />
@@ -115,7 +123,7 @@
 <script setup lang="ts">
 import { omit, last } from 'lodash-es'
 import { basename } from 'path'
-import { computed, onBeforeUnmount, onMounted, unref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { Resource } from '@opencloud-eu/web-client'
 import {

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -32,11 +32,11 @@
         />
         <template v-else>
           <custom-component-target
-            v-if="isSpaceFrontpage && hasSpaceHeaderExtension"
-            :extension-point="spaceHeaderExtensionPoint"
+            v-if="hasGenericSpaceHeaderExtension"
+            :extension-point="genericSpaceHeaderExtensionPoint"
           />
           <space-header
-            v-else-if="isSpaceFrontpage"
+            v-if="isSpaceFrontpage"
             :space="space"
             class="px-4"
           />
@@ -157,7 +157,7 @@ import {
   FolderLoaderOptions,
   CustomComponentTarget
 } from '@opencloud-eu/web-pkg'
-import { spaceHeaderExtensionPoint } from '../../extensionPoints'
+import { genericSpaceHeaderExtensionPoint } from '../../extensionPoints'
 import CreateAndUpload from '../../components/AppBar/CreateAndUpload.vue'
 import FilesViewWrapper from '../../components/FilesViewWrapper.vue'
 import ListInfo from '../../components/FilesList/ListInfo.vue'
@@ -211,8 +211,8 @@ const canUpload = computed(() => {
 
 const folderNotFound = computed(() => unref(currentFolder) === null)
 
-const hasSpaceHeaderExtension = computed(() => {
-  return extensionRegistry.requestExtensions(spaceHeaderExtensionPoint).length > 0
+const hasGenericSpaceHeaderExtension = computed(() => {
+  return extensionRegistry.requestExtensions(genericSpaceHeaderExtensionPoint).length > 0
 })
 const isCurrentFolderEmpty = computed(() => unref(paginatedResources).length < 1)
 

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -31,7 +31,15 @@
           :class="{ 'h-[40vh]': isSpaceFrontpage }"
         />
         <template v-else>
-          <space-header v-if="isSpaceFrontpage" :space="space" class="px-4" />
+          <custom-component-target
+            v-if="isSpaceFrontpage && hasSpaceHeaderExtension"
+            :extension-point="spaceHeaderExtensionPoint"
+          />
+          <space-header
+            v-else-if="isSpaceFrontpage"
+            :space="space"
+            class="px-4"
+          />
           <no-content-message
             v-if="isCurrentFolderEmpty"
             id="files-space-empty"
@@ -146,8 +154,10 @@ import {
   useKeyboardActions,
   useRoute,
   useRouteQuery,
-  FolderLoaderOptions
+  FolderLoaderOptions,
+  CustomComponentTarget
 } from '@opencloud-eu/web-pkg'
+import { spaceHeaderExtensionPoint } from '../../extensionPoints'
 import CreateAndUpload from '../../components/AppBar/CreateAndUpload.vue'
 import FilesViewWrapper from '../../components/FilesViewWrapper.vue'
 import ListInfo from '../../components/FilesList/ListInfo.vue'
@@ -200,6 +210,10 @@ const canUpload = computed(() => {
 })
 
 const folderNotFound = computed(() => unref(currentFolder) === null)
+
+const hasSpaceHeaderExtension = computed(() => {
+  return extensionRegistry.requestExtensions(spaceHeaderExtensionPoint).length > 0
+})
 const isCurrentFolderEmpty = computed(() => unref(paginatedResources).length < 1)
 
 const titleSegments = computed(() => {

--- a/packages/web-pkg/src/components/CustomComponentTarget.vue
+++ b/packages/web-pkg/src/components/CustomComponentTarget.vue
@@ -1,14 +1,17 @@
 <template>
-  <component
-    :is="extension.content"
-    v-for="extension in extensions"
-    :key="`custom-component-${extension.id}`"
-    v-bind="extension.componentProps ? extension.componentProps() : undefined"
-  />
+  <template v-for="extension in extensions" :key="`custom-component-${extension.id}`">
+    <component
+      :is="extension.content"
+      v-bind="extension.componentProps ? extension.componentProps() : undefined"
+      @vue:mounted="onChildMounted"
+      @vue:unmounted="onChildUnmounted"
+    />
+  </template>
+  <slot v-if="!hasRenderedContent" name="fallback" />
 </template>
 
 <script setup lang="ts">
-import { computed, unref } from 'vue'
+import { computed, ref, unref } from 'vue'
 import {
   CustomComponentExtension,
   ExtensionPoint,
@@ -22,6 +25,24 @@ const props = defineProps<{
 
 const extensionRegistry = useExtensionRegistry()
 const extensionPreferences = useExtensionPreferencesStore()
+
+// Track whether any extension component actually rendered visible content
+const mountedCount = ref(0)
+const hasRenderedContent = computed(() => mountedCount.value > 0)
+
+function onChildMounted(e: any) {
+  // Check if the component rendered something visible (not just a comment node)
+  const el = e?.el
+  if (el && el.nodeType !== 8 /* Comment */) {
+    mountedCount.value++
+  }
+}
+
+function onChildUnmounted() {
+  if (mountedCount.value > 0) mountedCount.value--
+}
+
+defineExpose({ hasRenderedContent })
 
 const allExtensions = computed(() => {
   return extensionRegistry.requestExtensions(props.extensionPoint)


### PR DESCRIPTION
## Summary

Add `app.files.space-header` extension point (type `customComponent`) that allows extensions to replace the default `SpaceHeader` on project space frontpages with a custom component.

## Motivation

Folder view extensions (e.g. typed folder views, DMS views) need to render their own space header with domain-specific information (icons, metadata, action buttons). Currently the only option is to modify GenericSpace.vue in the core, which creates maintenance burden and tight coupling.

This extension point follows the same pattern as the existing `app.files.sidebar.*` and `app.files.folder-views.*` extension points.

## Changes

| File | Change |
|---|---|
| `extensionPoints.ts` | Add `spaceHeaderExtensionPoint` definition |
| `GenericSpace.vue` | Check for registered extension; render `CustomComponentTarget` if present, otherwise default `SpaceHeader` |

## How extensions use it

```typescript
// In an extension's setup():
extensions: computed(() => [
  {
    id: 'my-extension.space-header',
    type: 'customComponent',
    extensionPointIds: ['app.files.space-header'],
    content: markRaw(MySpaceHeaderComponent),
    componentProps: () => ({ space, resources })
  }
])
```

## Backward compatibility

No breaking changes. When no extension registers at this point, the default `SpaceHeader` renders exactly as before.