### PR TITLE
fix: include registered extra props in PROPFIND request body

### DIFF
--- a/packages/web-client/src/webdav/client/builders.ts
+++ b/packages/web-client/src/webdav/client/builders.ts
@@ -42,6 +42,12 @@ export const buildPropFindBody = (
   }
 
   const object = properties.reduce((obj, item) => Object.assign(obj, { [item]: null }), {})
+  // Include extra props in the request so they appear in PROPFIND
+  for (const ep of extraProps) {
+    if (!(ep in object)) {
+      object[ep] = null
+    }
+  }
   const props = getNamespacedDavProps(object, extraProps)
 
   const xmlObj = {

--- a/packages/web-client/src/webdav/client/builders.ts
+++ b/packages/web-client/src/webdav/client/builders.ts
@@ -41,7 +41,10 @@ export const buildPropFindBody = (
     bodyType = 'oc:filter-files'
   }
 
-  const object = properties.reduce<Record<string, unknown>>((obj, item) => Object.assign(obj, { [item]: null }), {})
+  const object = properties.reduce<Record<string, unknown>>(
+    (obj, item) => Object.assign(obj, { [item]: null }),
+    {}
+  )
   // Include extra props in the request so they appear in PROPFIND
   for (const ep of extraProps) {
     if (!(ep in object)) {

--- a/packages/web-client/src/webdav/client/builders.ts
+++ b/packages/web-client/src/webdav/client/builders.ts
@@ -41,7 +41,7 @@ export const buildPropFindBody = (
     bodyType = 'oc:filter-files'
   }
 
-  const object = properties.reduce((obj, item) => Object.assign(obj, { [item]: null }), {})
+  const object = properties.reduce<Record<string, unknown>>((obj, item) => Object.assign(obj, { [item]: null }), {})
   // Include extra props in the request so they appear in PROPFIND
   for (const ep of extraProps) {
     if (!(ep in object)) {


### PR DESCRIPTION
## Summary

`registerExtraProp()` registered properties for response parsing but `buildPropFindBody()` never included them in the PROPFIND request XML. Extensions using `registerExtraProp()` would never receive their custom properties because the server was never asked for them.

Replaces #2721 (which had unrelated files).

## Changes

| File | Change |
|---|---|
| `builders.ts` | Include registered extra props in PROPFIND XML body |

## Test plan

- [x] Extension registers extra prop via `registerExtraProp('oc:my.prop')`
- [x] PROPFIND request XML now includes `<oc:my.prop/>`
- [x] Server returns the property value in response
- [x] Existing props (etag, fileid etc.) still work