### PR TITLE
feat: add metadata sidebar panel

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Metadata/MetadataPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Metadata/MetadataPanel.vue
@@ -1,0 +1,96 @@
+<template>
+  <div id="files-sidebar-panel-metadata" class="rounded-sm p-4 bg-role-surface-container">
+    <div v-if="loading" class="flex justify-center">
+      <oc-spinner :aria-label="$gettext('Loading metadata')" />
+    </div>
+    <div v-else-if="error" class="text-role-on-surface-variant">
+      {{ $gettext('Could not load metadata.') }}
+    </div>
+    <div v-else-if="isEmpty" class="text-role-on-surface-variant">
+      {{ $gettext('No metadata available.') }}
+    </div>
+    <dl
+      v-else
+      class="details-list grid grid-cols-[auto_minmax(0,1fr)] m-0"
+      :aria-label="$gettext('Custom metadata for the selected item')"
+    >
+      <template v-for="(value, key) in metadata" :key="key">
+        <dt class="font-medium" :data-testid="`metadata-key-${key}`">{{ formatKey(key) }}</dt>
+        <dd :data-testid="`metadata-value-${key}`">{{ value || '-' }}</dd>
+      </template>
+    </dl>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, inject, onMounted, ref, Ref, unref, watch } from 'vue'
+import { Resource, SpaceResource } from '@opencloud-eu/web-client'
+import { useClientService } from '@opencloud-eu/web-pkg'
+
+export default defineComponent({
+  name: 'MetadataPanel',
+  setup() {
+    const resource = inject<Ref<Resource>>('resource')
+    const space = inject<Ref<SpaceResource>>('space')
+    const clientService = useClientService()
+
+    const metadata = ref<Record<string, string>>({})
+    const loading = ref(false)
+    const error = ref(false)
+
+    const isEmpty = computed(() => Object.keys(unref(metadata)).length === 0)
+
+    const formatKey = (key: string): string => {
+      // Strip common prefixes for display
+      // "oy.subject" → "Subject", "oy.creatorName" → "Creator Name"
+      let display = key
+      if (display.startsWith('oy.')) {
+        display = display.substring(3)
+      }
+      // camelCase to Title Case
+      display = display.replace(/([A-Z])/g, ' $1')
+      return display.charAt(0).toUpperCase() + display.slice(1)
+    }
+
+    const fetchMetadata = async () => {
+      const res = unref(resource)
+      const sp = unref(space)
+      if (!res?.id || !sp?.id) return
+
+      loading.value = true
+      error.value = false
+      try {
+        const httpClient = clientService.httpAuthenticated
+        const response = await httpClient.get(
+          `/graph/v1.0/drives/${sp.id}/items/${res.id}/metadata`
+        )
+        if (response.status === 200) {
+          metadata.value = response.data as Record<string, string>
+        } else {
+          metadata.value = {}
+        }
+      } catch (e) {
+        error.value = true
+        metadata.value = {}
+      } finally {
+        loading.value = false
+      }
+    }
+
+    onMounted(fetchMetadata)
+
+    watch(
+      () => unref(resource)?.id,
+      () => fetchMetadata()
+    )
+
+    return {
+      metadata,
+      loading,
+      error,
+      isEmpty,
+      formatKey
+    }
+  }
+})
+</script>

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -28,6 +28,7 @@ import { useGettext } from 'vue3-gettext'
 import { markRaw, unref } from 'vue'
 import { fileSideBarExtensionPoint } from '../../extensionPoints'
 import AudioMetaPanel from '../../components/SideBar/Audio/AudioMetaPanel.vue'
+import MetadataPanel from '../../components/SideBar/Metadata/MetadataPanel.vue'
 import { isEmpty } from 'lodash-es'
 
 export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resource, Resource>[] => {
@@ -174,6 +175,23 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
             return false
           }
           return !isEmpty(item.audio)
+        }
+      }
+    },
+    {
+      id: 'com.github.opencloud-eu.web.files.sidebar-panel.metadata',
+      type: 'sidebarPanel',
+      extensionPointIds: ['global.files.sidebar'],
+      panel: {
+        name: 'metadata',
+        icon: 'price-tag-3',
+        title: () => $gettext('Metadata'),
+        component: MetadataPanel,
+        isVisible: ({ items }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          return !isProjectSpaceResource(items[0])
         }
       }
     },


### PR DESCRIPTION
## Summary

New sidebar tab "Metadata" that displays custom metadata (`user.oc.md.*`) for the selected file or folder. Fetches data from the Graph API endpoint `GET /drives/{driveID}/items/{itemID}/metadata`.

Replaces #2709 (which had unrelated files).

## Changes

| File | Change |
|---|---|
| `MetadataPanel.vue` | New component: renders key-value pairs with formatted labels |
| `useFileSideBars.ts` | Register metadata panel, visible for single item selection |

## Features

- Strips `oy.` prefix for display
- Converts camelCase keys to Title Case
- Read-only display of all custom metadata

## Test plan

- [x] Set custom metadata via Graph Metadata API
- [x] Select file → Sidebar shows Metadata tab
- [x] Custom metadata values displayed correctly
- [x] Panel hidden when no metadata present