### PR TITLE
fix: file list scroll after closing an editor

### DIFF
--- a/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
+++ b/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
@@ -9,7 +9,8 @@ import {
   useExtensionRegistry,
   ExtensionPoint,
   FolderViewExtension,
-  FolderView
+  FolderView,
+  useRouter
 } from '@opencloud-eu/web-pkg'
 import { queryItemAsString, useRouteQuery } from '@opencloud-eu/web-pkg'
 import {
@@ -70,6 +71,7 @@ export const useResourcesViewDefaults = <T extends Resource, TT, TU extends any[
   const language = useGettext()
   const resourcesStore = useResourcesStore()
   const extensionRegistry = useExtensionRegistry()
+  const router = useRouter()
   const storeItems = computed(() => resourcesStore.activeResources) as unknown as Ref<T[]>
 
   const { refresh: refreshFileListHeaderPosition, y: fileListHeaderY } = useFileListHeaderPosition()
@@ -114,6 +116,14 @@ export const useResourcesViewDefaults = <T extends Resource, TT, TU extends any[
     page: paginationPage
   } = usePagination<T>({ items, perPageStoragePrefix: 'files' })
 
+  const scrollToParam = useRouteQuery('scrollTo')
+  const resetScrollToParam = async () => {
+    await router.push({
+      ...unref(router.currentRoute),
+      query: { ...unref(router.currentRoute).query, scrollTo: undefined }
+    })
+  }
+
   resourcesStore.$onAction((action) => {
     action.after(async () => {
       switch (action.name) {
@@ -125,6 +135,23 @@ export const useResourcesViewDefaults = <T extends Resource, TT, TU extends any[
           await nextTick()
           for (const resource of action.args[0]) {
             fileList.accentuateItem(resource.id)
+          }
+          break
+        case 'toggleSelection':
+          if (!resourcesStore.selectedIds.includes(action.args[0]) && unref(scrollToParam)) {
+            // resource got deselected
+            resetScrollToParam()
+          }
+          break
+        case 'resetSelection':
+          if (unref(scrollToParam)) {
+            resetScrollToParam()
+          }
+          break
+        case 'setSelection':
+          if (action.args[0].length === 0 && unref(scrollToParam)) {
+            // selection reset
+            resetScrollToParam()
           }
           break
       }

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -387,7 +387,12 @@ const performLoaderTask = async (sameRoute: boolean, path?: string, fileId?: str
     console.error(e)
   }
 
-  scrollToResourceFromRoute([unref(currentFolder), ...unref(paginatedResources)], 'files-app-bar')
+  if (!unref(displayResourceAsSingleResource)) {
+    // when a single resource is shown (e.g. a public link to a file), the file list table
+    // - and therefore the row to scroll to - is not rendered, so there is nothing to scroll to
+    scrollToResourceFromRoute([unref(currentFolder), ...unref(paginatedResources)], 'files-app-bar')
+  }
+
   refreshFileListHeaderPosition()
   focusAndAnnounceBreadcrumb(sameRoute)
 

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -135,6 +135,11 @@ describe('GenericSpace view', () => {
     })
   })
   describe('loader task', () => {
+    it('scrolls to the resource from the route when a file list is rendered', async () => {
+      const { mocks } = getMountedWrapper()
+      await flushPromises()
+      expect(mocks.scrollToResourceFromRoute).toHaveBeenCalledTimes(1)
+    })
     it('re-loads the resources on item change', async () => {
       const { wrapper, mocks } = getMountedWrapper()
       await flushPromises()
@@ -182,6 +187,22 @@ describe('GenericSpace view', () => {
           })
         })
         expect(wrapper.find('resource-details-stub').exists()).toBeTruthy()
+      })
+      it('does not scroll to the resource since no file list is rendered', async () => {
+        const { mocks } = getMountedWrapper({
+          currentFolder: {
+            ...mock<Resource>()
+          },
+          files: [{ ...mock<Resource>({ name: 'file.txt' }), isFolder: false }],
+          space: mock<SpaceResource>({
+            id: '1',
+            getDriveAliasAndItem: vi.fn(),
+            name: 'Personal space',
+            driveType: 'public'
+          })
+        })
+        await flushPromises()
+        expect(mocks.scrollToResourceFromRoute).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -17,8 +17,13 @@
   >
     <div
       v-if="isHidden"
-      class="oc-tile-card-lazy-shimmer h-30 overflow-hidden relative after:absolute after:inset-0 after:transform-[translateX(-100%)] opacity-20 after:animate-shimmer"
-    />
+      class="oc-tile-card-lazy-shimmer overflow-hidden relative after:absolute after:inset-0 after:transform-[translateX(-100%)] opacity-20 after:animate-shimmer"
+    >
+      <div class="w-full aspect-[16/9]" />
+      <div class="p-2">
+        <div class="h-6" />
+      </div>
+    </div>
     <template v-else>
       <resource-link
         class="oc-card-media-top flex justify-center items-center m-0 w-full relative aspect-[16/9]"

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -72,7 +72,7 @@ export function useAppNavigation({
   currentFileContext
 }: AppNavigationOptions): AppNavigationResult {
   const navigateToContext = (context: MaybeRef<FileContext>) => {
-    const { fileName, routeName, routeParams, routeQuery } = unref(context)
+    const { itemId, routeName, routeParams, routeQuery } = unref(context)
 
     if (!unref(routeName)) {
       return router.push({ path: '/' })
@@ -83,7 +83,7 @@ export function useAppNavigation({
       params: unref(routeParams),
       query: {
         ...unref(routeQuery),
-        scrollTo: unref(fileName)
+        scrollTo: unref(itemId)
       }
     })
   }

--- a/packages/web-pkg/tests/unit/composables/appDefaults/useAppNavigation.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/appDefaults/useAppNavigation.spec.ts
@@ -1,0 +1,62 @@
+import { defaultComponentMocks } from '@opencloud-eu/web-test-helpers'
+import { useAppNavigation } from '../../../../src/composables/appDefaults/useAppNavigation'
+import { FileContext } from '../../../../src/composables/appDefaults/types'
+import { SpaceResource } from '@opencloud-eu/web-client'
+
+describe('useAppNavigation', () => {
+  describe('closeApp', () => {
+    it('navigates to the root if no context route name is given', () => {
+      const { router } = createSetup({})
+      const currentFileContext = { ...createFileContext({}), routeName: '' }
+      const { closeApp } = useAppNavigation({ router, currentFileContext })
+
+      closeApp()
+
+      expect(router.push).toHaveBeenCalledWith({ path: '/' })
+    })
+
+    it('passes the resource id (not the file name) as "scrollTo" so the file list can scroll back to it', () => {
+      const { router } = createSetup({})
+      const { closeApp } = useAppNavigation({
+        router,
+        currentFileContext: createFileContext({ itemId: 'file-id', fileName: 'example.txt' })
+      })
+
+      closeApp()
+
+      expect(router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'files-spaces-generic',
+          query: expect.objectContaining({ scrollTo: 'file-id' })
+        })
+      )
+    })
+  })
+})
+
+function createSetup({}: Record<string, never>) {
+  const mocks = defaultComponentMocks()
+  return { router: mocks.$router }
+}
+
+function createFileContext({
+  itemId = 'file-id',
+  fileName = 'example.txt',
+  routeName = 'files-spaces-generic'
+}: {
+  itemId?: string
+  fileName?: string
+  routeName?: string
+}): FileContext {
+  return {
+    path: '/example.txt',
+    driveAliasAndItem: 'personal/admin/example.txt',
+    space: {} as SpaceResource,
+    item: '/example.txt',
+    itemId,
+    fileName,
+    routeName,
+    routeParams: { driveAliasAndItem: 'personal/admin/example.txt' },
+    routeQuery: {}
+  }
+}


### PR DESCRIPTION
Fixes an issue where the file list would not scroll to the resource that has just been closed. This was due to a wrong `scrollTo` param value.

Additionally, fixes another issue where the `scrollTo` param would not actually scroll to the correct resource in the tiles view. This happened because the lazy loading containers of the tiles view didn't match the tiles' actual size.

fixes https://github.com/opencloud-eu/web/issues/2662