### PR TITLE
fix: select personal account (isPersonal) instead of first in account…

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/groupware/accounts.ts
+++ b/packages/web-pkg/src/composables/piniaStores/groupware/accounts.ts
@@ -92,8 +92,9 @@ export const useGroupwareAccountsStore = defineStore('accounts', () => {
     if (query) {
       queryAccount = unref(accounts).find(({ accountId }) => accountId === query)
     }
+    const personalAccount = unref(accounts).find((account) => account.isPersonal)
 
-    setCurrentAccount(queryAccount || unref(accounts)[0])
+    setCurrentAccount(queryAccount || personalAccount || unref(accounts)[0])
   }
 
   return {


### PR DESCRIPTION
After the Stalwart 0.16 upgrade, the /groupware/accounts endpoint returns accounts in a different order. Previously the user's personal account happened to be first in the list, so defaulting to accounts[0] selected the correct account on load.
Now a shared account (e.g. a group/list mailbox like programmers@example.org) can come first, which has isPersonal: false. As a result the account switcher pre-selected the shared mailbox instead of the user's own account on initial load.

This has been fixed by loadCurrentAccount no longer falls back to the first account in the list. It now prefers the account flagged with isPersonal: true