### PR TITLE
fix: isolate module federation shared scope per app

### DIFF
--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -17,7 +17,7 @@ import * as webClientOcs from '@opencloud-eu/web-client/ocs'
 import * as webClientSse from '@opencloud-eu/web-client/sse'
 import * as webClientWebdav from '@opencloud-eu/web-client/webdav'
 
-import type { ModuleFederation } from '@module-federation/runtime'
+import { ModuleFederation } from '@module-federation/runtime'
 import { urlJoin } from '@opencloud-eu/web-client'
 import { App } from 'vue'
 import { AppConfigObject, ClassicApplicationScript } from '@opencloud-eu/web-pkg'
@@ -75,24 +75,27 @@ const loadScriptDynamicImport = async <T>(moduleUri: string) => {
   return ((await import(/* @vite-ignore */ moduleUri)) as any).default as T
 }
 
-const loadScriptModuleFederation = async <T>(
-  federation: ModuleFederation,
-  remoteUrl: string
-): Promise<T> => {
+const loadScriptModuleFederation = async <T>(remoteUrl: string, name: string): Promise<T> => {
+  // Each remote gets its own Module Federation instance with an isolated shared scope.
+  // All remotes loaded through a single instance share the same `shareScopeMap` by
+  // reference, so a faulty app that corrupts that scope during init breaks every other
+  // app too. Per-instance isolation contains such failures to the offending app.
+  // This is cheap: the shared modules are imported once at the top of this file and only
+  // referenced here, so creating an instance just registers a handful of lazy descriptors.
+  const federation = new ModuleFederation({ name: `opencloud-web-${name}`, remotes: [] })
+  registerSharedModules(federation)
   federation.registerRemotes([{ name: remoteUrl, entry: remoteUrl, type: 'module' }])
   const module = await federation.loadRemote(remoteUrl)
   return (module as any).default as T
 }
 
 export const loadApplication = async ({
-  federation,
   appName,
   applicationKey,
   applicationPath,
   applicationConfig,
   configStore
 }: {
-  federation: ModuleFederation
   appName?: string
   applicationKey: string
   applicationPath: string
@@ -110,40 +113,38 @@ export const loadApplication = async ({
   }
 
   let applicationScript: ClassicApplicationScript
-  try {
-    if (applicationPath.includes('/')) {
-      if (
-        !applicationPath.startsWith('http://') &&
-        !applicationPath.startsWith('https://') &&
-        !applicationPath.startsWith('//')
-      ) {
-        applicationPath = urlJoin(configStore.serverUrl, applicationPath)
-      }
+  if (applicationPath.includes('/')) {
+    if (
+      !applicationPath.startsWith('http://') &&
+      !applicationPath.startsWith('https://') &&
+      !applicationPath.startsWith('//')
+    ) {
+      applicationPath = urlJoin(configStore.serverUrl, applicationPath)
+    }
 
-      if (applicationPath.endsWith('.mjs')) {
+    if (applicationPath.endsWith('.mjs')) {
+      try {
         applicationScript = await loadScriptModuleFederation<ClassicApplicationScript>(
-          federation,
-          applicationPath
+          applicationPath,
+          applicationKey
         )
-      } else {
-        throw new RuntimeError(
-          'cannot load application as applicationPath is not a valid module federation remote entry'
-        )
+      } catch (e) {
+        throw new RuntimeError('failed to load application', applicationKey, e)
       }
     } else {
-      const productionModule = window.WEB_APPS_MAP?.[applicationPath]
-      if (productionModule) {
-        applicationScript =
-          await loadScriptDynamicImport<ClassicApplicationScript>(productionModule)
-      } else {
-        throw new RuntimeError(
-          'cannot load application as only a name (and no path) is given and that name is not known to the application import map'
-        )
-      }
+      throw new RuntimeError(
+        'cannot load application as applicationPath is not a valid module federation remote entry'
+      )
     }
-  } catch (e) {
-    console.trace(e)
-    throw new RuntimeError('cannot load application', applicationPath, e)
+  } else {
+    const productionModule = window.WEB_APPS_MAP?.[applicationPath]
+    if (productionModule) {
+      applicationScript = await loadScriptDynamicImport<ClassicApplicationScript>(productionModule)
+    } else {
+      throw new RuntimeError(
+        'cannot load application as only a name (and no path) is given and that name is not known to the application import map'
+      )
+    }
   }
 
   return {

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -129,20 +129,33 @@ export const loadApplication = async ({
           applicationKey
         )
       } catch (e) {
-        throw new RuntimeError('failed to load application', applicationKey, e)
+        throw new RuntimeError(
+          `failed to load external application ${applicationKey}`,
+          applicationKey,
+          e
+        )
       }
     } else {
       throw new RuntimeError(
-        'cannot load application as applicationPath is not a valid module federation remote entry'
+        `cannot load external application ${applicationKey} as applicationPath is not a valid module federation remote entry`
       )
     }
   } else {
     const productionModule = window.WEB_APPS_MAP?.[applicationPath]
     if (productionModule) {
-      applicationScript = await loadScriptDynamicImport<ClassicApplicationScript>(productionModule)
+      try {
+        applicationScript =
+          await loadScriptDynamicImport<ClassicApplicationScript>(productionModule)
+      } catch (e) {
+        throw new RuntimeError(
+          `failed to load internal application ${applicationKey}`,
+          applicationKey,
+          e
+        )
+      }
     } else {
       throw new RuntimeError(
-        'cannot load application as only a name (and no path) is given and that name is not known to the application import map'
+        `cannot load internalapplication ${applicationKey} as only a name (and no path) is given and that name is not known to the application import map`
       )
     }
   }

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -1,4 +1,3 @@
-import { ModuleFederation } from '@module-federation/runtime'
 import { buildApplication, loadApplication, NextApplication } from './application'
 import { RouteLocationRaw, Router, RouteRecordNormalized } from 'vue-router'
 import { App, computed, watch } from 'vue'
@@ -212,14 +211,12 @@ export const announceConfiguration = async ({
  * - bulk initializes all applications
  */
 export const initializeApplications = async ({
-  federation,
   app,
   configStore,
   router,
   appProviderService,
   appProviderApps
 }: {
-  federation: ModuleFederation
   app: App
   configStore: ConfigStore
   router: Router
@@ -245,7 +242,6 @@ export const initializeApplications = async ({
     applicationResponses = await Promise.allSettled(
       appProviderService.appNames.map((appName) =>
         loadApplication({
-          federation,
           appName,
           applicationKey: `web-app-external-${appName}`,
           applicationPath: 'web-app-external',
@@ -266,7 +262,6 @@ export const initializeApplications = async ({
     applicationResponses = await Promise.allSettled(
       rawApplications.map((rawApplication) =>
         loadApplication({
-          federation,
           applicationKey: rawApplication.path,
           applicationPath: rawApplication.path,
           applicationConfig: rawApplication.config || {},

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -3,8 +3,6 @@ import { router } from './router'
 import { abilitiesPlugin } from '@casl/vue'
 import { createMongoAbility } from '@casl/ability'
 
-import { ModuleFederation } from '@module-federation/runtime'
-import { registerSharedModules } from './container/application'
 import {
   announceConfiguration,
   initializeApplications,
@@ -89,8 +87,6 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
     clientService
   })
 
-  const federation = new ModuleFederation({ name: 'opencloud-web', remotes: [] })
-  registerSharedModules(federation)
   announceLoadingService({ app })
   announceArchiverService({ app, configStore, userStore, capabilityStore })
   announcePreviewService({
@@ -107,7 +103,6 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
     loadCustomTranslations({ configStore }),
     announceTheme({ app, designSystem, configStore }),
     initializeApplications({
-      federation,
       app,
       configStore,
       router,
@@ -122,7 +117,6 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
   // Reason: the `external` app serves as a blueprint for creating the app provider apps.
   if (applicationStore.has('web-app-external')) {
     await initializeApplications({
-      federation,
       app,
       configStore,
       router,

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -19,7 +19,6 @@ import {
 } from '../../../src/container/bootstrap'
 import { buildApplication, loadApplication } from '../../../src/container/application'
 import { createTestingPinia, mockAxiosResolve } from '@opencloud-eu/web-test-helpers'
-import type { ModuleFederation } from '@module-federation/runtime'
 
 vi.mock('../../../src/container/application')
 
@@ -64,7 +63,6 @@ describe('initialize applications', () => {
     ]
 
     const applications = await initializeApplications({
-      federation: mock<ModuleFederation>(),
       app: createApp(defineComponent({})),
       configStore,
       router: undefined,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-7.1`:
 - [Merge pull request #2768 from opencloud-eu/feat/isolated-module-federation-scopes](https://github.com/opencloud-eu/web/pull/2768)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)