### PR TITLE
🎉 Release 7.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@JammingBen
+@AlexAndBear, @JammingBen
 
 ### 🐛 Bug Fixes
 
+- [stable-7.1] fix (tiptap): don't render html files via html strategy (#2774) [[#2776](https://github.com/opencloud-eu/web/pull/2776)]
 - fix: isolate module federation shared scope per app [[#2770](https://github.com/opencloud-eu/web/pull/2770)]
 
 ## [7.1.2](https://github.com/opencloud-eu/web/releases/tag/v7.1.2) - 2026-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [7.1.3](https://github.com/opencloud-eu/web/releases/tag/v7.1.3) - 2026-06-30
+
+### ❤️ Thanks to all contributors! ❤️
+
+@JammingBen
+
+### 🐛 Bug Fixes
+
+- fix: isolate module federation shared scope per app [[#2770](https://github.com/opencloud-eu/web/pull/2770)]
+
 ## [7.1.2](https://github.com/opencloud-eu/web/releases/tag/v7.1.2) - 2026-06-24
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@AlexAndBear, @JammingBen
+@AlexAndBear, @JammingBen, @kulmann
 
 ### 🐛 Bug Fixes
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `7.1.3` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-7.1` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [7.1.3](https://github.com/opencloud-eu/web/releases/tag/v7.1.3) - 2026-06-30

### 🐛 Bug Fixes

- [stable-7.1] fix (tiptap): don't render html files via html strategy (#2774) [[#2776](https://github.com/opencloud-eu/web/pull/2776)]
- fix: isolate module federation shared scope per app [[#2770](https://github.com/opencloud-eu/web/pull/2770)]