### PR TITLE
fix: align inline search inputs & a11y

### DIFF
--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -12,6 +12,7 @@
         :aria-label="label"
         :disabled="loading"
         :placeholder="placeholder"
+        type="search"
         @keydown.enter="onSearch"
         @keyup="$emit('keyup', $event)"
       />
@@ -132,6 +133,11 @@ export interface Props {
    */
   cancelButtonColorRole?: OcButtonProps['colorRole']
   /**
+   * @docs Determines if the search bar should have rounded corners.
+   * @default true
+   */
+  isRounded?: boolean
+  /**
    * @docs The handler for the cancel button.
    */
   cancelHandler?: () => void
@@ -176,6 +182,7 @@ const {
   showCancelButton = false,
   cancelButtonAppearance = 'raw',
   cancelButtonColorRole = 'secondary',
+  isRounded = true,
   cancelHandler = () => {}
 } = defineProps<Props>()
 
@@ -196,8 +203,6 @@ const inputClass = computed(() => {
   const classes = [
     'oc-search-input',
     'oc-input',
-    'p-4',
-    'rounded-4xl',
     'disabled:cursor-not-allowed',
     'focus:bg-none',
     'focus:outline focus:outline-offset-2 focus:outline-white'
@@ -208,7 +213,10 @@ const inputClass = computed(() => {
   if (small) {
     classes.push(...['leading-7', 'h-8'])
   } else {
-    classes.push('h-10')
+    classes.push('h-9')
+  }
+  if (isRounded) {
+    classes.push(...['rounded-4xl', 'p-4'])
   }
   return classes
 })
@@ -229,3 +237,11 @@ const onCancel = () => {
   cancelHandler()
 }
 </script>
+
+<style scoped>
+[type='search']::-webkit-search-cancel-button,
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+</style>

--- a/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="group-filters flex justify-end flex-wrap items-end mx-4 mb-4">
-    <oc-text-input
-      id="groups-filter"
+    <oc-search-bar
       v-model="filterTerm"
       class="w-3xs"
       :label="$gettext('Search')"
-      autocomplete="off"
+      :placeholder="$gettext('Search for groups')"
+      button-hidden
+      :is-rounded="false"
     />
   </div>
   <no-content-message

--- a/packages/web-app-admin-settings/src/components/Groups/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/SideBar/MembersPanel.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="ml-2">
-    <oc-text-input v-model="filterTerm" class="mr-2 mt-4" :label="$gettext('Filter members')" />
+    <oc-search-bar
+      v-model="filterTerm"
+      class="mr-2 mt-4"
+      :label="$gettext('Filter members')"
+      :placeholder="$gettext('Search for members')"
+      button-hidden
+      :is-rounded="false"
+    />
     <div ref="membersListRef" data-testid="space-members">
       <div v-if="!filteredGroupMembers.length">
         <h3 class="font-semibold text-base" v-text="$gettext('No members found')" />

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="ml-2">
-    <oc-text-input v-model="filterTerm" class="mr-2 mt-4" :label="$gettext('Filter members')" />
+    <oc-search-bar
+      v-model="filterTerm"
+      class="mr-2 mt-4"
+      :label="$gettext('Filter members')"
+      :placeholder="$gettext('Search for members')"
+      button-hidden
+      :is-rounded="false"
+    />
     <div ref="membersListRef" data-testid="space-members">
       <div v-if="!filteredPermissions.length">
         <h3 class="font-semibold text-base" v-text="$gettext('No members found')" />

--- a/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="space-filters flex justify-end flex-wrap items-end mx-4 mb-4">
-    <oc-text-input
-      id="spaces-filter"
+    <oc-search-bar
       v-model="filterTerm"
       class="w-3xs"
       :label="$gettext('Search')"
-      autocomplete="off"
+      :placeholder="$gettext('Search for spaces')"
+      button-hidden
+      :is-rounded="false"
     />
   </div>
   <no-content-message

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -78,24 +78,21 @@
             </item-filter>
           </div>
           <div class="flex items-center">
-            <oc-text-input
-              id="users-filter"
-              v-model.trim="filterTermDisplayName"
+            <oc-search-bar
+              v-model="filterTermDisplayName"
               class="w-3xs"
               :label="$gettext('Search')"
-              autocomplete="off"
-              @keypress.enter="filterDisplayName"
+              :placeholder="$gettext('Search for users')"
+              :is-rounded="false"
+              button-hidden
+              @search="
+                (term) => {
+                  filterTermDisplayName = term
+                  filterDisplayName()
+                }
+              "
+              @advanced-search="filterDisplayName"
             />
-            <oc-button
-              id="users-filter-confirm"
-              v-oc-tooltip="$gettext('Search')"
-              class="ml-1 p-1 mt-5"
-              appearance="raw"
-              :aria-label="$gettext('Search users')"
-              @click="filterDisplayName"
-            >
-              <oc-icon name="search" fill-type="line" aria-hidden="true" />
-            </oc-button>
           </div>
         </template>
         <template #noResults>
@@ -225,7 +222,7 @@ export default defineComponent({
     const sideBarLoading = ref(false)
     const template = useTemplateRef<ComponentPublicInstance<typeof AppTemplate>>('template')
     const displayNameQuery = useRouteQuery('q_displayName')
-    const filterTermDisplayName = ref(queryItemAsString(unref(displayNameQuery)))
+    const filterTermDisplayName = ref(queryItemAsString(unref(displayNameQuery)) || '')
 
     let editQuotaActionEventToken: string
 

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/__snapshots__/MembersPanel.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/__snapshots__/MembersPanel.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MembersPanel > should display an empty result if no matching members found 1`] = `
 "<div class="ml-2">
-  <oc-text-input-stub label="Filter members" id="oc-textinput-3" type="text" modelvalue="no-match" clearbuttonenabled="false" clearbuttonaccessiblelabel="" disabled="false" inlinelabel="false" errormessagedebouncedtime="500" fixmessageline="false" readonly="false" requiredmark="false" passwordpolicy="[object Object]" hasborder="true" class="mr-2 mt-4"></oc-text-input-stub>
+  <oc-search-bar-stub label="Filter members" icon="search" placeholder="Search for members" small="false" buttonlabel="Search" buttonhidden="true" typeahead="false" trimquery="true" loading="false" isfilter="false" loadingaccessiblelabel="" showcancelbutton="false" cancelbuttonappearance="raw" cancelbuttoncolorrole="secondary" isrounded="false" cancelhandler="[Function]" modelvalue="no-match" class="mr-2 mt-4"></oc-search-bar-stub>
   <div data-testid="space-members">
     <div>
       <h3 class="font-semibold text-base">No members found</h3>
@@ -14,7 +14,7 @@ exports[`MembersPanel > should display an empty result if no matching members fo
 
 exports[`MembersPanel > should render all members accordingly to their role assignments 1`] = `
 "<div class="ml-2">
-  <oc-text-input-stub label="Filter members" id="oc-textinput-1" type="text" modelvalue="" clearbuttonenabled="false" clearbuttonaccessiblelabel="" disabled="false" inlinelabel="false" errormessagedebouncedtime="500" fixmessageline="false" readonly="false" requiredmark="false" passwordpolicy="[object Object]" hasborder="true" class="mr-2 mt-4"></oc-text-input-stub>
+  <oc-search-bar-stub label="Filter members" icon="search" placeholder="Search for members" small="false" buttonlabel="Search" buttonhidden="true" typeahead="false" trimquery="true" loading="false" isfilter="false" loadingaccessiblelabel="" showcancelbutton="false" cancelbuttonappearance="raw" cancelbuttoncolorrole="secondary" isrounded="false" cancelhandler="[Function]" modelvalue="" class="mr-2 mt-4"></oc-search-bar-stub>
   <div data-testid="space-members">
     <!--v-if-->
     <div class="mb-4" data-testid="group-members">

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
@@ -66,7 +66,7 @@ function getWrapper({ spaceResource = spaceMock } = {}) {
   return {
     wrapper: shallowMount(MembersPanel, {
       global: {
-        stubs: { OcTextInput: false },
+        stubs: { OcSearchBar: false },
         plugins: [...defaultPlugins({ piniaOptions: { sharesState: { graphRoles } } })],
         provide: { resource: spaceResource }
       }

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/__snapshots__/MembersPanel.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/__snapshots__/MembersPanel.spec.ts.snap
@@ -2,15 +2,14 @@
 
 exports[`MembersPanel > should display an empty result if no matching members found 1`] = `
 "<div class="ml-2">
-  <div class="mr-2 mt-4"><label class="inline-block mb-0.5" for="oc-textinput-3">Filter members
-      <!--v-if-->
-    </label>
-    <div class="relative">
-      <!--v-if--> <input id="oc-textinput-3" aria-invalid="false" class="oc-text-input oc-input h-9" type="text" teleport-id="v-0" value="no-match">
-      <!--v-if-->
+  <div data-v-8440503a="" role="search" class="oc-search flex items-center mr-2 mt-4">
+    <div data-v-8440503a="" class="flex-1 relative"><input data-v-8440503a="" id="search-input-v-0" class="oc-search-input oc-input disabled:cursor-not-allowed focus:bg-none focus:outline focus:outline-offset-2 focus:outline-white h-9" aria-label="Filter members" placeholder="Search for members" type="search">
+      <oc-button-stub data-v-8440503a="" arialabel="Search" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="true" class="absolute top-[50%] transform-[translateY(-50%)] right-0 mx-4 mb-4 mt-0"></oc-button-stub>
+    </div>
+    <div data-v-8440503a="" class="oc-search-button-wrapper sr-only">
+      <oc-button-stub data-v-8440503a="" appearance="filled" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" class="oc-search-button z-0 ml-4 rounded-l-none transform-[translateX(-1px)]"></oc-button-stub>
     </div>
     <!--v-if-->
-    <div id="v-0"></div>
   </div>
   <div data-testid="space-members">
     <div>
@@ -32,15 +31,14 @@ exports[`MembersPanel > should display an empty result if no matching members fo
 
 exports[`MembersPanel > should render all members accordingly to their role assignments 1`] = `
 "<div class="ml-2">
-  <div class="mr-2 mt-4"><label class="inline-block mb-0.5" for="oc-textinput-1">Filter members
-      <!--v-if-->
-    </label>
-    <div class="relative">
-      <!--v-if--> <input id="oc-textinput-1" aria-invalid="false" class="oc-text-input oc-input h-9" type="text" teleport-id="v-0" value="">
-      <!--v-if-->
+  <div data-v-8440503a="" role="search" class="oc-search flex items-center mr-2 mt-4">
+    <div data-v-8440503a="" class="flex-1 relative"><input data-v-8440503a="" id="search-input-v-0" class="oc-search-input oc-input disabled:cursor-not-allowed focus:bg-none focus:outline focus:outline-offset-2 focus:outline-white h-9" aria-label="Filter members" placeholder="Search for members" type="search">
+      <oc-button-stub data-v-8440503a="" arialabel="Search" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="true" class="absolute top-[50%] transform-[translateY(-50%)] right-0 mx-4 mb-4 mt-0"></oc-button-stub>
+    </div>
+    <div data-v-8440503a="" class="oc-search-button-wrapper sr-only">
+      <oc-button-stub data-v-8440503a="" appearance="filled" colorrole="secondary" disabled="true" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" class="oc-search-button z-0 ml-4 rounded-l-none transform-[translateX(-1px)]"></oc-button-stub>
     </div>
     <!--v-if-->
-    <div id="v-0"></div>
   </div>
   <div data-testid="space-members">
     <!--v-if-->

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -2,15 +2,24 @@
 
 exports[`SpacesList > should render all spaces in a table 1`] = `
 "<div class="space-filters flex justify-end flex-wrap items-end mx-4 mb-4">
-  <div class="w-3xs"><label class="inline-block mb-0.5" for="spaces-filter">Search
-      <!--v-if-->
-    </label>
-    <div class="relative">
-      <!--v-if--> <input id="spaces-filter" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input h-9" type="text" teleport-id="v-0" value="">
-      <!--v-if-->
-    </div>
+  <div data-v-8440503a="" role="search" class="oc-search flex items-center w-3xs">
+    <div data-v-8440503a="" class="flex-1 relative"><input data-v-8440503a="" id="search-input-v-0" class="oc-search-input oc-input disabled:cursor-not-allowed focus:bg-none focus:outline focus:outline-offset-2 focus:outline-white h-9" aria-label="Search" placeholder="Search for spaces" type="search"> <button data-v-8440503a="" type="button" aria-label="Search" class="oc-button-secondary oc-button-raw oc-button-secondary-raw gap-2 justify-center text-base min-h-4 no-hover oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default absolute top-[50%] transform-[translateY(-50%)] right-0 mx-4 mb-4 mt-0">
+        <!--v-if-->
+        <!-- @slot Content of the button --> <span data-v-8440503a="" class="oc-icon box-content inline-block align-baseline [&amp;_svg]:block size-4"><svg data-testid="inline-svg-stub" src="icons/search-line.svg" transform-source="(svg) => {
+			if (__props.accessibleLabel !== &quot;&quot;) {
+				const title = document.createElement(&quot;title&quot;);
+				title.setAttribute(&quot;id&quot;, svgTitleId.value);
+				title.appendChild(document.createTextNode(__props.accessibleLabel));
+				svg.insertBefore(title, svg.firstChild);
+			};
+			return svg;
+		}" aria-hidden="true" focusable="false" class="size-4"></svg></span> <span data-v-8440503a="" class="oc-spinner inline-block after:block after:bg-transparent after:border after:border-current after:rounded-full after:size-full relative after:relative animate-spin after:content-[''] after:border-b-transparent size-5" aria-label="Loading results" aria-live="polite" tabindex="-1" role="img" style="display: none;"></span>
+      </button></div>
+    <div data-v-8440503a="" class="oc-search-button-wrapper sr-only"><button data-v-8440503a="" type="button" disabled="" class="oc-button-secondary oc-button-filled oc-button-secondary-filled gap-2 justify-center text-base min-h-4 oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default oc-search-button z-0 ml-4 rounded-l-none transform-[translateX(-1px)]">
+        <!--v-if-->
+        <!-- @slot Content of the button --> Search
+      </button></div>
     <!--v-if-->
-    <div id="v-0"></div>
   </div>
 </div>
 

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -25,17 +25,15 @@ exports[`Users view > list view > renders initially warning if filters are manda
             <item-filter-stub filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
           </div>
           <div class="flex items-center">
-            <div class="w-3xs"><label class="inline-block mb-0.5" for="users-filter">Search
-                <!--v-if-->
-              </label>
-              <div class="relative">
-                <!--v-if--> <input id="users-filter" modelmodifiers="[object Object]" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input h-9" type="text" teleport-id="v-0">
-                <!--v-if-->
+            <div data-v-8440503a="" role="search" class="oc-search flex items-center w-3xs">
+              <div data-v-8440503a="" class="flex-1 relative"><input data-v-8440503a="" id="search-input-v-0" class="oc-search-input oc-input disabled:cursor-not-allowed focus:bg-none focus:outline focus:outline-offset-2 focus:outline-white h-9" aria-label="Search" placeholder="Search for users" type="search">
+                <oc-button-stub data-v-8440503a="" arialabel="Search" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="true" class="absolute top-[50%] transform-[translateY(-50%)] right-0 mx-4 mb-4 mt-0"></oc-button-stub>
+              </div>
+              <div data-v-8440503a="" class="oc-search-button-wrapper sr-only">
+                <oc-button-stub data-v-8440503a="" appearance="filled" colorrole="secondary" disabled="true" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" class="oc-search-button z-0 ml-4 rounded-l-none transform-[translateX(-1px)]"></oc-button-stub>
               </div>
               <!--v-if-->
-              <div id="v-0"></div>
             </div>
-            <oc-button-stub arialabel="Search users" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" id="users-filter-confirm" class="ml-1 p-1 mt-5"></oc-button-stub>
           </div>
         </div>
         <no-content-message-stub icon="" iconfilltype="fill" imgsrc="/images/empty-states/empty-users.svg"></no-content-message-stub>
@@ -71,17 +69,15 @@ exports[`Users view > list view > renders list initially 1`] = `
             <item-filter-stub filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
           </div>
           <div class="flex items-center">
-            <div class="w-3xs"><label class="inline-block mb-0.5" for="users-filter">Search
-                <!--v-if-->
-              </label>
-              <div class="relative">
-                <!--v-if--> <input id="users-filter" modelmodifiers="[object Object]" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input h-9" type="text" teleport-id="v-0">
-                <!--v-if-->
+            <div data-v-8440503a="" role="search" class="oc-search flex items-center w-3xs">
+              <div data-v-8440503a="" class="flex-1 relative"><input data-v-8440503a="" id="search-input-v-0" class="oc-search-input oc-input disabled:cursor-not-allowed focus:bg-none focus:outline focus:outline-offset-2 focus:outline-white h-9" aria-label="Search" placeholder="Search for users" type="search">
+                <oc-button-stub data-v-8440503a="" arialabel="Search" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="true" class="absolute top-[50%] transform-[translateY(-50%)] right-0 mx-4 mb-4 mt-0"></oc-button-stub>
+              </div>
+              <div data-v-8440503a="" class="oc-search-button-wrapper sr-only">
+                <oc-button-stub data-v-8440503a="" appearance="filled" colorrole="secondary" disabled="true" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" class="oc-search-button z-0 ml-4 rounded-l-none transform-[translateX(-1px)]"></oc-button-stub>
               </div>
               <!--v-if-->
-              <div id="v-0"></div>
             </div>
-            <oc-button-stub arialabel="Search users" appearance="raw" colorrole="secondary" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" nohover="false" id="users-filter-confirm" class="ml-1 p-1 mt-5"></oc-button-stub>
           </div>
         </div>
         <table data-v-3c9ab66c="" class="oc-table oc-table-hover oc-table-sticky has-item-context-menu users-table">

--- a/packages/web-app-app-store/src/views/AppList.vue
+++ b/packages/web-app-app-store/src/views/AppList.vue
@@ -5,12 +5,13 @@
       <app-contextual-helper />
     </h1>
     <div class="flex items-center mb-4">
-      <oc-text-input
-        id="apps-filter"
+      <oc-search-bar
+        class="apps-filter"
         :model-value="filterTermInput"
         :label="$gettext('Search')"
-        :clear-button-enabled="true"
-        autocomplete="off"
+        :placeholder="$gettext('Search for apps')"
+        button-hidden
+        :is-rounded="false"
         @update:model-value="setFilterTerm"
       />
     </div>

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -53,11 +53,13 @@
             </item-filter>
           </div>
           <div>
-            <oc-text-input
+            <oc-search-bar
               v-model="filterTerm"
               class="search-filter w-3xs"
               :label="$gettext('Search')"
-              autocomplete="off"
+              :placeholder="$gettext('Search for shares')"
+              button-hidden
+              :is-rounded="false"
             />
           </div>
         </div>

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -35,12 +35,13 @@
         </no-content-message>
         <template v-else>
           <div class="flex justify-end flex-wrap items-end mx-4 mb-4">
-            <oc-text-input
-              id="spaces-filter"
+            <oc-search-bar
               v-model="filterTerm"
               class="w-3xs"
               :label="$gettext('Search')"
-              autocomplete="off"
+              :placeholder="$gettext('Search for spaces')"
+              button-hidden
+              :is-rounded="false"
             />
           </div>
           <no-content-message

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -18,12 +18,13 @@
         </no-content-message>
         <template v-else>
           <div class="flex justify-end flex-wrap items-end mx-4 mb-4">
-            <oc-text-input
-              id="trash-filter"
+            <oc-search-bar
               v-model="filterTerm"
               class="w-3xs"
               :label="$gettext('Search')"
-              autocomplete="off"
+              :placeholder="$gettext('Search for spaces')"
+              button-hidden
+              :is-rounded="false"
             />
           </div>
           <no-content-message

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
@@ -38,11 +38,11 @@ describe('SharedWithMe view', () => {
   describe('different files view states', () => {
     it('shows the loading spinner during loading', () => {
       const { wrapper } = getMountedWrapper({ loading: true })
-      expect(wrapper.find('oc-spinner-stub').exists()).toBeTruthy()
+      expect(wrapper.find('app-loading-spinner-stub').exists()).toBeTruthy()
     })
     it('does not show the loading spinner after loading finished', () => {
       const { wrapper } = getMountedWrapper()
-      expect(wrapper.find('oc-spinner-stub').exists()).toBeFalsy()
+      expect(wrapper.find('app-loading-spinner-stub').exists()).toBeFalsy()
     })
   })
   describe('open with default app', () => {
@@ -206,7 +206,12 @@ function getMountedWrapper({
       global: {
         plugins,
         mocks: defaultMocks,
-        stubs: { ...defaultStubs, itemFilterInline: true, ItemFilter: true }
+        stubs: {
+          ...defaultStubs,
+          itemFilterInline: true,
+          ItemFilter: true,
+          AppLoadingSpinner: true
+        }
       }
     })
   }

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
@@ -6,15 +6,25 @@ exports[`Projects view > different files view states > lists all available proje
     <div id="files-view" class="outline-0 z-0 flex flex-col">
       <app-bar-stub viewmodedefault="resource-tiles" breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" viewmodes="[object Object]" hasbulkactions="true" hasviewoptions="true" hashiddenfiles="false" hasfileextensions="false" haspagination="false" showactionsonselection="true" batchactionsloading="false"></app-bar-stub>
       <div class="flex justify-end flex-wrap items-end mx-4 mb-4">
-        <div class="w-3xs"><label class="inline-block mb-0.5" for="spaces-filter">Search
-            <!--v-if-->
-          </label>
-          <div class="relative">
-            <!--v-if--> <input id="spaces-filter" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input h-9" type="text" teleport-id="v-0" value="">
-            <!--v-if-->
-          </div>
+        <div data-v-8440503a="" role="search" class="oc-search flex items-center w-3xs">
+          <div data-v-8440503a="" class="flex-1 relative"><input data-v-8440503a="" id="search-input-v-0" class="oc-search-input oc-input disabled:cursor-not-allowed focus:bg-none focus:outline focus:outline-offset-2 focus:outline-white h-9" aria-label="Search" placeholder="Search for spaces" type="search"> <button data-v-8440503a="" type="button" aria-label="Search" class="oc-button-secondary oc-button-raw oc-button-secondary-raw gap-2 justify-center text-base min-h-4 no-hover oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default absolute top-[50%] transform-[translateY(-50%)] right-0 mx-4 mb-4 mt-0">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span data-v-8440503a="" class="oc-icon box-content inline-block align-baseline [&amp;_svg]:block size-4"><svg data-testid="inline-svg-stub" src="icons/search-line.svg" transform-source="(svg) => {
+			if (__props.accessibleLabel !== &quot;&quot;) {
+				const title = document.createElement(&quot;title&quot;);
+				title.setAttribute(&quot;id&quot;, svgTitleId.value);
+				title.appendChild(document.createTextNode(__props.accessibleLabel));
+				svg.insertBefore(title, svg.firstChild);
+			};
+			return svg;
+		}" aria-hidden="true" focusable="false" class="size-4"></svg></span>
+              <oc-spinner-stub data-v-8440503a="" arialabel="Loading results" size="medium" style="display: none;"></oc-spinner-stub>
+            </button></div>
+          <div data-v-8440503a="" class="oc-search-button-wrapper sr-only"><button data-v-8440503a="" type="button" disabled="" class="oc-button-secondary oc-button-filled oc-button-secondary-filled gap-2 justify-center text-base min-h-4 oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default oc-search-button z-0 ml-4 rounded-l-none transform-[translateX(-1px)]">
+              <!--v-if-->
+              <!-- @slot Content of the button --> Search
+            </button></div>
           <!--v-if-->
-          <div id="v-0"></div>
         </div>
       </div>
       <table data-v-3c9ab66c="" class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table" sort-fields="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" view-size="1" id="files-space-table" selection="">

--- a/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
@@ -6,15 +6,25 @@ exports[`TrashOverview > view states > should render trash list 1`] = `
     <div id="files-view" class="outline-0 z-0 flex flex-col">
       <app-bar-stub viewmodedefault="resource-tiles" breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" viewmodes="[object Object]" hasbulkactions="false" hasviewoptions="true" hashiddenfiles="false" hasfileextensions="false" haspagination="false" showactionsonselection="false" batchactionsloading="false"></app-bar-stub>
       <div class="flex justify-end flex-wrap items-end mx-4 mb-4">
-        <div class="w-3xs"><label class="inline-block mb-0.5" for="trash-filter">Search
-            <!--v-if-->
-          </label>
-          <div class="relative">
-            <!--v-if--> <input id="trash-filter" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input h-9" type="text" teleport-id="v-0" value="">
-            <!--v-if-->
-          </div>
+        <div data-v-8440503a="" role="search" class="oc-search flex items-center w-3xs">
+          <div data-v-8440503a="" class="flex-1 relative"><input data-v-8440503a="" id="search-input-v-0" class="oc-search-input oc-input disabled:cursor-not-allowed focus:bg-none focus:outline focus:outline-offset-2 focus:outline-white h-9" aria-label="Search" placeholder="Search for spaces" type="search"> <button data-v-8440503a="" type="button" aria-label="Search" class="oc-button-secondary oc-button-raw oc-button-secondary-raw gap-2 justify-center text-base min-h-4 no-hover oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default absolute top-[50%] transform-[translateY(-50%)] right-0 mx-4 mb-4 mt-0">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span data-v-8440503a="" class="oc-icon box-content inline-block align-baseline [&amp;_svg]:block size-4"><svg data-testid="inline-svg-stub" src="icons/search-line.svg" transform-source="(svg) => {
+			if (__props.accessibleLabel !== &quot;&quot;) {
+				const title = document.createElement(&quot;title&quot;);
+				title.setAttribute(&quot;id&quot;, svgTitleId.value);
+				title.appendChild(document.createTextNode(__props.accessibleLabel));
+				svg.insertBefore(title, svg.firstChild);
+			};
+			return svg;
+		}" aria-hidden="true" focusable="false" class="size-4"></svg></span>
+              <oc-spinner-stub data-v-8440503a="" arialabel="Loading results" size="medium" style="display: none;"></oc-spinner-stub>
+            </button></div>
+          <div data-v-8440503a="" class="oc-search-button-wrapper sr-only"><button data-v-8440503a="" type="button" disabled="" class="oc-button-secondary oc-button-filled oc-button-secondary-filled gap-2 justify-center text-base min-h-4 oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default oc-search-button z-0 ml-4 rounded-l-none transform-[translateX(-1px)]">
+              <!--v-if-->
+              <!-- @slot Content of the button --> Search
+            </button></div>
           <!--v-if-->
-          <div id="v-0"></div>
         </div>
       </div>
       <resource-table-stub resources="[object Object],[object Object],[object Object]" resourcedomselector="[Function]" arepathsdisplayed="false" selectedids="" hasactions="true" showrenamequickaction="false" areresourcesclickable="true" headerposition="0" isselectable="false" dragdrop="false" viewmode="resource-table" hover="true" sortby="name" fieldsdisplayed="name" sortdir="asc" resourcetype="file" lazy="true" class="trash-table" sort-fields="" are-thumbnails-displayed="false" view-size="1"></resource-table-stub>

--- a/packages/web-app-ocm/src/views/Wayf.vue
+++ b/packages/web-app-ocm/src/views/Wayf.vue
@@ -54,18 +54,14 @@
         <div v-else class="flex-1 grid grid-rows-[auto_1fr_auto] min-h-0">
           <!-- Search Section -->
           <div class="px-4 pb-2 border-b shrink-0 overflow-hidden min-h-[80px]">
-            <oc-text-input
-              id="wayf-search"
+            <oc-search-bar
               v-model="query"
               :label="$gettext('Search providers')"
-              type="text"
-              name="search"
+              :placeholder="$gettext('Search providers')"
               class="mb-2"
-            >
-              <template #icon>
-                <oc-icon name="magnify" size="medium" />
-              </template>
-            </oc-text-input>
+              button-hidden
+              :is-rounded="false"
+            />
           </div>
 
           <!-- Empty State (no federations or no matches) -->

--- a/tests/e2e/support/objects/app-store/actions.ts
+++ b/tests/e2e/support/objects/app-store/actions.ts
@@ -12,7 +12,7 @@ const selectors = {
   selectAppTitle: '//a[contains(.,"%s")]',
   appDetailsBack: '.app-details-back',
   appDetailsTitle: '//h2[contains(@class, "app-details-title")][text()="%s"]',
-  appsFilter: '#apps-filter',
+  appsFilter: '.apps-filter input',
   tag: '//button[contains(@class,"oc-tag")][span[text()="%s"]]',
   appTag: '//a[contains(.,"%s")]/following::button[contains(@class,"oc-tag")][span[text()="%s"]]'
 }


### PR DESCRIPTION
Visually align inline search inputs to look the same across the page (and with other, regular input fields) and add `type="search"` to be a11y compliant.