### PR TITLE
[stable-7.1] fix (tiptap): don't render html files via html strategy (#2774)

### DIFF
--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -46,9 +46,7 @@ const parsedContentType = computed<ContentType>(() => {
   if (ext === 'md' || ext === 'markdown' || mimeType === 'text/markdown') {
     return 'markdown'
   }
-  if (ext === 'html' || ext === 'htm' || mimeType === 'text/html') {
-    return 'html'
-  }
+
   return 'plain-text'
 })
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-7.1`:
 - [fix (tiptap): don't render html files via html strategy (#2774)](https://github.com/opencloud-eu/web/pull/2774)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)