### PR TITLE
fix(design-system): fix docs build under vitepress' vite 5

### DIFF
--- a/packages/design-system/docs/.vitepress/config.ts
+++ b/packages/design-system/docs/.vitepress/config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
             }
           ]
         })()
-      }) as any // FIXME: remove type cast once vitepress uses vite 6
+      }) as any // FIXME: remove type cast and the vite-plugin-static-copy patch once vitepress uses vite 6
     ]
   },
   themeConfig: {

--- a/patches/vite-plugin-static-copy@4.1.1.patch
+++ b/patches/vite-plugin-static-copy@4.1.1.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.js b/dist/index.js
+index 5bb53d64957e72328f7b91fdad6da61aa05af0b8..cbf31b5276aba03e405015c567e58d01f84c7f7c 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1069,7 +1069,7 @@ const buildPlugin = ({ targets, silent, hook, environment }) => {
+ 			if (this.environment && this.environment.name !== environment) return;
+ 			if (output) return;
+ 			output = true;
+-			const result = await copyAll(config.root, this.environment.config.build.outDir, targets, silent);
++			const result = await copyAll(config.root, this.environment?.config.build.outDir ?? config.build.outDir, targets, silent);
+ 			if (!silent) outputCopyLog(config.logger, result);
+ 		}
+ 	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
 
 patchedDependencies:
   caf@15.0.1: b09bdde8a1f7e834af8677123b32ceb4f485966fdb476facf5b6c64157c9fc14
+  vite-plugin-static-copy@4.1.1: b4b816bcbbbd46a52560de210fc39a55df2f65d64cc8b1ac8dcc6e097258ad1c
   vue-inline-svg@4.0.1: 29bc386a6e932912ee46485a87911f6ff5409dca9ed70ba0ff32c52d6f56986b
 
 importers:
@@ -132,7 +133,7 @@ importers:
         version: 0.28.0(rollup@4.60.0)(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: ^4.0.0
-        version: 4.1.1(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
+        version: 4.1.1(patch_hash=b4b816bcbbbd46a52560de210fc39a55df2f65d64cc8b1ac8dcc6e097258ad1c)(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.2
         version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
@@ -278,7 +279,7 @@ importers:
     devDependencies:
       vite-plugin-static-copy:
         specifier: ^4.0.0
-        version: 4.1.1(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
+        version: 4.1.1(patch_hash=b4b816bcbbbd46a52560de210fc39a55df2f65d64cc8b1ac8dcc6e097258ad1c)(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
 
   packages/prettier-config:
     dependencies:
@@ -9146,7 +9147,7 @@ snapshots:
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.2
-      semver: 7.8.5
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -10161,7 +10162,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-static-copy@4.1.1(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0)):
+  vite-plugin-static-copy@4.1.1(patch_hash=b4b816bcbbbd46a52560de210fc39a55df2f65d64cc8b1ac8dcc6e097258ad1c)(vite@8.1.2(@types/node@25.9.4)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ allowBuilds:
 
 patchedDependencies:
   caf@15.0.1: patches/caf@15.0.1.patch
+  vite-plugin-static-copy@4.1.1: patches/vite-plugin-static-copy@4.1.1.patch
   vue-inline-svg@4.0.1: patches/vue-inline-svg@4.0.1.patch
 
 overrides:


### PR DESCRIPTION
The design system docs build is currently broken, see: https://ci.opencloud.rocks/repos/6/pipeline/381/58

`vite-plugin-static-copy` v4 reads the build `outDir` via the Vite 6+ Environment API (`this.environment.config.build.outDir`). The design-system docs build runs through VitePress 1.6.4, which bundles Vite 5, where `this.environment` is `undefined`, so the `writeBundle` hook crashed with `"Cannot read properties of undefined (reading 'config')".`

Patch the plugin to fall back to the already-resolved `config.build.outDir` when `this.environment` is absent. Behavior is unchanged under Vite 6+/8.

This patch can be removed as soon as VitePress updates Vite on their side and publish a new version.