### PR TITLE
fix: fixing mailcompose Tiptap toolbar dropdowns

### DIFF
--- a/packages/web-app-mail/src/components/MailComposeForm.vue
+++ b/packages/web-app-mail/src/components/MailComposeForm.vue
@@ -52,7 +52,7 @@
       <div class="mail-body-editor flex flex-col gap-2 h-full min-h-0 flex-1">
         <div class="mail-body-editor-wrapper flex-1 min-h-0" @click="onWrapperClick">
           <TextEditorProvider :editor="textEditor">
-            <TextEditorToolbar />
+            <TextEditorToolbar :teleport="toolbarDropTeleport" />
             <TextEditorContent />
           </TextEditorProvider>
         </div>
@@ -108,8 +108,9 @@ export type ComposeFormState = {
   attachments?: MailComposeAttachment[]
 }
 
-const { modelValue } = defineProps<{
+const { modelValue, toolbarDropTeleport = undefined } = defineProps<{
   modelValue: ComposeFormState
+  toolbarDropTeleport?: string
 }>()
 
 const emit = defineEmits<{

--- a/packages/web-app-mail/src/components/MailWidget.vue
+++ b/packages/web-app-mail/src/components/MailWidget.vue
@@ -33,9 +33,12 @@
 
       <div class="flex flex-col flex-1 min-h-0">
         <div class="flex-1 min-h-0 overflow-auto">
-          <MailComposeForm v-model="composeState" />
+          <MailComposeForm
+            v-model="composeState"
+            :toolbar-drop-teleport="composeToolbarDropTeleport"
+          />
         </div>
-
+        <div :id="composeToolbarDropId" />
         <div class="px-4 pt-3 pb-2">
           <div class="flex items-center justify-start gap-3">
             <oc-button
@@ -83,9 +86,12 @@
     <template #content>
       <div class="flex flex-col flex-1 min-h-0">
         <div class="flex-1 min-h-0 overflow-auto">
-          <MailComposeForm v-model="composeState" />
+          <MailComposeForm
+            v-model="composeState"
+            :toolbar-drop-teleport="composeToolbarDropTeleport"
+          />
         </div>
-
+        <div :id="composeToolbarDropId" />
         <div class="px-4 pt-3">
           <div class="flex items-center justify-start gap-3">
             <oc-button
@@ -169,6 +175,9 @@ const selectedIdentityId = computed(() => {
 })
 
 const isExpanded = ref(false)
+
+const composeToolbarDropId = 'mail-compose-toolbar-drop'
+const composeToolbarDropTeleport = `#${composeToolbarDropId}`
 
 const { showSavedHint, flashSavedHint, clearSavedHint } = useSavedHint(SAVED_HINT_DURATION_MS)
 

--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -38,6 +38,7 @@
             <oc-drop
               :drop-id="`toolbar-dropdown-${item.id}`"
               :toggle="`#toolbar-dropdown-trigger-${item.id}`"
+              :teleport="teleport"
               mode="click"
               class="text-editor-toolbar-dropdown w-auto min-w-40"
               padding-size="small"
@@ -114,6 +115,10 @@
 import { computed, inject, nextTick, onMounted, ref, unref, useTemplateRef } from 'vue'
 import type { TextEditorInstance } from '../types'
 import { EditorAction } from '../composables'
+
+defineProps<{
+  teleport?: string
+}>()
 
 const textEditor = inject<TextEditorInstance>('textEditor')!
 


### PR DESCRIPTION
This fix https://github.com/opencloud-eu/web/issues/2794
Tiptap toolbar dropdowns cannot be opened in MailCompose
