### PR TITLE
fix(e2e): sync singular/plural wording in step tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,13 @@
   "editor.quickSuggestions": {
     "strings": true
   },
-  "cucumberautocomplete.steps": ["tests/e2e/cucumber/steps/**/*.ts"],
+  "cucumberautocomplete.steps": [
+    "tests/e2e/steps/**/*.ts",
+    "tests/e2e/environment/fixtures.ts",
+    "tests/e2e/environment/hooks.ts"
+  ],
   "cucumberautocomplete.strictGherkinCompletion": true,
+  "cucumberautocomplete.pureTextSteps": false,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "vue.server.includeLanguages": ["vue"]
 }

--- a/tests/e2e/features/a11y/smoke.feature
+++ b/tests/e2e/features/a11y/smoke.feature
@@ -6,7 +6,7 @@ Feature: Accessibility checks
       | id    |
       | Alice |
       | Brian |
-    And "Admin" creates following groups using API
+    And "Admin" creates following group using API
       | id    |
       | sales |
     And "Admin" assigns following roles to the users using API
@@ -33,10 +33,10 @@ Feature: Accessibility checks
       | localFile       | to              |
       | testavatar.jpeg | testavatar.jpeg |
       | lorem.txt       | lorem.txt       |
-    And "Alice" adds the following tags for the following resources using API
+    And "Alice" adds the following tag for the following resource using API
       | resource        | tags      |
       | testavatar.jpeg | alice tag |
-    And "Alice" shares the following resource using API
+    And "Alice" shares the following resources using API
       | resource | recipient | type  | role     |
       | parent   | Brian     | user  | Can edit |
       | parent   | sales     | group | Can edit |

--- a/tests/e2e/features/admin-settings/groups.feature
+++ b/tests/e2e/features/admin-settings/groups.feature
@@ -8,7 +8,7 @@ Feature: groups management
       | id       |
       | sales    |
       | security |
-    Then "Admin" should see the following group
+    Then "Admin" should see the following groups
       | group    |
       | sales    |
       | security |
@@ -44,7 +44,7 @@ Feature: groups management
     Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" creates following groups using API
+    And "Admin" creates following group using API
       | id    |
       | sales |
     And "Admin" logs in

--- a/tests/e2e/features/admin-settings/spaces.feature
+++ b/tests/e2e/features/admin-settings/spaces.feature
@@ -1,10 +1,10 @@
 Feature: spaces management
 
   Scenario: spaces can be created
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Admin" creates the following project spaces using API
@@ -61,7 +61,7 @@ Feature: spaces management
     Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" creates the following project spaces using API
@@ -120,7 +120,7 @@ Feature: spaces management
       | Carol |
       | David |
       | Edith |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Admin" creates the following project spaces using API

--- a/tests/e2e/features/admin-settings/users.feature
+++ b/tests/e2e/features/admin-settings/users.feature
@@ -71,7 +71,7 @@ Feature: users management
       | Alice |
       | Brian |
     When "Admin" reloads the page
-    Then "Admin" should see the following users
+    Then "Admin" should see the following user
       | user  |
       | Carol |
     And "Admin" should not see the following users
@@ -147,7 +147,7 @@ Feature: users management
       | Alice |
       | Brian |
       | Carol |
-    And "Admin" should not see the following users
+    And "Admin" should not see the following user
       | user  |
       | David |
     When "Admin" deletes the following users using the batch actions

--- a/tests/e2e/features/app-provider-euro-office/officeSuites.feature
+++ b/tests/e2e/features/app-provider-euro-office/officeSuites.feature
@@ -13,7 +13,7 @@ Feature: Integrate with online office suites using Euro-Office online office
 
 
   Scenario: create a Microsoft Word file with Euro-Office
-    When "Alice" creates the following resources
+    When "Alice" creates the following resource
       | resource           | type           | content                |
       | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
     And "Alice" creates a public link of following resource using the sidebar panel
@@ -76,7 +76,7 @@ Feature: Integrate with online office suites using Euro-Office online office
 
 
   Scenario: public creates a Microsoft Word file with Euro-Office
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" creates the following project space using API
@@ -96,14 +96,14 @@ Feature: Integrate with online office suites using Euro-Office online office
     # public create .docx file using spaceLink
     When "Anonymous" opens the public link "spaceLink"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" creates the following resources
+    And "Anonymous" creates the following resource
       | resource            | type           | content                                                      |
       | usingSpaceLink.docx | Microsoft Word | public can create files in the project space using spaceLink |
 
     # public create .docx file using folderLink
     When "Anonymous" opens the public link "Unnamed link"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" creates the following resources
+    And "Anonymous" creates the following resource
       | resource             | type           | content                |
       | usingFolderLink.docx | Microsoft Word | Microsoft Word Content |
 
@@ -131,7 +131,7 @@ Feature: Integrate with online office suites using Euro-Office online office
     Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "Euro-Office"
     And "Alice" closes the file viewer
 
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource      |
       | Template.docx |
 
@@ -139,7 +139,7 @@ Feature: Integrate with online office suites using Euro-Office online office
     Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "Euro-Office"
 
     When "Alice" closes the file viewer
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource          |
       | Template (1).docx |
 

--- a/tests/e2e/features/app-provider-euro-office/urlJourneys.feature
+++ b/tests/e2e/features/app-provider-euro-office/urlJourneys.feature
@@ -5,11 +5,11 @@ Feature: url stability for mobile and desktop client
 
 
   Scenario: open office suite files with Euro-Office
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
     And "Alice" logs in
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource           | type           | content                |
       | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
     And for "Alice" file "MicrosoftWord.docx" should not be locked

--- a/tests/e2e/features/app-provider/lock.feature
+++ b/tests/e2e/features/app-provider/lock.feature
@@ -12,7 +12,7 @@ Feature: lock
       | Brian |
       | Carol |
     And "Alice" logs in
-    When "Alice" creates the following resources
+    When "Alice" creates the following resource
       | resource | type         | content      |
       | test.odt | OpenDocument | some content |
     And "Alice" shares the following resource using API

--- a/tests/e2e/features/app-provider/officeSuites.feature
+++ b/tests/e2e/features/app-provider/officeSuites.feature
@@ -15,7 +15,7 @@ Feature: Integration with Collabora online office
 
 
   Scenario: create an OpenDocument file with Collabora
-    When "Alice" creates the following resources
+    When "Alice" creates the following resource
       | resource         | type         | content              |
       | OpenDocument.odt | OpenDocument | OpenDocument Content |
     And "Alice" creates a public link of following resource using the sidebar panel
@@ -81,7 +81,7 @@ Feature: Integration with Collabora online office
 
 
   Scenario: public creates a Microsoft Word file with Collabora
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" creates the following project space using API
@@ -101,14 +101,14 @@ Feature: Integration with Collabora online office
     # public create .odt file using spaceLink
     When "Anonymous" opens the public link "spaceLink"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" creates the following resources
+    And "Anonymous" creates the following resource
       | resource           | type         | content                                                      |
       | usingSpaceLink.odt | OpenDocument | public can create files in the project space using spaceLink |
 
     # public create .odt file using folderLink
     When "Anonymous" opens the public link "Unnamed link"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" creates the following resources
+    And "Anonymous" creates the following resource
       | resource            | type         | content              |
       | usingFolderLink.odt | OpenDocument | OpenDocument Content |
 
@@ -136,7 +136,7 @@ Feature: Integration with Collabora online office
     Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "CollaboraOnline"
 
     When "Alice" closes the file viewer
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource      |
       | Template.odt  |
 
@@ -144,14 +144,14 @@ Feature: Integration with Collabora online office
     Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "CollaboraOnline"
 
     When "Alice" closes the file viewer
-    Then following resources should not be displayed in the files list for user "Alice"
+    Then following resource should not be displayed in the files list for user "Alice"
       | resource          |
       | Template (1).docx |
     And "Alice" logs out
 
 
   Scenario: open the file using the context menu
-    Given "Alice" creates the following files into personal space using API
+    Given "Alice" creates the following file into personal space using API
       | pathToFile | content      |
       | new.txt    | test content |
     When "Alice" opens file "new.txt" via "collabora-online" using the context menu

--- a/tests/e2e/features/app-provider/secureView.feature
+++ b/tests/e2e/features/app-provider/secureView.feature
@@ -23,7 +23,7 @@ Feature: Secure view
       | simple.pdf      | shared folder/simple.pdf      |
       | testavatar.jpeg | shared folder/testavatar.jpeg |
       | lorem.txt       | shared folder/lorem.txt       |
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource           | type         | content                 |
       | secureDocument.odt | OpenDocument | very important document |
 
@@ -70,7 +70,7 @@ Feature: Secure view
       | simple.pdf      | shared folder/secure.pdf       |
       | testavatar.jpeg | shared folder/securePhoto.jpeg |
       | lorem.txt       | shared folder/secureFile.txt   |
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource           | type         | content                 |
       | secureDocument.odt | OpenDocument | very important document |
     And "Alice" shares the following resources using the sidebar panel

--- a/tests/e2e/features/app-provider/urlJourneys.feature
+++ b/tests/e2e/features/app-provider/urlJourneys.feature
@@ -8,11 +8,11 @@ Feature: url stability for mobile and desktop client
 
 
   Scenario: open office suite files with Collabora
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
     And "Alice" logs in
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile       | content              |
       | OpenDocument.odt | OpenDocument Content |
 

--- a/tests/e2e/features/embed/embedMode.feature
+++ b/tests/e2e/features/embed/embedMode.feature
@@ -6,7 +6,7 @@ Feature: Embed mode with delegated authentication
 
 
   Scenario: embed mode stays active after delegated authentication
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
     When "Alice" opens the app in embed mode with delegated authentication

--- a/tests/e2e/features/file-action/copyMove.feature
+++ b/tests/e2e/features/file-action/copyMove.feature
@@ -171,21 +171,21 @@ Feature: Copy
     And "Alice" logs in
 
     # copy and move file
-    When "Alice" copies the following resource using sidebar-panel
+    When "Alice" copies the following resources using sidebar-panel
       | resource     | to                  | option    |
       | example1.txt | Personal/folder1   | keep both |
       | example1.txt | Personal/folder1   | replace   |
-    And "Alice" moves the following resource using sidebar-panel
+    And "Alice" moves the following resources using sidebar-panel
       | resource             | to                   | option    |
       | example1.txt         | Personal/sub/folder1 | keep both |
       | folder1/example1.txt | Personal/sub/folder1 | replace   |
 
     # copy and move folder
-    And "Alice" copies the following resource using sidebar-panel
+    And "Alice" copies the following resources using sidebar-panel
       | resource | to           | option    |
       | folder1  | Personal/sub | keep both |
       | folder1  | Personal/sub | replace   |
-    And "Alice" moves the following resource using sidebar-panel
+    And "Alice" moves the following resources using sidebar-panel
       | resource     | to           | option    |
       | folder1      | Personal/sub | keep both |
       | sub1/folder1 | Personal/sub | replace   |
@@ -193,23 +193,23 @@ Feature: Copy
 
   
   Scenario: copy/move resources between spaces
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" creates the following project spaces using API
       | name    | id      |
       | mySpace | mySpace |
-    And "Brian" creates the following folders in personal space using API
+    And "Brian" creates the following folder in personal space using API
       | name  |
       | share |
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name        |
       | f1/f2/f3/f4 |
-    And "Brian" creates the following files into personal space using API
+    And "Brian" creates the following file into personal space using API
       | pathToFile     | content     |
       | share/file.txt | lorem ipsum |
     And "Brian" shares the following resource using API

--- a/tests/e2e/features/file-action/delete.feature
+++ b/tests/e2e/features/file-action/delete.feature
@@ -4,7 +4,7 @@ Feature: Delete
 
 
   Background:
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
@@ -20,10 +20,10 @@ Feature: Delete
       | resource     |
       | new file.txt |
     When "Alice" deletes the resource using the app topbar
-    Then following resources should not be displayed in the files list for user "Alice"
+    Then following resource should not be displayed in the files list for user "Alice"
       | resource     |
       | new file.txt |
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource         |
       | new testfile.txt |
     And "Alice" logs out
@@ -50,14 +50,14 @@ Feature: Delete
       | testavatar.jpg |
       | testavatar.png |
       | sampleGif.gif  |
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource         |
       | textfile.txt |
     And "Alice" logs out
 
   
   Scenario: quick restore deleted files
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" creates the following folder in personal space using API

--- a/tests/e2e/features/file-action/download.feature
+++ b/tests/e2e/features/file-action/download.feature
@@ -4,7 +4,7 @@ Feature: Download
 
 
   Background:
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
@@ -15,13 +15,13 @@ Feature: Download
       | name         |
       | folderPublic |
       | emptyFolder  |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile                | content     |
       | folderPublic/new file.txt | lorem ipsum |
     And "Alice" uploads the following local file into personal space using API
       | localFile      | to             |
       | testavatar.jpg | testavatar.jpg |
-    And "Alice" shares the following resource using API
+    And "Alice" shares the following resources using API
       | resource       | recipient | type | role     |
       | folderPublic   | Brian     | user | Can edit |
       | emptyFolder    | Brian     | user | Can edit |
@@ -36,7 +36,7 @@ Feature: Download
     And "Alice" opens the following file in mediaviewer
       | resource       |
       | testavatar.jpg |
-    And "Alice" downloads the following resources using the preview topbar
+    And "Alice" downloads the following resource using the preview topbar
       | resource       | type |
       | testavatar.jpg | file |
     And "Alice" closes the file viewer
@@ -58,7 +58,7 @@ Feature: Download
     And "Brian" opens the following file in mediaviewer
       | resource       |
       | testavatar.jpg |
-    And "Brian" downloads the following resources using the preview topbar
+    And "Brian" downloads the following resource using the preview topbar
       | resource       | type |
       | testavatar.jpg | file |
     And "Brian" logs out

--- a/tests/e2e/features/file-action/favorites.feature
+++ b/tests/e2e/features/file-action/favorites.feature
@@ -3,19 +3,19 @@ Feature: Favorites
   I want to mark resources as favorites and find them in the favorites section
 
   Background:
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
 
   Scenario: mark resources as favorites
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" creates the following project space using API
       | name         | id           |
       | service-team | service-team |
-    And "Alice" adds the following members to the space "service-team" using API
+    And "Alice" adds the following member to the space "service-team" using API
       | user  | role     | shareType |
       | Brian | Can view | user      |
     And "Alice" creates the following folder in personal space using API
@@ -36,18 +36,18 @@ Feature: Favorites
     And "Brian" logs in
     And "Brian" navigates to the shared with me page
     And "Brian" opens folder "shared"
-    When "Brian" marks the following resources as favorite using "context menu"
+    When "Brian" marks the following resource as favorite using "context menu"
       | resource        |
       | testavatar.jpg  |
     And "Brian" navigates to the personal space page
-    And "Brian" marks the following resources as favorite using "sidebar panel"
+    And "Brian" marks the following resource as favorite using "sidebar panel"
       | resource   |
       | image.png  |
     And "Brian" opens the following file in mediaviewer
       | resource  |
       | video.mp4 |
     And "Brian" is in a media-viewer
-    And "Brian" marks the following resources as favorite using "preview"
+    And "Brian" marks the following resource as favorite using "preview"
       | resource  |
       | video.mp4 |
     And "Brian" closes the file viewer
@@ -57,10 +57,10 @@ Feature: Favorites
       | testavatar.jpg |
       | image.png      |
       | video.mp4      |
-    And "Brian" removes the following resources from favorites using "context menu"
+    And "Brian" removes the following resource from favorites using "context menu"
       | resource  |
       | image.png |
-    And following resources should not be displayed in the files list for user "Brian"
+    And following resource should not be displayed in the files list for user "Brian"
       | resource       |
       | image.png      |
     And "Brian" logs out

--- a/tests/e2e/features/file-action/groupActions.feature
+++ b/tests/e2e/features/file-action/groupActions.feature
@@ -5,14 +5,14 @@ Feature: Group actions
   - accepting multiple shares by using a batch action
 
   Scenario: batch share a resource to multiple users and groups
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
       | Carol |
       | David |
       | Edith |
-    And "Admin" creates following group using API
+    And "Admin" creates following groups using API
       | id       |
       | sales    |
       | finance  |
@@ -35,7 +35,7 @@ Feature: Group actions
       | folder4                |
       | folder5                |
       | parentFolder/SubFolder |
-    And "Alice" shares the following resource using API
+    And "Alice" shares the following resources using API
       | resource     | recipient | type | role     |
       | folder1      | Brian     | user | Can edit |
       | folder2      | Brian     | user | Can edit |

--- a/tests/e2e/features/file-action/rename.feature
+++ b/tests/e2e/features/file-action/rename.feature
@@ -4,14 +4,14 @@ Feature: rename
   So I can rename resources from different locations
 
   Scenario: rename resources
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name   |
       | folder |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile         | content      |
       | folder/example.txt | example text |
     And "Alice" shares the following resource using API

--- a/tests/e2e/features/journeys/kindergarten.feature
+++ b/tests/e2e/features/journeys/kindergarten.feature
@@ -10,7 +10,7 @@ Feature: Kindergarten can use web to organize a day
       | Alice |
       | Brian |
       | Carol |
-    And "Admin" creates following group using API
+    And "Admin" creates following groups using API
       | id       |
       | sales    |
       | security |
@@ -59,7 +59,7 @@ Feature: Kindergarten can use web to organize a day
       | groups/Teddy Bear Daycare/meal plan/data.zip       | Brian     | user  | Can edit | file         |
       | groups/Teddy Bear Daycare/meal plan/data.zip       | Carol     | user  | Can edit | file         |
     # update share
-    And "Alice" updates following sharee role
+    And "Alice" updates following sharees role
       | resource                                           | recipient | type  | role     | resourceType |
       | groups/Pre-Schools Pirates/meal plan               | Carol     | user  | Can view | folder       |
       | groups/Pre-Schools Pirates/meal plan/lorem-big.txt | sales     | group | Can edit | file         |
@@ -68,7 +68,7 @@ Feature: Kindergarten can use web to organize a day
     # Then what do we check for to be confident that the above things done by Alice have worked?
     When "Brian" logs in
     And "Brian" navigates to the shared with me page
-    And "Brian" downloads the following resources using the sidebar panel
+    And "Brian" downloads the following resource using the sidebar panel
       | resource | from      | type |
       | data.zip | meal plan | file |
     # Then what do we check for to be confident that the above things done by Brian have worked?

--- a/tests/e2e/features/keycloak/smoke.feature
+++ b/tests/e2e/features/keycloak/smoke.feature
@@ -10,7 +10,7 @@ Feature: keycloak integration
       | Alice |
       | Brian |
       | Carol |
-    And admin assigns following roles to the users using keycloak API
+    And admin assigns following role to the users using keycloak API
       | id    | role        |
       | Alice | Space Admin |
     # Group role assignment - all members of the group inherit the assigned role
@@ -44,7 +44,7 @@ Feature: keycloak integration
       | security-folder | folder  |
       | finance-folder  | folder  |
       
-    And "Alice" shares the following resource using the sidebar panel
+    And "Alice" shares the following resources using the sidebar panel
       | resource        | recipient | type  | role     | resourceType |
       | finance-folder  | finance   | group | Can edit | folder       |
       | security-folder | Brian     | user  | Can edit | folder       |

--- a/tests/e2e/features/mobile-view/smoke.feature
+++ b/tests/e2e/features/mobile-view/smoke.feature
@@ -5,10 +5,10 @@ Feature: Mobile device test
       | id    |
       | Alice |
       | Brian |
-    And "Admin" creates following groups using API
+    And "Admin" creates following group using API
       | id    |
       | sales |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     
@@ -27,7 +27,7 @@ Feature: Mobile device test
       | resource   |
       | simple.pdf |
     Then "Alice" is in a pdf-viewer
-    And "Alice" downloads the following resources using the preview topbar
+    And "Alice" downloads the following resource using the preview topbar
       | resource   | type |
       | simple.pdf | file |
     And "Alice" closes the file viewer
@@ -35,7 +35,7 @@ Feature: Mobile device test
       | resource       |
       | testavatar.png |
     Then "Alice" is in a media-viewer
-    And "Alice" downloads the following resources using the preview topbar
+    And "Alice" downloads the following resource using the preview topbar
       | resource       | type |
       | testavatar.png | file |
     And "Alice" closes the file viewer

--- a/tests/e2e/features/navigation/applicationMenu.feature
+++ b/tests/e2e/features/navigation/applicationMenu.feature
@@ -12,7 +12,7 @@ Feature: Application menu
     And "Alice" enters the text "Hello world" in editor "TextEditor"
     And "Alice" saves the file viewer
     And "Alice" closes the file viewer
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource     |
       | New file.txt |
     And "Alice" logs out

--- a/tests/e2e/features/navigation/breadcrumb.feature
+++ b/tests/e2e/features/navigation/breadcrumb.feature
@@ -14,15 +14,15 @@ Feature: access breadcrumb
       | parent                         | folder |
       | parent/folder%2Fwith%2FSlashes | folder |
     And "Alice" opens folder "parent/folder%2Fwith%2FSlashes"
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource               | type   |
       | 'single-double quotes" | folder |
     And "Alice" opens folder "\'single-double quotes\""
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource              | type   |
       | "inner" double quotes | folder |
     And "Alice" opens folder "\"inner\" double quotes"
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource   | type   |
       | sub-folder | folder |
     And "Alice" opens folder "sub-folder"

--- a/tests/e2e/features/navigation/shortcut.feature
+++ b/tests/e2e/features/navigation/shortcut.feature
@@ -7,10 +7,10 @@ Feature: Users can create shortcuts for resources and sites
       | Brian |
 
   Scenario: shortcut
-    When "Alice" creates the following folders in personal space using API
+    When "Alice" creates the following folder in personal space using API
       | name |
       | docs |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile      | content           |
       | docs/notice.txt | important content |
     And "Alice" uploads the following local file into personal space using API
@@ -33,7 +33,7 @@ Feature: Users can create shortcuts for resources and sites
       | docs                       |                | folder  |
       | https://opencloud.eu/news/ | companyNews    | website |
 
-    And "Alice" downloads the following resources using the sidebar panel
+    And "Alice" downloads the following resource using the sidebar panel
       | resource           | type |
       | important file.url | file |
 
@@ -46,7 +46,7 @@ Feature: Users can create shortcuts for resources and sites
 
     # create a shortcut to the shared file
     When "Brian" logs in
-    And "Brian" creates a shortcut for the following resources
+    And "Brian" creates a shortcut for the following resource
       | resource       | name | type |
       | testavatar.jpg | logo | file |
     And "Brian" opens a shortcut "logo.url"
@@ -55,7 +55,7 @@ Feature: Users can create shortcuts for resources and sites
 
     # create a shortcut to the public link
     When "Brian" opens the "files" app
-    And "Brian" creates a shortcut for the following resources
+    And "Brian" creates a shortcut for the following resource
       | resource     | name             | type        |
       | myPublicLink | linkToNoticeFile | public link |
     And "Brian" opens a shortcut "linkToNoticeFile.url"

--- a/tests/e2e/features/navigation/urlJourneys.feature
+++ b/tests/e2e/features/navigation/urlJourneys.feature
@@ -2,14 +2,14 @@ Feature: web can be navigated through urls
 
 
   Scenario: navigate web directly through urls
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name   |
       | FOLDER |
     And "Alice" creates the following files into personal space using API
@@ -26,7 +26,7 @@ Feature: web can be navigated through urls
       | spaceTextfile.txt | This is test file. Cheers |
     And "Alice" logs in
     When "Alice" navigates to "versions" details panel of file "lorem.txt" of space "personal" through the URL
-    Then "Alice" restores following resources version
+    Then "Alice" restores following resource version
       | resource  | to | version | openDetailsPanel |
       | lorem.txt | /  | 1       | false            |
     When "Alice" navigates to "sharing" details panel of file "lorem.txt" of space "personal" through the URL

--- a/tests/e2e/features/ocm/ocm.feature
+++ b/tests/e2e/features/ocm/ocm.feature
@@ -9,7 +9,7 @@ Feature: federation management
     And "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name         |
       | folderPublic |
     And "Alice" uploads the following local file into personal space using API
@@ -38,7 +38,7 @@ Feature: federation management
       | user         | email             |
       | Brian Murphy | brian@example.org |
     And "Alice" opens the "files" app
-    And "Alice" shares the following resource using the sidebar panel
+    And "Alice" shares the following resources using the sidebar panel
       | resource       | recipient | type | role     | resourceType | shareType |
       | folderPublic   | Brian     | user | Can edit | folder       | external  |
       | sampleGif.gif  | Brian     | user | Can edit | file         | external  |
@@ -63,7 +63,7 @@ Feature: federation management
       | folderPublic   | folder |
       | sampleGif.gif  | file   |
       | testavatar.jpg | file   |
-    When "Brian" uploads the following resources
+    When "Brian" uploads the following resource
       | resource       | to           |
       | testavatar.png | folderPublic |
     And "Brian" opens folder "folderPublic"

--- a/tests/e2e/features/oidc/iframeTokenRenewal.feature
+++ b/tests/e2e/features/oidc/iframeTokenRenewal.feature
@@ -6,10 +6,10 @@ Feature: Token renewal using iframe
 
 
   Scenario: access token renewal via iframe
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -20,10 +20,10 @@ Feature: Token renewal using iframe
       | team | team.1 |
     When "Alice" waits for token renewal via iframe
     And "Alice" navigates to the project space "team.1"
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource     | type   |
       | space-folder | folder |
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource     |
       | space-folder |
     And "Alice" logs out

--- a/tests/e2e/features/oidc/refreshToken.feature
+++ b/tests/e2e/features/oidc/refreshToken.feature
@@ -6,10 +6,10 @@ Feature: Token renewal using refresh token
 
 
   Scenario: access token renewal via refresh token
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -20,10 +20,10 @@ Feature: Token renewal using refresh token
       | team | team.1 |
     When "Alice" waits for token renewal via refresh token
     And "Alice" navigates to the project space "team.1"
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource     | type   |
       | space-folder | folder |
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource     |
       | space-folder |
     When "Alice" navigates to new tab

--- a/tests/e2e/features/rclone-crypt/vault.feature
+++ b/tests/e2e/features/rclone-crypt/vault.feature
@@ -5,7 +5,7 @@ Feature: Work with an rclone-crypt encrypted vault
   We check that when uploading files or editing them, the payload sent to the server is encrypted
 
   Background:
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
 
@@ -18,7 +18,7 @@ Feature: Work with an rclone-crypt encrypted vault
       | my.vault/sub            | folder  |                     | foobar   |
       | my.vault/sub/nested.txt | txtFile | nested file content | foobar   |
       | my.vault/hello.txt      | txtFile | hello world         | foobar   |
-    And "Alice" uploads the following resources
+    And "Alice" uploads the following resource
       | resource          | to           | password |
       | PARENT/parent.txt | my.vault/sub | foobar   |
     And "Alice" enters the vault "my.vault" with passphrase "foobar"
@@ -48,7 +48,7 @@ Feature: Work with an rclone-crypt encrypted vault
   @rclone-crypt
   Scenario: Drag-drop a directory tree into a vault
     When "Alice" logs in
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource | type    | password       |
       | my.vault | vault   | myStrongPass#1 |
     And "Alice" enters the vault "my.vault" with passphrase "myStrongPass#1"
@@ -67,7 +67,7 @@ Feature: Work with an rclone-crypt encrypted vault
   @rclone-crypt
   Scenario: A wrong passphrase is rejected
     When "Alice" logs in
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource | type    | password |
       | my.vault | vault   | 123      |
     And "Alice" navigates to the personal space page
@@ -76,7 +76,7 @@ Feature: Work with an rclone-crypt encrypted vault
 
   @rclone-crypt
   Scenario: A vault root is collaborator-shareable but not public-linkable, its content stays private
-   Given "Admin" creates following users using API
+   Given "Admin" creates following user using API
       | id    |
       | Brian |
    When "Alice" logs in
@@ -91,7 +91,7 @@ Feature: Work with an rclone-crypt encrypted vault
     When "Brian" logs in
     And "Brian" navigates to the shared with me page
     And "Brian" enters the vault "share.vault" with passphrase "foobar"
-    And following resources should be displayed in the files list for user "Brian"
+    And following resource should be displayed in the files list for user "Brian"
       | resource  |
       | hello.txt |
     And "Brian" opens the following file in texteditor
@@ -112,10 +112,10 @@ Feature: Work with an rclone-crypt encrypted vault
       | resource | as                 |
       | my.vault | renamed.vault |
     And "Alice" enters the vault "renamed.vault" with passphrase "foobar"
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource  |
       | hello.txt |
-    And "Alice" downloads the following resources using the sidebar panel
+    And "Alice" downloads the following resource using the sidebar panel
       | resource  | type |
       | hello.txt | file |
     And "Alice" logs out

--- a/tests/e2e/features/search/fullTextSearch.feature
+++ b/tests/e2e/features/search/fullTextSearch.feature
@@ -8,13 +8,13 @@ Feature: Search
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Brian | Space Admin |
     And "Alice" uploads the following local file into personal space using API
       | localFile    | to              |
       | textfile.txt | fileToShare.txt |
-    And "Alice" adds the following tags for the following resources using API
+    And "Alice" adds the following tag for the following resource using API
       | resource        | tags      |
       | fileToShare.txt | alice tag |
     And "Alice" shares the following resource using API
@@ -47,7 +47,7 @@ Feature: Search
     Then "Brian" should see the message "Search for files" on the search result
 
     When "Brian" selects tag "alice tag" from the search result filter chip
-    Then following resources should be displayed in the files list for user "Brian"
+    Then following resource should be displayed in the files list for user "Brian"
       | resource        |
       | fileToShare.txt |
 
@@ -59,7 +59,7 @@ Feature: Search
       | withTag.txt     |
 
     When "Brian" searches "file" using the global search and the "all files" filter and presses enter
-    Then following resources should be displayed in the files list for user "Brian"
+    Then following resource should be displayed in the files list for user "Brian"
       | resource        |
       | fileWithTag.txt |
 

--- a/tests/e2e/features/search/search.feature
+++ b/tests/e2e/features/search/search.feature
@@ -16,7 +16,7 @@ Feature: Search
       | localFile         | to                |
       | new-lorem-big.txt | new-lorem-big.txt |
     And "Brian" logs in
-    And "Brian" shares the following resource using the sidebar panel
+    And "Brian" shares the following resources using the sidebar panel
       | resource             | recipient | type | role     | resourceType |
       | new_share_from_brian | Alice     | user | Can view | folder       |
       | new-lorem-big.txt    | Alice     | user | Can view | file         |
@@ -31,7 +31,7 @@ Feature: Search
       | FolDer/child-one/child-two | folder |
       | strängéनेपालीName          | folder |
     And "Alice" enables the option to display the hidden file
-    And "Alice" uploads the following resources
+    And "Alice" uploads the following resource
       | resource         |
       | .hidden-file.txt |
 
@@ -49,7 +49,7 @@ Feature: Search
 
     # search for hidden file
     When "Alice" searches "hidden" using the global search and the "all files" filter
-    Then following resources should be displayed in the search list for user "Alice"
+    Then following resource should be displayed in the search list for user "Alice"
       | resource         |
       | .hidden-file.txt |
     But following resources should not be displayed in the search list for user "Alice"
@@ -86,7 +86,7 @@ Feature: Search
     And "Alice" opens the "files" app
 
     # search renamed resources
-    When "Alice" renames the following resource
+    When "Alice" renames the following resources
       | resource | as            |
       | folder   | renamedFolder |
       | FolDer   | renamedFolDer |
@@ -112,7 +112,7 @@ Feature: Search
       | resource          | from |
       | strängéनेपालीName |      |
     And "Alice" searches "forDeleting" using the global search and the "all files" filter
-    Then following resources should not be displayed in the search list for user "Alice"
+    Then following resource should not be displayed in the search list for user "Alice"
       | resource          |
       | strängéनेपालीName |
 
@@ -120,10 +120,10 @@ Feature: Search
 
 
   Scenario: Search using "current folder" filter
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name                 |
       | mainFolder/subFolder |
     And "Alice" creates the following files into personal space using API
@@ -145,17 +145,17 @@ Feature: Search
       | resource                                  |
       | mainFolder/exampleInsideTheMainFolder.txt |
       | …/subFolder/exampleInsideTheSubFolder.txt |
-    But following resources should not be displayed in the search list for user "Alice"
+    But following resource should not be displayed in the search list for user "Alice"
       | resource                          |
       | exampleInsideThePersonalSpace.txt |
     And "Alice" logs out
 
 
   Scenario: Search using mediaType filter
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name      |
       | mediaTest |
     And "Alice" uploads the following local file into personal space using API
@@ -171,22 +171,22 @@ Feature: Search
     And "Alice" searches "mediaTest" using the global search and the "all files" filter and presses enter
     And "Alice" enables the option to search title only
     And "Alice" selects mediaType "Document" from the search result filter chip
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource      |
       | mediaTest.txt |
     And "Alice" clears mediaType filter
     When "Alice" selects mediaType "PDF" from the search result filter chip
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource      |
       | mediaTest.pdf |
     And "Alice" clears mediaType filter
     When "Alice" selects mediaType "Audio" from the search result filter chip
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource      |
       | mediaTest.mp3 |
     And "Alice" clears mediaType filter
     When "Alice" selects mediaType "Archive" from the search result filter chip
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource      |
       | mediaTest.zip |
     And "Alice" clears mediaType filter
@@ -207,10 +207,10 @@ Feature: Search
 
 
   Scenario: Search using lastModified filter
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name       |
       | mainFolder |
     And "Alice" creates the following files with mtime into personal space using API
@@ -233,11 +233,11 @@ Feature: Search
       | resource                 |
       | mainFolder/mediaTest.txt |
       | mainFolder/mediaTest.md  |
-    But following resources should not be displayed in the files list for user "Alice"
+    But following resource should not be displayed in the files list for user "Alice"
       | resource                 |
       | mainFolder/mediaTest.pdf |
     When "Alice" selects lastModified "today" from the search result filter chip
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource                |
       | mainFolder/mediaTest.md |
     But following resources should not be displayed in the files list for user "Alice"

--- a/tests/e2e/features/search/searchProjectSpace.feature
+++ b/tests/e2e/features/search/searchProjectSpace.feature
@@ -4,7 +4,7 @@ Feature: Search in the project space
     Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -12,27 +12,27 @@ Feature: Search in the project space
       | name | id     |
       | team | team.1 |
     And "Alice" navigates to the project space "team.1"
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource                   | type   |
       | folder(WithSymbols:!;_+-&) | folder |
-    And "Alice" uploads the following resources
+    And "Alice" uploads the following resource
       | resource               | to                         |
       | new-'single'quotes.txt | folder(WithSymbols:!;_+-&) |
     And "Alice" navigates to the personal space page
 
     # search for project space objects
     When "Alice" searches "-'s" using the global search and the "all files" filter
-    Then following resources should be displayed in the search list for user "Alice"
+    Then following resource should be displayed in the search list for user "Alice"
       | resource                                          |
       | folder(WithSymbols:!;_+-&)/new-'single'quotes.txt |
-    But following resources should not be displayed in the search list for user "Alice"
+    But following resource should not be displayed in the search list for user "Alice"
       | resource                   |
       | folder(WithSymbols:!;_+-&) |
     When "Alice" searches "!;_+-&)" using the global search and the "all files" filter
-    Then following resources should be displayed in the search list for user "Alice"
+    Then following resource should be displayed in the search list for user "Alice"
       | resource                   |
       | folder(WithSymbols:!;_+-&) |
-    But following resources should not be displayed in the search list for user "Alice"
+    But following resource should not be displayed in the search list for user "Alice"
       | resource                                          |
       | folder(WithSymbols:!;_+-&)/new-'single'quotes.txt |
     And "Alice" logs out

--- a/tests/e2e/features/shares/link.feature
+++ b/tests/e2e/features/shares/link.feature
@@ -14,7 +14,7 @@ Feature: link
       | name                   |
       | folderPublic           |
       | folderPublic/SubFolder |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile             | content     |
       | folderPublic/lorem.txt | lorem ipsum |
 
@@ -27,7 +27,7 @@ Feature: link
     And "Alice" sets the expiration date of the public link named "myPublicLink" of resource "folderPublic" to "+5 days"
     When "Anonymous" opens the public link "myPublicLink"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" drop uploads following resources
+    And "Anonymous" drop uploads following resource
       | resource     |
       | textfile.txt |
 
@@ -35,7 +35,7 @@ Feature: link
     When "Brian" logs in
     And "Brian" opens the public link "myPublicLink"
     And "Brian" unlocks the public link with password "%public%"
-    And "Brian" drop uploads following resources
+    And "Brian" drop uploads following resource
       | resource   |
       | simple.pdf |
 
@@ -55,7 +55,7 @@ Feature: link
       | simple.pdf   |
       | SubFolder    |
       | lorem.txt    |
-    And "Brian" deletes the following resources from public link using sidebar panel
+    And "Brian" deletes the following resource from public link using sidebar panel
       | resource   |
       | simple.pdf |
     And "Brian" logs out
@@ -73,7 +73,7 @@ Feature: link
       | resource       | type   |
       | myfolder       | folder |
       | myfolder/child | folder |
-    And "Anonymous" uploads the following resources in public link page
+    And "Anonymous" uploads the following resource in public link page
       | resource | type   |
       | PARENT   | folder |
     And "Anonymous" moves the following resource using drag-drop
@@ -96,12 +96,12 @@ Feature: link
 
 
   Scenario: public link for folder and file (by authenticated user)
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Brian |
       | Carol |
     And "Alice" logs in
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name         |
       | folderPublic |
     And "Alice" creates the following files into personal space using API
@@ -113,7 +113,7 @@ Feature: link
       | simple.pdf     | simple.pdf     |
       | testavatar.jpg | testavatar.jpg |
       | test_video.mp4 | test_video.mp4 |
-    And "Alice" shares the following resource using API
+    And "Alice" shares the following resources using API
       | resource       | recipient | type | role     |
       | folderPublic   | Brian     | user | Can edit |
       | simple.pdf     | Brian     | user | Can edit |
@@ -153,7 +153,7 @@ Feature: link
     And "Brian" downloads the following public link resources using the sidebar panel
       | resource         | type |
       | shareToBrian.txt | file |
-    And "Brian" uploads the following resources
+    And "Brian" uploads the following resource
       | resource  |
       | lorem.txt |
     When "Brian" opens the public link "textLink"
@@ -256,7 +256,7 @@ Feature: link
 
   Scenario: add banned password for public link
     When "Alice" logs in
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile | content   |
       | lorem.txt  | some text |
 
@@ -287,10 +287,10 @@ Feature: link
 
   Scenario: edit password of the public link
     When "Alice" logs in
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name         |
       | folderPublic |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile             | content     |
       | folderPublic/lorem.txt | lorem ipsum |
     And "Alice" opens the "files" app
@@ -311,10 +311,10 @@ Feature: link
 
   Scenario: link indication
     When "Alice" logs in
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name         |
       | folderPublic |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile             | content     |
       | folderPublic/lorem.txt | lorem ipsum |
     And "Alice" opens the "files" app
@@ -329,7 +329,7 @@ Feature: link
     Then "Alice" should see link-indirect indicator on the file "lorem.txt"
 
     And "Alice" navigates to the shared via link page
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource     |
       | folderPublic |
 
@@ -338,18 +338,18 @@ Feature: link
     And "Alice" copies the link "Unnamed link" of resource "folderPublic"
     And "Alice" opens the "%clipboard%" url
     And "Alice" unlocks the public link with password "%public%"
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource  |
       | lorem.txt |
     And "Alice" logs out
 
 
   Scenario: password is triggered when changing public link to writable role
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role  |
       | Alice | Admin |
     When "Alice" logs in
-    And "Alice" creates the following folders in personal space using API
+    And "Alice" creates the following folder in personal space using API
       | name         |
       | folderPublic |
     And "Alice" opens the "files" app

--- a/tests/e2e/features/shares/share.feature
+++ b/tests/e2e/features/shares/share.feature
@@ -9,17 +9,17 @@ Feature: share
   Scenario: folder
     # disabling auto accepting to check accepting share
     Given "Brian" disables auto-accepting using API
-    And "Alice" creates the following folder in personal space using API
+    And "Alice" creates the following folders in personal space using API
       | name               |
       | folder_to_shared   |
       | folder_to_shared_2 |
       | shared_folder      |
     And "Alice" logs in
-    And "Alice" uploads the following resource
+    And "Alice" uploads the following resources
       | resource      | to                 |
       | lorem.txt     | folder_to_shared   |
       | lorem-big.txt | folder_to_shared_2 |
-    When "Alice" shares the following resource using the sidebar panel
+    When "Alice" shares the following resources using the sidebar panel
       | resource           | recipient | type | role     | resourceType |
       | folder_to_shared   | Brian     | user | Can edit | folder       |
       | shared_folder      | Brian     | user | Can edit | folder       |
@@ -29,7 +29,7 @@ Feature: share
     And "Brian" navigates to the shared with me page
     And "Brian" opens folder "folder_to_shared"
     # user should have access to unsynced shares
-    Then following resources should be displayed in the files list for user "Brian"
+    Then following resource should be displayed in the files list for user "Brian"
       | resource  |
       | lorem.txt |
     When "Brian" navigates to the shared with me page
@@ -47,11 +47,11 @@ Feature: share
     And "Brian" renames the following resource
       | resource                   | as            |
       | folder_to_shared/lorem.txt | lorem_new.txt |
-    And "Brian" uploads the following resource
+    And "Brian" uploads the following resources
       | resource        | to                 |
       | simple.pdf      | folder_to_shared   |
       | testavatar.jpeg | folder_to_shared_2 |
-    When "Brian" deletes the following resources using the sidebar panel
+    When "Brian" deletes the following resource using the sidebar panel
       | resource      | from               |
       | lorem-big.txt | folder_to_shared_2 |
     And "Alice" opens the "files" app
@@ -87,7 +87,7 @@ Feature: share
       | resource         | content                   |
       | shareToBrian.txt | new content edited        |
       | shareToBrian.md  | new readme content edited |
-    And "Alice" uploads the following resource
+    And "Alice" uploads the following resources
       | resource        |
       | simple.pdf      |
       | sampleGif.gif   |
@@ -138,7 +138,7 @@ Feature: share
       | resource       | type |
       | test_video.mp4 | file |
     And "Alice" closes the file viewer
-    And "Alice" shares the following resource using the sidebar panel
+    And "Alice" shares the following resources using the sidebar panel
       | resource         | recipient | type | role     | resourceType |
       | shareToBrian.txt | Brian     | user | Can edit | file         |
       | shareToBrian.md  | Brian     | user | Can edit | file         |
@@ -176,7 +176,7 @@ Feature: share
       | simple.pdf |
     And "Brian" closes the file viewer
     And "Alice" navigates to the personal space page
-    And "Alice" removes following sharee
+    And "Alice" removes following sharees
       | resource         | recipient |
       | shareToBrian.txt | Brian     |
       | shareToBrian.md  | Brian     |
@@ -195,7 +195,7 @@ Feature: share
     And "Admin" adds user to the group using API
       | user  | group |
       | Brian | sales |
-    And "Alice" creates the following folder in personal space using API
+    And "Alice" creates the following folders in personal space using API
       | name       |
       | myfolder   |
       | mainFolder |
@@ -204,7 +204,7 @@ Feature: share
       | new.txt              | some content |
       | mainFolder/lorem.txt | lorem epsum  |
     And "Alice" logs in
-    When "Alice" shares the following resource using the sidebar panel
+    When "Alice" shares the following resources using the sidebar panel
       | resource   | recipient | type  | role     | resourceType | expirationDate |
       | new.txt    | Brian     | user  | Can edit | file         | +5 days        |
       | myfolder   | sales     | group | Can view | folder       | +10 days       |
@@ -232,17 +232,17 @@ Feature: share
 
 
   Scenario: receive two shares with same name
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Carol |
     And "Alice" creates the following folder in personal space using API
       | name        |
       | test-folder |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile   | content      |
       | testfile.txt | example text |
     And "Alice" logs in
-    And "Alice" shares the following resource using the sidebar panel
+    And "Alice" shares the following resources using the sidebar panel
       | resource     | recipient | type | role     |
       | testfile.txt | Brian     | user | Can view |
       | test-folder  | Brian     | user | Can view |
@@ -250,11 +250,11 @@ Feature: share
     And "Carol" creates the following folder in personal space using API
       | name        |
       | test-folder |
-    And "Carol" creates the following files into personal space using API
+    And "Carol" creates the following file into personal space using API
       | pathToFile   | content      |
       | testfile.txt | example text |
     And "Carol" logs in
-    And "Carol" shares the following resource using the sidebar panel
+    And "Carol" shares the following resources using the sidebar panel
       | resource     | recipient | type | role     |
       | testfile.txt | Brian     | user | Can view |
       | test-folder  | Brian     | user | Can view |
@@ -271,7 +271,7 @@ Feature: share
 
 
   Scenario: check file with same name but different paths are displayed correctly in shared with others page
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Carol |
     And "Alice" creates the following folder in personal space using API
@@ -281,7 +281,7 @@ Feature: share
       | pathToFile               | content      |
       | testfile.txt             | example text |
       | test-folder/testfile.txt | some text    |
-    And "Alice" shares the following resource using API
+    And "Alice" shares the following resources using API
       | resource                 | recipient | type | role     |
       | testfile.txt             | Brian     | user | Can edit |
       | test-folder/testfile.txt | Brian     | user | Can edit |
@@ -295,7 +295,7 @@ Feature: share
 
 
   Scenario: share indication
-    When "Alice" creates the following folders in personal space using API
+    When "Alice" creates the following folder in personal space using API
       | name                  |
       | shareFolder/subFolder |
     And "Alice" shares the following resource using API

--- a/tests/e2e/features/smoke/activity.feature
+++ b/tests/e2e/features/smoke/activity.feature
@@ -5,7 +5,7 @@ Feature: Users can see all activities of the resources and spaces
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
 
@@ -13,7 +13,7 @@ Feature: Users can see all activities of the resources and spaces
     Given "Alice" creates the following project space using API
       | name | id     |
       | team | team.1 |
-    And "Alice" adds the following members to the space "team" using API
+    And "Alice" adds the following member to the space "team" using API
       | user  | role     | shareType |
       | Brian | Can view | user      |
     And "Alice" creates a public link of the space using API
@@ -34,7 +34,7 @@ Feature: Users can see all activities of the resources and spaces
 
     When "Anonymous" opens the public link "Unnamed link"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" edits the following resources
+    And "Anonymous" edits the following resource
       | resource     | content     |
       | textfile.txt | new content |
     Then "Anonymous" should not see any activity of the following resource
@@ -48,7 +48,7 @@ Feature: Users can see all activities of the resources and spaces
     And "Alice" deletes the following resource using the sidebar panel
       | resource  | from         |
       | subFolder | sharedFolder |
-    Then "Alice" should see activity of the following resource
+    Then "Alice" should see activity of the following resources
       | resource     | activity                                         |
       | sharedFolder | Alice Hansen deleted subFolder from sharedFolder |
       | sharedFolder | Alice Hansen renamed textfile.txt to new.txt     |

--- a/tests/e2e/features/smoke/sse.feature
+++ b/tests/e2e/features/smoke/sse.feature
@@ -26,7 +26,7 @@ Feature: server sent events
 
 
   Background:
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
@@ -34,7 +34,7 @@ Feature: server sent events
   
   @webkit-skip
   Scenario: space sse events
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Brian" logs in
@@ -46,7 +46,7 @@ Feature: server sent events
       | Marketing | marketing |
 
     # space-member-added
-    When "Alice" adds the following members to the space "Marketing" using API
+    When "Alice" adds the following member to the space "Marketing" using API
       | user  | role     | shareType |
       | Brian | Can view | user      |
     Then "Alice" should get "space-member-added" SSE event
@@ -61,14 +61,14 @@ Feature: server sent events
       | space-folder |
     Then "Alice" should get "folder-created" SSE event
     And "Brian" should get "folder-created" SSE event
-    And following resources should be displayed in the files list for user "Brian"
+    And following resource should be displayed in the files list for user "Brian"
       | resource     |
       | space-folder |
     And "Brian" should not be able to edit folder "space-folder"
 
     # space-share-updated
     When "Alice" navigates to the project space "marketing"
-    And "Alice" changes the roles of the following users in the project space
+    And "Alice" changes the roles of the following user in the project space
       | user  | role     |
       | Brian | Can edit |
     Then "Alice" should get "space-share-updated" SSE event
@@ -121,7 +121,7 @@ Feature: server sent events
     # space-member-removed
     When "Brian" navigates to the projects space page
     And "Alice" navigates to the project space "marketing"
-    And "Alice" removes access to following users from the project space
+    And "Alice" removes access to following user from the project space
       | user  |
       | Brian |
     Then "Alice" should get "space-member-removed" SSE event
@@ -130,7 +130,7 @@ Feature: server sent events
 
 
     # space-disabled
-    When "Alice" adds the following members to the space "Marketing" using API
+    When "Alice" adds the following member to the space "Marketing" using API
       | user  | role     | shareType |
       | Brian | Can view | user      |
     And "Alice" navigates to the projects space page
@@ -199,13 +199,13 @@ Feature: server sent events
 
   @webkit-skip
   Scenario: sse events on file operations
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" creates the following project space using API
       | name      | id        |
       | Marketing | marketing |
-    And "Alice" adds the following members to the space "Marketing" using API
+    And "Alice" adds the following member to the space "Marketing" using API
       | user  | role     | shareType |
       | Brian | Can edit | user      |
     And "Alice" creates the following folder in space "Marketing" using API
@@ -217,25 +217,25 @@ Feature: server sent events
     And "Brian" navigates to the project space "marketing"
 
     # postprocessing-finished - upload file
-    When "Brian" uploads the following resources
+    When "Brian" uploads the following resource
       | resource   |
       | simple.pdf |
     Then "Brian" should get "postprocessing-finished" SSE event
     And "Alice" should get "postprocessing-finished" SSE event
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource   |
       | simple.pdf |
 
     # postprocessing-finished - create file
     # file-touched -create file
-    When "Alice" creates the following resources
+    When "Alice" creates the following resource
       | resource    | type    | content   |
       | example.txt | txtFile | some text |
     Then "Alice" should get "postprocessing-finished" SSE event
     And "Alice" should get "file-touched" SSE event
     And "Brian" should get "postprocessing-finished" SSE event
     And "Brian" should get "file-touched" SSE event
-    And following resources should be displayed in the files list for user "Brian"
+    And following resource should be displayed in the files list for user "Brian"
       | resource    |
       | example.txt |
 
@@ -245,7 +245,7 @@ Feature: server sent events
       | simple.pdf | simple-renamed.pdf |
     Then "Brian" should get "item-renamed" SSE event
     And "Alice" should get "item-renamed" SSE event
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource           |
       | simple-renamed.pdf |
 
@@ -255,19 +255,19 @@ Feature: server sent events
       | example.txt |
     Then "Alice" should get "item-trashed" SSE event
     And "Brian" should get "item-trashed" SSE event
-    And following resources should not be displayed in the files list for user "Brian"
+    And following resource should not be displayed in the files list for user "Brian"
       | resource    |
       | example.txt |
 
     # item-restored
     When "Brian" navigates to the trashbin
     When "Brian" opens trashbin of the project space "marketing"
-    And "Brian" restores the following resources from trashbin
+    And "Brian" restores the following resource from trashbin
       | resource    |
       | example.txt |
     Then "Brian" should get "item-restored" SSE event
     And "Alice" should get "item-restored" SSE event
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource    |
       | example.txt |
 
@@ -279,7 +279,7 @@ Feature: server sent events
       | simple-renamed.pdf | space-folder |
     Then "Alice" should get "item-moved" SSE event
     And "Brian" should get "item-moved" SSE event
-    And following resources should be displayed in the files list for user "Brian"
+    And following resource should be displayed in the files list for user "Brian"
       | resource           |
       | simple-renamed.pdf |
 

--- a/tests/e2e/features/smoke/tags.feature
+++ b/tests/e2e/features/smoke/tags.feature
@@ -7,27 +7,27 @@ Feature: Users can use web to organize tags
       | Brian |
 
   Scenario: Tag management
-    When "Alice" creates the following files into personal space using API
+    When "Alice" creates the following file into personal space using API
       | pathToFile | content     |
       | lorem.txt  | lorem ipsum |
     And "Alice" logs in
     And "Alice" switches to the "table" view
-    And "Alice" adds the following tags for the following resources using the sidebar panel
+    And "Alice" adds the following tag for the following resource using the sidebar panel
       | resource  | tags         |
       | lorem.txt | tag 1, tag 2 |
-    Then the following resources should contain the following tags in the files list for user "Alice"
+    Then the following resource should contain the following tag in the files list for user "Alice"
       | resource  | tags         |
       | lorem.txt | tag 1, tag 2 |
-    Then the following resources should contain the following tags in the details panel for user "Alice"
+    Then the following resource should contain the following tag in the details panel for user "Alice"
       | resource  | tags         |
       | lorem.txt | tag 1, tag 2 |
-    When "Alice" removes the following tags for the following resources using the sidebar panel
+    When "Alice" removes the following tag for the following resource using the sidebar panel
       | resource  | tags  |
       | lorem.txt | tag 1 |
-    Then the following resources should contain the following tags in the files list for user "Alice"
+    Then the following resource should contain the following tag in the files list for user "Alice"
       | resource  | tags  |
       | lorem.txt | tag 2 |
-    Then the following resources should contain the following tags in the details panel for user "Alice"
+    Then the following resource should contain the following tag in the details panel for user "Alice"
       | resource  | tags  |
       | lorem.txt | tag 2 |
     And "Alice" logs out
@@ -40,29 +40,29 @@ Feature: Users can use web to organize tags
       | textfile.txt | test file   |
     And "Alice" logs in
     And "Alice" switches to the "table" view
-    And "Alice" adds the following tags for the following resources using the sidebar panel
+    And "Alice" adds the following tag for the following resource using the sidebar panel
       | resource  | tags       |
       | lorem.txt | tag1, tag2 |
     And "Alice" clicks the tag "tag1" on the resource "lorem.txt"
-    Then the following resources should contain the following tags in the files list for user "Alice"
+    Then the following resource should contain the following tag in the files list for user "Alice"
       | resource  | tags |
       | lorem.txt | tag1 |
-    Then following resources should not be displayed in the files list for user "Alice"
+    Then following resource should not be displayed in the files list for user "Alice"
       | resource     |
       | textfile.txt |
     And "Alice" logs out
 
 
   Scenario: Tag sharing
-    Given "Alice" creates the following folders in personal space using API
+    Given "Alice" creates the following folder in personal space using API
       | name             |
       | folder_to_shared |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile                 | content     |
       | folder_to_shared/lorem.txt | lorem ipsum |
     And "Alice" logs in
     And "Alice" switches to the "table" view
-    And "Alice" adds the following tags for the following resources using the sidebar panel
+    And "Alice" adds the following tag for the following resource using the sidebar panel
       | resource                   | tags         |
       | folder_to_shared/lorem.txt | tag 1, tag 2 |
     When "Alice" shares the following resource using the sidebar panel
@@ -73,7 +73,7 @@ Feature: Users can use web to organize tags
     And "Brian" logs in
     And "Brian" switches to the "table" view
     And "Brian" navigates to the shared with me page
-    Then the following resources should contain the following tags in the files list for user "Brian"
+    Then the following resource should contain the following tag in the files list for user "Brian"
       | resource                   | tags         |
       | folder_to_shared/lorem.txt | tag 1, tag 2 |
     And "Brian" logs out

--- a/tests/e2e/features/smoke/trashbinDelete.feature
+++ b/tests/e2e/features/smoke/trashbinDelete.feature
@@ -4,7 +4,7 @@ Feature: Trashbin delete
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
@@ -53,7 +53,7 @@ Feature: Trashbin delete
       | folderToShare/lorem.txt | lorem ipsum |
       | sample.txt              | sample      |
     And "Alice" opens the "files" app
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource   |
       | sample.txt |
     And "Alice" shares the following resource using the sidebar panel
@@ -62,14 +62,14 @@ Feature: Trashbin delete
     And "Brian" logs in
     And "Brian" navigates to the shared with me page
     And "Brian" opens folder "folderToShare"
-    And following resources should be displayed in the files list for user "Brian"
+    And following resource should be displayed in the files list for user "Brian"
       | resource  |
       | lorem.txt |
-    When "Brian" deletes the following resources using the sidebar panel
+    When "Brian" deletes the following resource using the sidebar panel
       | resource  |
       | lorem.txt |
     And "Brian" navigates to the trashbin
-    Then following resources should not be displayed in the trashbin for user "Brian"
+    Then following resource should not be displayed in the trashbin for user "Brian"
       | resource                |
       | folderToShare/lorem.txt |
     When "Alice" deletes the following resources using the sidebar panel
@@ -77,10 +77,10 @@ Feature: Trashbin delete
       | sample.txt   |
       | empty-folder |
     And "Alice" navigates to the trashbin
-    Then following resources should be displayed in the trashbin for user "Alice"
+    Then following resource should be displayed in the trashbin for user "Alice"
       | resource                |
       | folderToShare/lorem.txt |
-    And "Alice" restores the following resources from trashbin
+    And "Alice" restores the following resource from trashbin
       | resource                |
       | folderToShare/lorem.txt |
     And "Alice" restores the following resources from trashbin using the batch action
@@ -89,12 +89,12 @@ Feature: Trashbin delete
       | empty-folder            |
     And "Alice" opens the "files" app
     And "Alice" opens folder "folderToShare"
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource  |
       | lorem.txt |
     And "Brian" navigates to the shared with me page
     And "Brian" opens folder "folderToShare"
-    And following resources should be displayed in the files list for user "Brian"
+    And following resource should be displayed in the files list for user "Brian"
       | resource  |
       | lorem.txt |
     And "Brian" logs out
@@ -102,7 +102,7 @@ Feature: Trashbin delete
 
 
   Scenario: empty trashbin using quick action
-    Given "Admin" assigns following roles to the users using API
+    Given "Admin" assigns following role to the users using API
       | id    | role        |
       | Brian | Space Admin |
     And "Brian" creates the following project space using API
@@ -115,7 +115,7 @@ Feature: Trashbin delete
     And "Brian" logs in
 
     When "Brian" navigates to the project space "sales"
-    And "Brian" deletes the following resources using the sidebar panel
+    And "Brian" deletes the following resource using the sidebar panel
       | resource |
       | f1       |
 
@@ -134,7 +134,7 @@ Feature: Trashbin delete
       | hr       |
     And "Brian" should see the text "3 trash bins in total (including 2 empty)" at the footer of the trashbin page
     When "Brian" empties the trashbin for space "sales" using quick action
-    Then following resources should not be displayed in the trashbin for user "Brian"
+    Then following resource should not be displayed in the trashbin for user "Brian"
       | resource |
       | sales    |
     And "Brian" logs out

--- a/tests/e2e/features/smoke/upload.feature
+++ b/tests/e2e/features/smoke/upload.feature
@@ -50,7 +50,7 @@ Feature: Upload
 
 
   Scenario: upload folder
-    When "Alice" uploads the following resources
+    When "Alice" uploads the following resource
       | resource | type   |
       | PARENT   | folder |
     # check that folder content exist
@@ -61,11 +61,11 @@ Feature: Upload
     And "Alice" closes the file viewer
     
     # folder upload via drag-n-drop
-    When "Alice" uploads the following resources via drag-n-drop
+    When "Alice" uploads the following resource via drag-n-drop
       | resource |
       | PARENT   |
     And "Alice" opens folder "PARENT/CHILD"
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource  |
       | child.txt |
     And "Alice" logs out
@@ -79,13 +79,13 @@ Feature: Upload
     And "Admin" logs out
 
     And "Alice" opens the "files" app
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource          | type    | content             |
       | new-lorem-big.txt | txtFile | new lorem big file  |
     When "Alice" tries to upload the following resource
       | resource      | error              |
       | lorem-big.txt | Insufficient quota |
-    Then following resources should not be displayed in the files list for user "Alice"
+    Then following resource should not be displayed in the files list for user "Alice"
       | resource      |
       | lorem-big.txt |
     And "Alice" logs out
@@ -93,7 +93,7 @@ Feature: Upload
 
   Scenario: upload resource from clipboard
     When "Alice" uploads an image from the clipboard
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource  |
       | image.png |
     And "Alice" opens the following file in mediaviewer
@@ -110,12 +110,12 @@ Feature: Upload
     Given "Alice" creates the following folder in personal space using API
       | name   |
       | PARENT |
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
       | pathToFile      | content      |
       | PARENT/test.txt | some content |
     
     # keep both option
-    And "Alice" uploads the following resources
+    And "Alice" uploads the following resource
       | resource  | type   | option    |
       | PARENT    | folder | keep both |
     Then following resources should be displayed in the files list for user "Alice"
@@ -123,25 +123,25 @@ Feature: Upload
       | PARENT     |
       | PARENT (1) |
     And "Alice" opens folder "PARENT"
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource  |
       | test.txt  |
     And "Alice" opens the "files" app
     And "Alice" opens folder "PARENT (1)"
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource   |
       | parent.txt |
     And "Alice" opens folder "CHILD"
-    And following resources should be displayed in the files list for user "Alice"
+    And following resource should be displayed in the files list for user "Alice"
       | resource  |
       | child.txt |
     
     # replace option
-    Given "Alice" creates the following files into personal space using API
+    Given "Alice" creates the following file into personal space using API
       | pathToFile        | content      |
       | PARENT/parent.txt | some content |
     When "Alice" opens the "files" app
-    And "Alice" uploads the following resources
+    And "Alice" uploads the following resource
       | resource  | type   | option |
       | PARENT    | folder | merge  |
     And "Alice" opens folder "PARENT"

--- a/tests/e2e/features/smoke/uploadResumable.feature
+++ b/tests/e2e/features/smoke/uploadResumable.feature
@@ -14,7 +14,7 @@ Feature: Upload large resources
       | largefile.txt |
     And "Alice" pauses the file upload
     And "Alice" cancels the file upload
-    Then following resources should not be displayed in the files list for user "Alice"
+    Then following resource should not be displayed in the files list for user "Alice"
       | resource      |
       | largefile.txt |
     When "Alice" starts uploading the following large resources from the temp upload directory
@@ -22,7 +22,7 @@ Feature: Upload large resources
       | largefile.txt |
     And "Alice" pauses the file upload
     And "Alice" resumes the file upload
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource      |
       | largefile.txt |
     And "Alice" logs out

--- a/tests/e2e/features/spaces/createSpaceFromSelection.feature
+++ b/tests/e2e/features/spaces/createSpaceFromSelection.feature
@@ -1,14 +1,14 @@
 Feature: create Space shortcut
 
   Scenario: create Space from folder
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
-    And "Alice" creates the following folder in personal space using API
+    And "Alice" creates the following folders in personal space using API
       | name             |
       | spaceFolder      |
       | spaceFolder/test |
@@ -27,10 +27,10 @@ Feature: create Space shortcut
     And "Alice" logs out
 
   Scenario: create space from resources
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in

--- a/tests/e2e/features/spaces/downloadSpace.feature
+++ b/tests/e2e/features/spaces/downloadSpace.feature
@@ -8,7 +8,7 @@ Feature: download space
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -23,7 +23,7 @@ Feature: download space
       | spaceFolder/lorem.txt | space team |
     And "Alice" navigates to the project space "team.1"
     When "Alice" downloads the space "team"
-    And "Alice" adds following users to the project space
+    And "Alice" adds following user to the project space
       | user     | role     | kind  |
       | Brian    | Can edit | user  |
     And "Alice" logs out

--- a/tests/e2e/features/spaces/memberExpiry.feature
+++ b/tests/e2e/features/spaces/memberExpiry.feature
@@ -5,7 +5,7 @@ Feature: spaces member expiry
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -13,7 +13,7 @@ Feature: spaces member expiry
       | name | id     |
       | team | team.1 |
     And "Alice" navigates to the project space "team.1"
-    And "Alice" adds following users to the project space
+    And "Alice" adds following user to the project space
       | user  | role     | kind |
       | Brian | Can edit | user |
     And "Alice" sets the expiration date of the member "Brian" of the project space to "+5 days"

--- a/tests/e2e/features/spaces/participantManagement.feature
+++ b/tests/e2e/features/spaces/participantManagement.feature
@@ -8,7 +8,7 @@ Feature: spaces participant management
       | Carol |
       | David |
       | Edith |
-    And "Admin" creates following group using API
+    And "Admin" creates following groups using API
       | id       |
       | sales    |
       | security |
@@ -16,7 +16,7 @@ Feature: spaces participant management
       | user  | group    |
       | David | sales    |
       | Edith | security |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -32,10 +32,10 @@ Feature: spaces participant management
       | security | Can edit | group |
     When "Brian" logs in
     And "Brian" navigates to the project space "team.1"
-    And "Brian" creates the following resources
+    And "Brian" creates the following resource
       | resource | type   |
       | parent   | folder |
-    And "Brian" uploads the following resources
+    And "Brian" uploads the following resource
       | resource  | to     |
       | lorem.txt | parent |
     When "David" logs in
@@ -44,10 +44,10 @@ Feature: spaces participant management
     And "David" logs out
     When "Edith" logs in
     And "Edith" navigates to the project space "team.1"
-    And "Edith" creates the following resources
+    And "Edith" creates the following resource
       | resource | type   |
       | edith    | folder |
-    And "Edith" uploads the following resources
+    And "Edith" uploads the following resource
       | resource  | to    |
       | lorem.txt | edith |
     And "Edith" logs out
@@ -59,13 +59,13 @@ Feature: spaces participant management
       | parent   | Can edit | %public% |
     And "Anonymous" opens the public link "Unnamed link"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" uploads the following resources in public link page
+    And "Anonymous" uploads the following resource in public link page
       | resource     |
       | textfile.txt |
-    And "Anonymous" deletes the following resources from public link using sidebar panel
+    And "Anonymous" deletes the following resource from public link using sidebar panel
       | resource  | from |
       | lorem.txt |      |
-    When "Brian" deletes the following resources using the sidebar panel
+    When "Brian" deletes the following resource using the sidebar panel
       | resource     | from   |
       | textfile.txt | parent |
     When "Carol" navigates to the trashbin
@@ -87,12 +87,12 @@ Feature: spaces participant management
       | resource            |
       | parent/textfile.txt |
     And "Alice" navigates to the project space "team.1"
-    And "Alice" removes access to following users from the project space
+    And "Alice" removes access to following user from the project space
       | user  |
       | Brian |
     Then "Brian" should not see space "team.1"
     And "Brian" logs out
-    When "Alice" changes the roles of the following users in the project space
+    When "Alice" changes the roles of the following user in the project space
       | user  | role       |
       | Carol | Can manage |
     And "Carol" navigates to the trashbin

--- a/tests/e2e/features/spaces/project.feature
+++ b/tests/e2e/features/spaces/project.feature
@@ -19,7 +19,7 @@ Feature: spaces.personal
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -72,10 +72,10 @@ Feature: spaces.personal
     And "Alice" deletes the space "team.2" image using context menu
     And "Alice" changes the space "team.2" icon to "😜" using context menu
 
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource     | type   |
       | folderPublic | folder |
-    And "Alice" uploads the following resources
+    And "Alice" uploads the following resource
       | resource  | to           |
       | lorem.txt | folderPublic |
 
@@ -90,7 +90,7 @@ Feature: spaces.personal
     # borrowed from link.feature, all existing resource actions can be reused
     When "Anonymous" opens the public link "team.1"
     And "Anonymous" unlocks the public link with password "%public%"
-    And "Anonymous" drop uploads following resources
+    And "Anonymous" drop uploads following resource
       | resource     |
       | textfile.txt |
 
@@ -125,7 +125,7 @@ Feature: spaces.personal
     # borrowed from link.feature, all existing resource actions can be reused
     When "Anonymous" opens the public link "team.2"
     And "Anonymous" unlocks the public link with password "new-strongPass1"
-    And "Anonymous" drop uploads following resources
+    And "Anonymous" drop uploads following resource
       | resource     |
       | textfile.txt |
 
@@ -136,7 +136,7 @@ Feature: spaces.personal
       | Alice |
       | Brian |
       | Carol |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
@@ -148,7 +148,7 @@ Feature: spaces.personal
       | resource            | type    | content             |
       | parent              | folder  |                      |
       | parent/textfile.txt | txtFile | some random content  |
-    When "Alice" uploads the following resources
+    When "Alice" uploads the following resource
       | resource     | to     | option  |
       | textfile.txt | parent | replace |
     And "Alice" adds following users to the project space
@@ -169,7 +169,7 @@ Feature: spaces.personal
     And "Brian" downloads old version of the following resource
       | resource     | to     |
       | textfile.txt | parent |
-    And "Brian" restores following resources version
+    And "Brian" restores following resource version
       | resource     | to     | version | openDetailsPanel |
       | textfile.txt | parent | 1       | true             |
     And "Brian" logs out

--- a/tests/e2e/features/spaces/publicLink.feature
+++ b/tests/e2e/features/spaces/publicLink.feature
@@ -8,7 +8,7 @@ Feature: spaces public link
       | Carol |
       | David |
       | Edith |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     When "Alice" logs in
@@ -18,7 +18,7 @@ Feature: spaces public link
     And "Alice" creates the following folder in space "team" using API
       | name                  |
       | spaceFolder/subFolder |
-    And "Alice" creates the following file in space "team" using API
+    And "Alice" creates the following files in space "team" using API
       | name                                  | content   |
       | spaceFolder/shareToBrian.txt          | some text |
       | spaceFolder/subFolder/shareToBrian.md | readme    |
@@ -109,10 +109,10 @@ Feature: spaces public link
       | subFolder | folder |
 
   Scenario: crud operation to public link for space
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     When "Alice" logs in
@@ -133,13 +133,13 @@ Feature: spaces public link
     And "Anonymous" downloads the following public link resources using the sidebar panel
       | resource    | type |
       | example.txt | file |
-    And "Anonymous" uploads the following resources in public link page
+    And "Anonymous" uploads the following resource in public link page
       | resource      |
       | new-lorem.txt |
     And "Anonymous" renames the following public link resources
       | resource    | as          |
       | example.txt | renamed.txt |
-    And "Anonymous" edits the following resources
+    And "Anonymous" edits the following resource
       | resource    | content     |
       | renamed.txt | new content |
     When "Anonymous" deletes the following resources using the sidebar panel

--- a/tests/e2e/features/user-settings/gdprExport.feature
+++ b/tests/e2e/features/user-settings/gdprExport.feature
@@ -4,7 +4,7 @@ Feature: GDPR export
   So I know what data is currently being stored on the system
 
   Background:
-    Given "Admin" creates following users using API
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
 

--- a/tests/e2e/features/user-settings/languageChange.feature
+++ b/tests/e2e/features/user-settings/languageChange.feature
@@ -23,7 +23,7 @@ Feature: language settings
     Then "Alice" should see the following account page title "Einstellungen"
     When "Alice" logs out
     And "Alice" logs in
-    Then "Alice" should see the following notifications
+    Then "Alice" should see the following notification
       | message                                          |
       | Brian Murphy hat check_message mit Ihnen geteilt |
     And "Alice" logs out

--- a/tests/e2e/features/user-settings/notifications.feature
+++ b/tests/e2e/features/user-settings/notifications.feature
@@ -9,17 +9,17 @@ Feature: Notifications
       | Alice |
       | Brian |
       | Carol |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
-    And "Admin" creates following groups using API
+    And "Admin" creates following group using API
       | id    |
       | sales |
     And "Admin" adds user to the group using API
       | user  | group |
       | Alice | sales |
       | Brian | sales |
-    And "Alice" creates the following folder in personal space using API
+    And "Alice" creates the following folders in personal space using API
       | name             |
       | folder_to_shared |
       | share_to_group   |
@@ -27,7 +27,7 @@ Feature: Notifications
       | name | id     |
       | team | team.1 |
     And "Alice" logs in
-    When "Alice" shares the following resource using the sidebar panel
+    When "Alice" shares the following resources using the sidebar panel
       | resource         | recipient | type  | role     | resourceType |
       | folder_to_shared | Brian     | user  | Can edit | folder       |
       | share_to_group   | sales     | group | Can edit | folder       |
@@ -51,7 +51,7 @@ Feature: Notifications
       | Alice Hansen unshared folder_to_shared with you |
       | Alice Hansen added you to Space team            |
     And "Brian" marks all notifications as read
-    When "Alice" removes access to following users from the project space
+    When "Alice" removes access to following user from the project space
       | user  | role     | kind |
       | Carol | Can edit | user |
     And "Carol" logs in
@@ -63,11 +63,11 @@ Feature: Notifications
     When "Alice" opens the "admin-settings" app
     And "Alice" navigates to the project spaces management page
     And "Alice" disables the space "team.1" using the context-menu
-    Then "Brian" should see the following notifications
+    Then "Brian" should see the following notification
       | message                          |
       | Alice Hansen disabled Space team |
     When "Alice" deletes the space "team.1" using the context-menu
-    Then "Brian" should see the following notifications
+    Then "Brian" should see the following notification
       | message                         |
       | Alice Hansen deleted Space team |
     And "Brian" logs out

--- a/tests/e2e/features/user-settings/pagination.feature
+++ b/tests/e2e/features/user-settings/pagination.feature
@@ -4,17 +4,17 @@ Feature: check files pagination in personal and project spaces
   So that I do not have to scroll deep down
 
   Scenario: pagination in the project space
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
-    And "Admin" assigns following roles to the users using API
+    And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
     And "Alice" logs in
     And "Alice" creates 55 folders in personal space using API
     And "Alice" creates 55 files in personal space using API
-    And "Alice" creates the following files into personal space using API
+    And "Alice" creates the following file into personal space using API
        | pathToFile           | content                |
        | .hidden-testFile.txt | This is a hidden file. |
     When "Alice" navigates to page "2" of the project space files view
@@ -22,10 +22,10 @@ Feature: check files pagination in personal and project spaces
       | resource        |
       | testfile50.txt |
     And "Alice" closes the file viewer
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource        |
       | testfile50.txt |
-    And following resources should not be displayed in the files list for user "Alice"
+    And following resource should not be displayed in the files list for user "Alice"
       | resource      |
       | testfile1.txt |
     And "Alice" should see the text "111 items with 1 kB in total (56 files including 1 hidden, 55 folders)" at the footer of the page
@@ -45,10 +45,10 @@ Feature: check files pagination in personal and project spaces
       | resource        |
       | testfile50.txt |
     And "Alice" closes the file viewer
-    Then following resources should be displayed in the files list for user "Alice"
+    Then following resource should be displayed in the files list for user "Alice"
       | resource        |
       | testfile50.txt |
-    And following resources should not be displayed in the files list for user "Alice"
+    And following resource should not be displayed in the files list for user "Alice"
       | resource      |
       | testfile1.txt |
     And "Alice" should see the text "112 items with 12 kB in total (56 files, 56 folders)" at the footer of the page

--- a/tests/e2e/features/user-settings/profilePhoto.feature
+++ b/tests/e2e/features/user-settings/profilePhoto.feature
@@ -27,7 +27,7 @@ Feature: profile photo
 
 
   Scenario: profile photo
-    Given "Admin" creates following user using API
+    Given "Admin" creates following users using API
       | id    |
       | Alice |
       | Brian |
@@ -37,7 +37,7 @@ Feature: profile photo
     And "Alice" creates the following folder in personal space using API
       | name         |
       | sharedFolder |
-    And "Alice" shares the following resource using API
+    And "Alice" shares the following resources using API
       | resource       | recipient | type | role     |
       | sharedFolder   | Brian     | user | Can edit |
       | sharedFolder   | Carol     | user | Can edit |

--- a/tests/e2e/features/user-settings/tiles.feature
+++ b/tests/e2e/features/user-settings/tiles.feature
@@ -8,13 +8,13 @@ Feature: Tiles
       | id    |
       | Alice |
     And "Alice" logs in
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource    | type   |
       | tile_folder | folder |
     And "Alice" switches to the "tiles" view
     And "Alice" sees the resources displayed as "tiles"
     And "Alice" opens folder "tile_folder"
-    And "Alice" creates the following resources
+    And "Alice" creates the following resource
       | resource     | type   |
       | tile_folder2 | folder |
     And "Alice" sees the resources displayed as "tiles"

--- a/tests/e2e/steps/api.ts
+++ b/tests/e2e/steps/api.ts
@@ -43,7 +43,7 @@ Given(
 )
 
 Given(
-  '{string} assigns following roles to the users using API',
+  '{string} assigns following role(s) to the users using API',
   async ({ world }: { world: World }, stepUser: string, stepTable: DataTable): Promise<void> => {
     const admin = world.usersEnvironment.getUser({ key: stepUser })
     for await (const info of stepTable.hashes()) {
@@ -54,7 +54,7 @@ Given(
 )
 
 Given(
-  'admin assigns following roles to the user(s) using keycloak API',
+  'admin assigns following role(s) to the user(s) using keycloak API',
   async ({ world }: { world: World }, stepTable: DataTable): Promise<void> => {
     for await (const info of stepTable.hashes()) {
       const user = world.usersEnvironment.getCreatedUser({ key: info.id })
@@ -140,7 +140,7 @@ Given(
 )
 
 Given(
-  '{string} shares the following resource using API',
+  '{string} shares the following resource(s) using API',
   async ({ world }: { world: World }, stepUser: string, stepTable: DataTable): Promise<void> => {
     const user = world.usersEnvironment.getCreatedUser({ key: stepUser })
     for (const info of stepTable.hashes()) {
@@ -303,7 +303,7 @@ Given(
 )
 
 Given(
-  '{string} adds the following tags for the following resources using API',
+  '{string} adds the following tag(s) for the following resource(s) using API',
   async ({ world }: { world: World }, stepUser: string, stepTable: DataTable): Promise<void> => {
     const user = world.usersEnvironment.getCreatedUser({ key: stepUser })
     for (const info of stepTable.hashes()) {

--- a/tests/e2e/steps/ui/favorites.ts
+++ b/tests/e2e/steps/ui/favorites.ts
@@ -13,7 +13,7 @@ When(
 )
 
 When(
-  '{string} removes the following resources from favorites using {string}',
+  '{string} removes the following resource(s) from favorites using {string}',
   async (
     { world }: { world: World },
     stepUser: string,

--- a/tests/e2e/steps/ui/public.ts
+++ b/tests/e2e/steps/ui/public.ts
@@ -104,7 +104,7 @@ When(
 )
 
 When(
-  '{string} drop uploads following resources',
+  '{string} drop uploads following resource(s)',
   async ({ world }: { world: World }, stepUser: string, stepTable: DataTable): Promise<void> => {
     const { page } = world.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.Public({ page })
@@ -177,7 +177,7 @@ Then(
 )
 
 When(
-  /^"([^"]*)" deletes the following resources from public link using (sidebar panel|batch action)$/,
+  /^"([^"]*)" deletes the following resources? from public link using (sidebar panel|batch action)$/,
   async (
     { world }: { world: World },
     stepUser: string,

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -384,7 +384,7 @@ When(
 )
 
 Then(
-  /^following resources (should|should not) be displayed in the (?:files list|Shares|trashbin) for user "([^"]*)"$/,
+  /^following resources? (should|should not) be displayed in the (?:files list|Shares|trashbin) for user "([^"]*)"$/,
   async (
     { world }: { world: World },
     actionType: string,
@@ -407,7 +407,7 @@ Then(
 )
 
 Then(
-  /^following resources (should|should not) be displayed in the search list for user "([^"]*)"$/,
+  /^following resources? (should|should not) be displayed in the search list for user "([^"]*)"$/,
   async (
     { world }: { world: World },
     actionType: string,
@@ -1220,7 +1220,7 @@ When(
 )
 
 When(
-  '{string} marks the following resources as favorite using {string}',
+  '{string} marks the following resource(s) as favorite using {string}',
   async (
     { world }: { world: World },
     stepUser: string,

--- a/tests/e2e/steps/ui/shares.ts
+++ b/tests/e2e/steps/ui/shares.ts
@@ -85,7 +85,7 @@ When(
 )
 
 When(
-  '{string} updates following sharee role(s)',
+  '{string} updates following sharee(s) role(s)',
   async function ({ world }: { world: World }, stepUser: string, stepTable: DataTable) {
     const { page } = world.actorsEnvironment.getActor({ key: stepUser })
     const shareObject = new objects.applicationFiles.Share({ page })

--- a/tests/e2e/steps/ui/spaces.ts
+++ b/tests/e2e/steps/ui/spaces.ts
@@ -173,7 +173,7 @@ When(
 )
 
 When(
-  '{string} removes access to following users from the project space',
+  '{string} removes access to following user(s) from the project space',
   async function (
     { world }: { world: World },
     stepUser: string,
@@ -209,7 +209,7 @@ Then(
 )
 
 When(
-  '{string} changes the roles of the following users in the project space',
+  '{string} changes the roles of the following user(s) in the project space',
   async function (
     { world }: { world: World },
     stepUser: string,


### PR DESCRIPTION
- Sync singular/plural wording like resource(s) user(s) etc in the e2e steps. 
- adjust setting.json so clicking a gherkin step navigates to its step definition