### PR TITLE
fix: name sorting in files table is off when folder name contains a dot

### DIFF
--- a/packages/web-client/tests/unit/helpers/resource/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/resource/functions.spec.ts
@@ -73,10 +73,20 @@ describe('filterResources', () => {
     })
     it.each([
       { name: 'afolder', isFolder: true },
-      { name: 'afolder', type: 'dir' },
-      { name: 'afolder', type: 'folder' }
+      { name: 'afolder', type: 'folder' },
+      { name: 'afolder', type: 'directory' }
     ])('should return empty string if folder', (resource) => {
       expect(extractExtensionFromFile(resource as Resource)).toEqual('')
+    })
+    it.each([
+      { name: 'afolder.with.dot', isFolder: true },
+      { name: 'afolder.with.dot', type: 'folder' },
+      { name: 'afolder.with.dot', type: 'directory' },
+      { name: 'my.vault', isFolder: true, type: 'folder' }
+    ])('should keep extension information for dotted folder names', (resource) => {
+      expect(extractExtensionFromFile(resource as Resource)).toEqual(
+        resource.name.split('.').pop() || ''
+      )
     })
   })
 })

--- a/packages/web-pkg/src/composables/sort/useSort.ts
+++ b/packages/web-pkg/src/composables/sort/useSort.ts
@@ -7,6 +7,7 @@ import { SortDir } from '@opencloud-eu/design-system/helpers'
 
 export interface SortableItem {
   type?: string
+  isFolder?: boolean
   extension?: string
 }
 
@@ -139,7 +140,8 @@ export const sortHelper = <T extends SortableItem>(
   const collator = new Intl.Collator(navigator.language, { sensitivity: 'base', numeric: true })
 
   if (sortBy === 'name') {
-    const isFolder = (item: T) => item.type === 'folder' && !item.extension
+    const isFolder = (item: T) =>
+      item.isFolder || item.type === 'folder' || item.type === 'directory'
     const folders = [...items.filter((i) => isFolder(i))].sort((a, b) =>
       compare(a, b, collator, sortBy, sortDir, sortable)
     )

--- a/packages/web-pkg/tests/unit/composables/sort/useSort.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/sort/useSort.spec.ts
@@ -42,7 +42,16 @@ describe('useSort', () => {
       { id: '6', name: 'b.png', path: '', webDavPath: '', mdate: '1' },
       { id: '7', name: 'Dir1', path: '', webDavPath: '', mdate: '5', type: 'folder' },
       { id: '8', name: 'dir11', path: '', webDavPath: '', mdate: '8', type: 'folder' },
-      { id: '9', name: 'dir3', path: '', webDavPath: '', mdate: '9', type: 'folder' }
+      { id: '9', name: 'dir3', path: '', webDavPath: '', mdate: '9', type: 'folder' },
+      {
+        id: '10',
+        name: 'dir.with.dot',
+        extension: 'dot',
+        path: '',
+        webDavPath: '',
+        mdate: '10',
+        type: 'folder'
+      }
     ]
 
     it('sorts resources by name', () => {
@@ -67,6 +76,7 @@ describe('useSort', () => {
         const { items } = useSort<Resource>(input)
 
         expect(unref(items).map((i) => i.name)).toMatchObject([
+          'dir.with.dot',
           'Dir1',
           'dir2',
           'dir3',
@@ -88,7 +98,8 @@ describe('useSort', () => {
           'Dir4',
           'dir3',
           'dir2',
-          'Dir1'
+          'Dir1',
+          'dir.with.dot'
         ])
       })
     })


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes #2842 

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
