### PR TITLE
fix: batch actions space issues

### DIFF
--- a/packages/web-app-admin-settings/src/components/AppTemplate.vue
+++ b/packages/web-app-admin-settings/src/components/AppTemplate.vue
@@ -60,6 +60,7 @@
                     >
                       <span
                         class="text-sm"
+                        :class="{ hidden: limitedScreenSpace }"
                         v-text="$gettext('%{count} selected', { count: batchActionItems.length })"
                       />
                       <oc-icon fill-type="line" name="close" />

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsPaste.ts
@@ -236,7 +236,7 @@ export const useFileActionsPaste = () => {
 
         return ''
       },
-      class: 'oc-files-actions-copy-trigger font-bold'
+      class: 'oc-files-actions-copy-trigger'
     }
   ])
 

--- a/packages/web-app-files/src/composables/extensions/useFileActions.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileActions.ts
@@ -15,7 +15,6 @@ import {
   useFileActionsFavorite,
   useFileActionsEnableSync,
   useFileActionsMove,
-  useFileActionsPaste,
   useFileActionsOpenShortcut,
   useSpaceActionsSetImage,
   useFileActionsRename,
@@ -23,8 +22,7 @@ import {
   useFileActionsShowShares,
   useFileActionsToggleHideShare,
   useFileActionsLockVault,
-  useFileActionsUnlockVault,
-  useFileActionsClearClipboard
+  useFileActionsUnlockVault
 } from '../actions'
 import { unref } from 'vue'
 
@@ -42,8 +40,6 @@ export const useFileActions = (): ActionExtension[] => {
   const { actions: disableSyncActions } = useFileActionsDisableSync()
   const { actions: enableSyncActions } = useFileActionsEnableSync()
   const { actions: moveActions } = useFileActionsMove()
-  const { actions: pasteActions } = useFileActionsPaste()
-  const { actions: clearClipboardActions } = useFileActionsClearClipboard()
   const { actions: renameActions } = useFileActionsRename()
   const { actions: favoriteActions } = useFileActionsFavorite()
   const { actions: setSpaceImageActions } = useSpaceActionsSetImage()
@@ -117,24 +113,6 @@ export const useFileActions = (): ActionExtension[] => {
       action: {
         ...unref(permanentLinkActions)[0],
         category: 'secondary'
-      }
-    },
-    {
-      id: 'com.github.opencloud-eu.web.files.context-action.paste',
-      extensionPointIds: [batchActionsExtensionPoint.id],
-      type: 'action',
-      action: {
-        ...unref(pasteActions)[0],
-        category: 'quaternary'
-      }
-    },
-    {
-      id: 'com.github.opencloud-eu.web.files.context-action.clear-clipboard',
-      extensionPointIds: [batchActionsExtensionPoint.id],
-      type: 'action',
-      action: {
-        ...unref(clearClipboardActions)[0],
-        category: 'quaternary'
       }
     },
     {

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -75,6 +75,7 @@
             >
               <span
                 class="text-sm"
+                :class="{ hidden: limitedScreenSpace }"
                 v-text="$gettext('%{count} selected', { count: selectedResources.length })"
               />
               <oc-icon fill-type="line" name="close" />


### PR DESCRIPTION
Fixes batch action display issues with limited screen space by:

1. removing clipboard buttons, copying/cutting is available via keyboard only anyways
2. hiding the selection label with limited screen space