### PR TITLE
[stable-7.1] chore: add Firefox ESR to supported browser list

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "browserslist": [
     "last 1 year",
+    "Firefox ESR",
     "> .2%",
     "not dead",
     "not Explorer > 0",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -32,6 +32,7 @@
   "browserslist": [
     "> 1%",
     "last 2 versions",
+    "Firefox ESR",
     "not Explorer > 0",
     "not ExplorerMobile > 0",
     "not BlackBerry > 0",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-7.1`:
 - [chore: add firefox ESR to supported browser list](https://github.com/opencloud-eu/web/pull/2853)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)