### PR TITLE
🎉 Release 7.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## [7.1.4](https://github.com/opencloud-eu/web/releases/tag/v7.1.4) - 2026-07-10
+## [7.1.4](https://github.com/opencloud-eu/web/releases/tag/v7.1.4) - 2026-07-13
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@AlexAndBear
+@AlexAndBear, @kulmann
 
+### 🐛 Bug Fixes
 
+- [stable-7.1] chore: add Firefox ESR to supported browser list [[#2855](https://github.com/opencloud-eu/web/pull/2855)]
 
 ## [7.1.3](https://github.com/opencloud-eu/web/releases/tag/v7.1.3) - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [7.1.4](https://github.com/opencloud-eu/web/releases/tag/v7.1.4) - 2026-07-10
+
+### ❤️ Thanks to all contributors! ❤️
+
+@AlexAndBear
+
+
+
 ## [7.1.3](https://github.com/opencloud-eu/web/releases/tag/v7.1.3) - 2026-06-30
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `7.1.4` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-7.1` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [7.1.4](https://github.com/opencloud-eu/web/releases/tag/v7.1.4) - 2026-07-13

### 🐛 Bug Fixes

- [stable-7.1] chore: add Firefox ESR to supported browser list [[#2855](https://github.com/opencloud-eu/web/pull/2855)]