### PR TITLE
fix: bring back x button in app top bar instead of left arrow

### DIFF
--- a/packages/web-pkg/src/components/AppTopBar.vue
+++ b/packages/web-pkg/src/components/AppTopBar.vue
@@ -10,7 +10,7 @@
       :aria-label="$gettext('Close')"
       @click="$emit('close')"
     >
-      <oc-icon name="arrow-left-s" fill-type="line" />
+      <oc-icon name="close" fill-type="line" />
     </oc-button>
     <div
       class="pr-1 my-2 mx-auto sm:m-0 inline-flex items-center bg-role-chrome rounded-lg h-10 gap-2 w-full sm:w-fit"

--- a/packages/web-pkg/src/components/AppTopBar.vue
+++ b/packages/web-pkg/src/components/AppTopBar.vue
@@ -6,7 +6,7 @@
       id="app-top-bar-close"
       appearance="raw-inverse"
       color-role="chrome"
-      class="p-1"
+      class="mr-2"
       :aria-label="$gettext('Close')"
       @click="$emit('close')"
     >


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

Multiple reasons to do so:

- the left arrow is kind of small and easy to overlook
- an x icon makes it more clear to the user that this will close the app and they need to save their state
- gdrive does it as well 🤡 

<img width="1511" height="831" alt="image" src="https://github.com/user-attachments/assets/403f261c-269a-4f53-ab5c-535ec81b9253" />

<img width="1512" height="246" alt="image" src="https://github.com/user-attachments/assets/3b6ce1b6-ef96-4dfc-aca4-eb14daa2a5d7" />



## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
