### PR TITLE
fix: add space after password label when copying

### DIFF
--- a/packages/web-pkg/src/composables/links/useCopyLink.ts
+++ b/packages/web-pkg/src/composables/links/useCopyLink.ts
@@ -33,7 +33,7 @@ export const useCopyLink = () => {
         // Only copy to clipboard if the user tries to create one single link
         try {
           copyToClipboardText = password
-            ? $gettext('%{link} Password:%{password}', {
+            ? $gettext('%{link} Password: %{password}', {
                 link: succeeded[0].value.webUrl,
                 password
               })


### PR DESCRIPTION
## Description

This change adds a space after `Password:` when copying a public link together with its password.

Currently, the password starts immediately after the colon:

```text
https://cloud.docs.opencloud.rocks/s/KKLPLdXPWRzHDkm Password:!=U8#9CSgHth
```

After this change, the copied text contains a space between the label and the password:

```text
https://cloud.docs.opencloud.rocks/s/KKLPLdXPWRzHDkm Password: !=U8#9CSgHth
```

This improves readability and makes it easier to distinguish the password from the `Password:` label.

<img width="531" height="234" alt="Copied link and password without a space after the Password label" src="https://github.com/user-attachments/assets/d8b1b74e-cfc1-4429-abc1-80a71769e80c" />

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

* [ ] Bugfix
* [x] Enhancement (a change that doesn't break existing code or deployments)
* [ ] Breaking change (a modification that affects current functionality)
* [ ] Technical debt (addressing code that needs refactoring or improvements)
* [ ] Tests (adding or improving tests)
* [ ] Documentation (updates or additions to documentation)
* [ ] Maintenance (like dependency updates or tooling adjustments)
