### PR TITLE
refactor: clean up icon props on app interfaces

### DIFF
--- a/packages/web-app-pdf-viewer/src/index.ts
+++ b/packages/web-app-pdf-viewer/src/index.ts
@@ -32,12 +32,11 @@ export default defineWebApplication({
         name: $gettext('PDF Viewer'),
         id: appId,
         icon: 'resource-type-pdf',
-        iconFillType: 'fill',
-        iconColor: 'var(--oc-color-icon-pdf)',
         extensions: [
           {
             extension: 'pdf',
-            routeName: 'pdf-viewer'
+            routeName: 'pdf-viewer',
+            iconFillType: 'fill'
           }
         ]
       },

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -63,7 +63,29 @@ export interface ApplicationFileExtension {
   hasPriority?: boolean
   label?: string | (() => string)
   name?: string
+  /**
+   * Defines the icon for the given file type in the file list, the "New"-
+   * and the "Open with..."-menu.
+   * Defaults to the `icon` property of the application if not specified.
+   *
+   * Note that in the file list, the icon might be overridden if there is a
+   * default icon defined for the given file type.
+   */
   icon?: string
+  /**
+   * Defines the color of the icon in the file list.
+   * In the "New"- and "Open with..."-menu, colors are not used, so this will be ignored.
+   * Defaults to the `color` property of the application if not specified.
+   *
+   * Note that in the file list, the icon might be overridden if there is a
+   * default icon defined for the given file type.
+   */
+  iconColor?: string
+  /**
+   * Defines the fill type of the icon in the "Open with..."-menu.
+   * In the file list and the "New"-menu, the fill type is always `fill`, so this will be ignored.
+   * Defaults to `line` in the "Open with..."-menu if not specified.
+   */
   iconFillType?: IconFillType
   mimeType?: string
   newFileMenu?: {
@@ -83,7 +105,9 @@ export interface ApplicationInformation {
   id?: string
   name?: string
   icon?: string
+  /** @deprecated use the iconFillType on ApplicationFileExtension instead */
   iconFillType?: IconFillType
+  /** @deprecated use the iconColor on ApplicationFileExtension instead */
   iconColor?: string
   img?: string
   meta?: {

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -96,9 +96,7 @@ export const useFileActions = () => {
             return appInfo.name
           },
           icon: fileExtension.icon || appInfo.icon,
-          ...(appInfo.iconFillType && {
-            iconFillType: appInfo.iconFillType
-          }),
+          iconFillType: fileExtension.iconFillType || appInfo.iconFillType,
           img: appInfo.img,
           route: ({ space, resources }) => {
             return getEditorRoute({

--- a/packages/web-pkg/src/helpers/resource/icon.ts
+++ b/packages/web-pkg/src/helpers/resource/icon.ts
@@ -4,6 +4,7 @@ export type IconFillType = FillType
 export type IconType = {
   name: string
   color?: string
+  /** @deprecated this property is not supported anymore */
   fillType?: IconFillType
   hasDarkVariant?: boolean
 }

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -337,15 +337,9 @@ export const announceApplicationsReady = async ({
     const app = appsStore.apps[fileExtensions.app]
 
     const getIconDefinition = () => {
-      const fillType = fileExtensions.iconFillType || app.iconFillType
       return {
         name: fileExtensions.icon || app.icon,
-        ...(fillType && {
-          fillType
-        }),
-        ...(app.iconColor && {
-          color: app.iconColor
-        })
+        color: fileExtensions.iconColor || app.color
       }
     }
 


### PR DESCRIPTION
Deprecate `iconColor` and `iconFillType` on the `ApplicationInformation` interface since they don't really fit there. An app already defines a `color` and an `icon` with a hard-coded `fill` fill-type for the app switcher menu.

File type icons (& their color and fill-type) are better defined on the `ApplicationFileExtension` interface. Introduce the missing `iconColor` there and add doc strings for all icon props.