### PR TITLE
feat(extension-sdk): inject package.json metadata into manifest.json

### DIFF
--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencloud-eu/extension-sdk",
-  "version": "7.2.0",
+  "version": "7.3.0-alpha.1",
   "description": "OpenCloud Web Extension SDK",
   "license": "AGPL-3.0",
   "main": "dist/extension-sdk.js",

--- a/packages/extension-sdk/src/index.ts
+++ b/packages/extension-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, searchForWorkspaceRoot, ViteDevServer } from 'vite'
+import { mergeConfig, ViteDevServer } from 'vite'
 import { join, posix as posixPath } from 'path'
 import { cwd } from 'process'
 import { readFileSync, existsSync } from 'fs'
@@ -39,9 +39,7 @@ export function defineConfig(overrides: ExtensionConfigOverrides = {}) {
     const isTesting = mode === 'test'
 
     // read package name from vite workspace
-    const packageJson = JSON.parse(
-      readFileSync(join(searchForWorkspaceRoot(cwd()), 'package.json')).toString()
-    )
+    const packageJson = JSON.parse(readFileSync(join(cwd(), 'package.json')).toString())
 
     const name = overrides.name || packageJson.name
 
@@ -135,7 +133,7 @@ export function defineConfig(overrides: ExtensionConfigOverrides = {}) {
               ]
             : []),
           tailwindcss(),
-          manifestPlugin(remoteEntryName),
+          manifestPlugin(remoteEntryName, packageJson),
           federationRegistrationClient({
             hostUrl,
             name,

--- a/packages/extension-sdk/src/plugins/manifest.ts
+++ b/packages/extension-sdk/src/plugins/manifest.ts
@@ -8,7 +8,10 @@ export const manifestPath = join('./src/', manifestFile)
 /**
  * Generates manifest.json for OpenCloud app discovery.
  */
-export function manifestPlugin(remoteEntryName: string): Plugin {
+export function manifestPlugin(
+  remoteEntryName: string,
+  packageJson: Record<string, unknown>
+): Plugin {
   let outputDir = ''
 
   return {
@@ -50,6 +53,13 @@ export function manifestPlugin(remoteEntryName: string): Plugin {
           )
         }
       }
+
+      const metaData = ['name', 'version', 'description', 'license', 'author']
+      metaData.forEach((key) => {
+        if (packageJson[key] && typeof packageJson[key] === 'string') {
+          manifest[key] = packageJson[key]
+        }
+      })
 
       // set entryPoint
       manifest.entrypoint = entryChunk!.fileName


### PR DESCRIPTION
- Add packageJson parameter to manifestPlugin
- Inject name, version, description, license, and author from package.json
- Simplify package.json reading by using cwd() instead of searchForWorkspaceRoot()

This allows extensions to automatically include metadata in their manifest without manual duplication.

<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
