### PR TITLE
split keycloak test

### DIFF
--- a/tests/e2e/cucumber/features/keycloak/smoke.feature
+++ b/tests/e2e/cucumber/features/keycloak/smoke.feature
@@ -69,7 +69,19 @@ Feature: keycloak integration
       | displayname | Carol King        |
       | email       | carol@example.org |
       | groups      | finance, security |
-    
+    And "Carol" logs out
+
+
+  Scenario: disabling and enabling users in keycloak
+    Given admin creates following users using keycloak API
+      | id    |
+      | Carol |
+    When "Carol" logs in
+    Then "Carol" should have self info:
+      | key         | value             |
+      | username    | carol             |
+      | displayname | Carol King        |
+      | email       | carol@example.org |
     # disble user and delete user sessions to force logout
     When admin disables user "Carol" using keycloak API
     And admin deletes sessions of user "Carol" using keycloak API
@@ -80,5 +92,4 @@ Feature: keycloak integration
     When admin enables user "Carol" using keycloak API
     Then "Carol" logs in
     And "Carol" opens the "files" app
-    And "Carol" navigates to the project space "brianSpace.1"
     And "Carol" logs out


### PR DESCRIPTION
moving disabling/enabling user to separate Scenario. 
@schweigisito we can change this line https://github.com/opencloud-eu/opencloud-charts/blob/9af13cc196f908a3085cc4a5ca12a65706882c61/.woodpecker.star#L288 as `bash run-e2e.sh cucumber/features/keycloak/smoke.feature:7` to don't run backchannel test

related: https://github.com/opencloud-eu/opencloud-charts/pull/257
https://github.com/opencloud-eu/opencloud-charts/issues/262
