### PR TITLE
🎉 Release 7.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [7.1.5](https://github.com/opencloud-eu/web/releases/tag/v7.1.5) - 2026-07-16
+
+### ❤️ Thanks to all contributors! ❤️
+
+@v-scharf
+
+### ✅ Tests
+
+- split keycloak test [[#2897](https://github.com/opencloud-eu/web/pull/2897)]
+
 ## [7.1.4](https://github.com/opencloud-eu/web/releases/tag/v7.1.4) - 2026-07-13
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [7.1.5](https://github.com/opencloud-eu/web/releases/tag/v7.1.5) - 2026-07-16
+## [7.1.5](https://github.com/opencloud-eu/web/releases/tag/v7.1.5) - 2026-08-12
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@v-scharf
+@AlexAndBear, @v-scharf
+
+### 🐛 Bug Fixes
+
+- [stable-7.1] fix: encode hash character in app route URLs to prevent truncation (#3075) [[#3080](https://github.com/opencloud-eu/web/pull/3080)]
 
 ### ✅ Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- fix(text-editor): update editor content when loaded via recovery [[#3081](https://github.com/opencloud-eu/web/pull/3081)]
 - [stable-7.1] fix: encode hash character in app route URLs to prevent truncation (#3075) [[#3080](https://github.com/opencloud-eu/web/pull/3080)]
 
 ### ✅ Tests


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `7.1.5` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-7.1` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [7.1.5](https://github.com/opencloud-eu/web/releases/tag/v7.1.5) - 2026-08-12

### 🐛 Bug Fixes

- fix(text-editor): update editor content when loaded via recovery [[#3081](https://github.com/opencloud-eu/web/pull/3081)]
- [stable-7.1] fix: encode hash character in app route URLs to prevent truncation (#3075) [[#3080](https://github.com/opencloud-eu/web/pull/3080)]

### ✅ Tests

- split keycloak test [[#2897](https://github.com/opencloud-eu/web/pull/2897)]