### PR TITLE
e2e-fix: a11y flaky in webkit

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,6 +11,7 @@
 - [Running Tests in VS Code](#running-tests-in-vs-code)
 - [Test Report](#test-report)
 - [Debugging](#debugging)
+- [Timeouts](#timeouts)
 
 ## Prerequisites
 
@@ -87,3 +88,18 @@ Install [Playwright Test for VSCode](https://marketplace.visualstudio.com/items?
   (combine with `--project=chromium -g "scenario name"` to target one test).
 - `pnpm playwright show-trace <trace.zip>` — [Trace Viewer](https://playwright.dev/docs/trace-viewer) for a recorded
   trace (recorded `on-first-retry` by default, see `playwright.config.ts`).
+
+## Timeouts
+
+There is a single **per-test** timeout, `testTimeout` (default `120`s, override with `TEST_TIMEOUT`). It is the
+budget for the whole scenario (all steps + hooks)
+
+When a scenario needs more time, use ([playwright-bdd special tags](https://vitalets.github.io/playwright-bdd/#/writing-features/special-tags)):
+
+```gherkin
+@slow                 # test.slow() → triples the timeout
+Scenario: Upload large resources ...
+
+@timeout:300000       # exact timeout in milliseconds
+Scenario: something even longer ...
+```

--- a/tests/e2e/features/a11y/smoke.feature
+++ b/tests/e2e/features/a11y/smoke.feature
@@ -1,6 +1,7 @@
 @a11y
 Feature: Accessibility checks
 
+  @timeout:300000
   Scenario: check files view wrapper accessibility
     Given "Admin" creates following users using API
       | id    |

--- a/tests/e2e/features/journeys/kindergarten.feature
+++ b/tests/e2e/features/journeys/kindergarten.feature
@@ -18,7 +18,7 @@ Feature: Kindergarten can use web to organize a day
       | user  | group |
       | Brian | sales |
 
-  @firefox-skip @webkit-skip
+  @firefox-skip @webkit-skip @timeout:300000
   Scenario: Alice can share this weeks meal plan with all parents
     When "Alice" logs in
     And "Alice" navigates to the personal space page

--- a/tests/e2e/features/smoke/uploadResumable.feature
+++ b/tests/e2e/features/smoke/uploadResumable.feature
@@ -3,6 +3,8 @@ Feature: Upload large resources
   I want to upload large resources
   So that I can pause and resume the upload
 
+  # a 1GB upload can run longer than the default test timeout; @slow triples it
+  @slow
   Scenario: Upload large resources in personal space
     Given "Admin" creates following user using API
       | id    |

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -55,7 +55,8 @@ export const appConfig = {
     return withHttp(url)
   },
 
-  // Timeouts
+  // Timeouts (in seconds; multiply by 1000 when passing to Playwright APIs).
+  // (@slow / @timeout:<ms>)
   testTimeout: parseInt(process.env.TEST_TIMEOUT || '120'),
   get timeout() {
     return this.testTimeout

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -91,9 +91,6 @@ When(
 
 When(
   '{string} {word} the file upload',
-  // increase the test timeout for large uploads.
-  // ignores the global timeout.
-  // { timeout: config.largeUploadTimeout * 1000 },
   async ({ world }: { world: World }, stepUser: string, action: string): Promise<void> => {
     const { page } = world.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1902,6 +1902,7 @@ export const clickViewModeToggle = async (args: switchViewModeArgs): Promise<voi
     await page.locator('#viewmode-switch-toggle').click()
     await page.locator(`#viewmode-switch-drop .${webSelectors[target]}`).click()
   }
+  await expect(page.locator(mobileViewmodeSwitchDropdown)).toBeHidden()
 }
 
 export const expectThatResourcesAreDisplayedAs = async (args: {

--- a/tests/e2e/support/utils/accessibility.ts
+++ b/tests/e2e/support/utils/accessibility.ts
@@ -26,8 +26,16 @@ async function checkAccessibility(
     // wait for drop animation
     await page.waitForTimeout(300)
   }
-  const builder = new AxeBuilder({ page }).withTags(a11yRuleTags).include(includeSelector)
-  const results = await builder.analyze()
+
+  function analyze() {
+    return new AxeBuilder({ page }).withTags(a11yRuleTags).include(includeSelector).analyze()
+  }
+
+  let results = await analyze()
+  if (results.violations.length > 0) {
+    await page.waitForTimeout(500)
+    results = await analyze()
+  }
 
   if (results.violations.length > 0) {
     console.error(`♿ Accessibility violations detected${context ? ` in ${context}` : ''}:`)


### PR DESCRIPTION
- fix a11y test flaky in webkit
- increase timeout for a11y test using [tags](https://vitalets.github.io/playwright-bdd/#/writing-features/special-tags) 