### PR TITLE
chore(design-system): fix docs build

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1217,6 +1217,7 @@ def designSystemDocs(ctx):
             },
         ],
         "when": [
+            event["pull_request"],
             event["main_branch"],
         ],
         "workspace": web_workspace,

--- a/packages/design-system/docs/.vitepress/config.ts
+++ b/packages/design-system/docs/.vitepress/config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
   appearance: false,
   head: [['link', { rel: 'icon', href: '/logo.svg' }]],
   vite: {
+    // Pinia (like Vue's own esm-bundler build) references Vue's compile-time
+    // feature flags such as `__VUE_PROD_DEVTOOLS__`. VitePress externalizes deps
+    // during SSR, so force-bundle Pinia to let Vite substitute those flags.
+    ssr: {
+      noExternal: ['pinia']
+    },
     resolve: {
       alias: {
         // necessary to allow compiling our live code blocks


### PR DESCRIPTION
Fixes building of the design-system docs which broke with the recent major upgrade of pinia. It mustn't get externalized by VitePress when building.

Also, instead of building the design-system docs only when merging on the main branch, build them on every PR. The publishing of the docs however still only happens on merges. This ensures that we detect failing doc builds early in CI.
