### PR TITLE
fix(pdf-viewer): harden rendering of PDFs

### DIFF
--- a/packages/web-app-pdf-viewer/package.json
+++ b/packages/web-app-pdf-viewer/package.json
@@ -8,6 +8,7 @@
     "@opencloud-eu/web-test-helpers": "workspace:*"
   },
   "peerDependencies": {
+    "@opencloud-eu/web-client": "workspace:*",
     "@opencloud-eu/web-pkg": "workspace:*",
     "vue3-gettext": "^4.0.0-beta.1"
   }

--- a/packages/web-app-pdf-viewer/src/App.vue
+++ b/packages/web-app-pdf-viewer/src/App.vue
@@ -1,25 +1,40 @@
 <template>
-  <object class="pdf-viewer size-full overflow-hidden" :data="url" :type="objectType" />
+  <iframe
+    v-if="isFirefox"
+    class="pdf-viewer size-full overflow-hidden"
+    :src="url"
+    :title="resource?.name"
+  />
+  <object v-else class="pdf-viewer size-full overflow-hidden" :data="url" :type="objectType">
+    <div
+      class="pdf-viewer-fallback flex size-full flex-col items-center justify-center gap-4 p-8 text-center"
+    >
+      <p class="text-lg" v-text="$gettext('This PDF could not be displayed in your browser.')" />
+      <oc-button type="a" appearance="filled" :href="url" :download="resource?.name">
+        <oc-icon name="download" fill-type="line" />
+        {{ $gettext('Download PDF') }}
+      </oc-button>
+    </div>
+  </object>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+import { Resource } from '@opencloud-eu/web-client'
 
-export default defineComponent({
-  props: {
-    url: {
-      type: String,
-      required: true
-    }
-  },
-  setup() {
-    const isSafari =
-      navigator.userAgent?.includes('Safari') && !navigator.userAgent?.includes('Chrome')
-    const objectType = isSafari ? undefined : 'application/pdf'
+const { url, resource = undefined } = defineProps<{
+  url: string
+  resource?: Resource
+}>()
 
-    return {
-      objectType
-    }
-  }
-})
+const userAgent = navigator.userAgent || ''
+
+// Firefox renders blob: PDFs unreliably in <object>/<embed> (often a blank frame), so it
+// gets an <iframe> instead, which handles blob: URLs reliably. Other browsers keep <object>:
+// it supports fallback content, and <iframe> is known to struggle with PDFs on iOS Safari.
+const isFirefox = userAgent.includes('Firefox')
+
+// Safari does not support the `type` attribute on <object> for PDFs, so it is omitted to
+// avoid a blank frame. Other browsers get the type attribute, which helps them render PDFs.
+const isSafari = userAgent.includes('Safari') && !userAgent.includes('Chrome')
+const objectType = isSafari ? undefined : 'application/pdf'
 </script>

--- a/packages/web-app-pdf-viewer/tests/unit/App.spec.ts
+++ b/packages/web-app-pdf-viewer/tests/unit/App.spec.ts
@@ -1,0 +1,88 @@
+import App from '../../src/App.vue'
+import { defaultPlugins, shallowMount } from '@opencloud-eu/web-test-helpers'
+import { Resource } from '@opencloud-eu/web-client'
+import { mock } from 'vitest-mock-extended'
+
+const FIREFOX_UA = 'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0'
+const CHROME_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+const SAFARI_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+const FIREFOX_IOS_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/605.1.15'
+
+const url = 'blob:https://example.com/abc'
+
+// `userAgent` is an inherited accessor on the Navigator prototype, so setting it creates a
+// shadowing own property. Capture the original descriptor (if any) to fully restore afterwards.
+const originalUserAgentDescriptor = Object.getOwnPropertyDescriptor(window.navigator, 'userAgent')
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true
+  })
+}
+
+afterEach(() => {
+  if (originalUserAgentDescriptor) {
+    Object.defineProperty(window.navigator, 'userAgent', originalUserAgentDescriptor)
+  } else {
+    Reflect.deleteProperty(window.navigator, 'userAgent')
+  }
+})
+
+function getWrapper({ resource = mock<Resource>({ name: 'doc.pdf' }) } = {}) {
+  return shallowMount(App, {
+    props: { url, resource },
+    global: {
+      plugins: [...defaultPlugins()]
+    }
+  })
+}
+
+describe('PDF viewer App', () => {
+  describe('in Firefox', () => {
+    it('renders an iframe pointing at the blob url', () => {
+      setUserAgent(FIREFOX_UA)
+      const wrapper = getWrapper()
+
+      const iframe = wrapper.find('iframe.pdf-viewer')
+      expect(iframe.exists()).toBe(true)
+      expect(iframe.attributes('src')).toBe(url)
+      expect(iframe.attributes('title')).toBe('doc.pdf')
+      expect(wrapper.find('object').exists()).toBe(false)
+    })
+  })
+
+  describe.each([
+    ['Chrome', CHROME_UA, 'application/pdf'],
+    ['Safari', SAFARI_UA, undefined],
+    ['Firefox for iOS', FIREFOX_IOS_UA, undefined]
+  ])('in %s', (_name, userAgent, expectedType) => {
+    it('renders an object with the expected type', () => {
+      setUserAgent(userAgent)
+      const wrapper = getWrapper()
+
+      const object = wrapper.find('object.pdf-viewer')
+      expect(object.exists()).toBe(true)
+      expect(object.attributes('data')).toBe(url)
+      expect(object.attributes('type')).toBe(expectedType)
+      expect(wrapper.find('iframe').exists()).toBe(false)
+    })
+
+    it('provides a download fallback inside the object', () => {
+      setUserAgent(userAgent)
+      const wrapper = getWrapper()
+
+      expect(wrapper.find('.pdf-viewer-fallback p').text()).toBe(
+        'This PDF could not be displayed in your browser.'
+      )
+
+      const downloadButton = wrapper.find('oc-button-stub')
+      expect(downloadButton.exists()).toBe(true)
+      expect(downloadButton.attributes('href')).toBe(url)
+      expect(downloadButton.attributes('download')).toBe('doc.pdf')
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
 
   packages/web-app-pdf-viewer:
     dependencies:
+      '@opencloud-eu/web-client':
+        specifier: workspace:*
+        version: link:../web-client
       '@opencloud-eu/web-pkg':
         specifier: workspace:*
         version: link:../web-pkg

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -130,7 +130,7 @@ const mobileViewmodeSwitchBtn = '#viewmode-switch-toggle'
 const mobileViewmodeSwitchDropdown = '#viewmode-switch-drop'
 
 // file viewer
-const pdfViewerContainer = '#pdf-viewer object.pdf-viewer'
+const pdfViewerContainer = '#pdf-viewer .pdf-viewer'
 const textEditorContainer = '.text-editor-provider .ProseMirror'
 
 // online office locators


### PR DESCRIPTION
Take 2 measurement to harden rendering of PDFs:

- Use `<iframe>` for rendering PDFs in Firefox, since the browser seems to struggle with the `<object>/<embed>` approach (the default csp settings allow `frame-src: blob`, so this isn't an issue).
- Fall back to an error message and a download button if loading a PDF fails for some reasons.

refs https://github.com/opencloud-eu/web/issues/2340