### PR TITLE
perf: improve file selection in tiles view

### DIFF
--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`Projects view > different files view states > lists all available proje
   <div class="files-view-wrapper relative grid grid-cols-1 flex-1 focus:outline-0 h-full overflow-y-auto gap-0">
     <div id="files-view" class="outline-0 z-0 flex flex-col">
       <app-bar-stub viewmodedefault="resource-tiles" breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" viewmodes="[object Object]" hasbulkactions="true" hasviewoptions="true" hashiddenfiles="false" hasfileextensions="false" haspagination="false" showactionsbar="true" showactionsonselection="true" batchactionsloading="false"></app-bar-stub>
-      <table data-v-3c9ab66c="" class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table" sort-fields="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" view-size="1" id="files-space-table" selection="">
+      <table data-v-3c9ab66c="" class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table" sort-fields="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" view-size="1" id="files-space-table">
         <thead data-v-3c9ab66c="" class="oc-thead border-b">
           <tr data-v-98c4aba8="" data-v-3c9ab66c="" class="oc-table-header-row h-10.5">
             <th data-v-27e13406="" data-v-c53469a5="" data-v-3c9ab66c="" class="oc-table-cell text-left align-middle w-px oc-th aria-[sort]:cursor-pointer oc-table-header-cell oc-table-header-cell-select z-10 pl-4" style="top: 0px;">

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -21,7 +21,6 @@
     :drag-drop="dragDrop"
     :hover="hover"
     :item-dom-selector="resourceDomSelector"
-    :selection="selectedResources"
     :sort-by="sortBy"
     :sort-dir="sortDir"
     :lazy="lazy"
@@ -410,7 +409,6 @@ const { isSticky } = useIsTopBarSticky()
 const { $gettext, $ngettext, current: currentLanguage } = useGettext()
 const { isLocationPicker, isFilePicker } = useEmbedMode()
 const {
-  selectedResources,
   disabledResources,
   isResourceSelected,
   fileContainerClicked,

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -39,7 +39,7 @@
           <div v-if="isLoading" class="oc-tile-card-loading-spinner z-990 m-2">
             <oc-spinner :aria-label="$gettext('File is being processed')" />
           </div>
-          <slot v-else name="selection" :item="resource" />
+          <slot v-else name="selection" :item="resource" :selected="isResourceSelected" />
         </div>
         <oc-tag
           v-if="isProjectSpaceResource(resource) && resource.disabled"
@@ -124,13 +124,12 @@ import { isSpaceResource } from '@opencloud-eu/web-client'
 import { RouteLocationRaw } from 'vue-router'
 import { useIsVisible } from '@opencloud-eu/design-system/composables'
 import { OcCard } from '@opencloud-eu/design-system/components'
-import { useFolderLink } from '../../composables'
+import { useFolderLink, useResourcesStore } from '../../composables'
 
 const {
   resource,
   space,
   resourceRoute,
-  isResourceSelected = false,
   isResourceClickable = true,
   isResourceDisabled = false,
   isExtensionDisplayed = true,
@@ -142,7 +141,6 @@ const {
   resource?: Resource
   resourceRoute?: RouteLocationRaw
   space?: SpaceResource
-  isResourceSelected?: boolean
   isResourceClickable?: boolean
   isResourceDisabled?: boolean
   isExtensionDisplayed?: boolean
@@ -164,7 +162,7 @@ defineSlots<{
   contextMenu?: (props: { item: Resource }) => unknown
   imageField?: (props: { item: Resource }) => unknown
   indicators?: (props: { item: Resource }) => unknown
-  selection?: (props: { item: Resource }) => unknown
+  selection?: (props: { item: Resource; selected: boolean }) => unknown
   additionalResourceContent?: (props: { item: Resource }) => unknown
 }>()
 
@@ -172,6 +170,9 @@ const { $gettext } = useGettext()
 const { getParentFolderName, getParentFolderLink } = useFolderLink({
   space: ref(space)
 })
+
+const resourcesStore = useResourcesStore()
+const isResourceSelected = computed(() => resourcesStore.selectedIdsSet.has(resource.id))
 
 const observerTarget = useTemplateRef<InstanceType<typeof OcCard>>('observerTarget')
 const observerTargetElement = computed<HTMLElement>(() => unref(observerTarget)?.$el)

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -54,7 +54,6 @@
           :resource="resource"
           :space="space"
           :resource-route="getResourceLink(resource)"
-          :is-resource-selected="isResourceSelected(resource)"
           :is-resource-clickable="isResourceClickable(resource, areResourcesClickable)"
           :is-resource-disabled="isResourceDisabled(resource)"
           :is-extension-displayed="areFileExtensionsShown"
@@ -76,7 +75,7 @@
           @item-visible="$emit('itemVisible', resource)"
           @tile-clicked="fileContainerClicked({ resource, event: $event[1] })"
         >
-          <template #selection>
+          <template #selection="{ selected }">
             <oc-checkbox
               v-if="isSelectable && !isLocationPicker && !isFilePicker"
               :label="getResourceCheckboxLabel(resource)"
@@ -84,7 +83,7 @@
               size="large"
               class="inline-flex p-2.5"
               :disabled="isResourceDisabled(resource)"
-              :model-value="isResourceSelected(resource)"
+              :model-value="selected"
               :data-test-selection-resource-name="resource.name"
               :data-test-selection-resource-path="resource.path"
               @click.stop="fileCheckboxClicked({ resource, event: $event })"
@@ -234,7 +233,6 @@ const sidebarStore = useSideBar()
 const { isSideBarOpen } = storeToRefs(sidebarStore)
 const {
   disabledResources,
-  isResourceSelected,
   fileContainerClicked,
   fileNameClicked,
   fileCheckboxClicked,

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -107,9 +107,10 @@ export const useResourcesStore = defineStore('resources', () => {
   const selectedIds = ref<string[]>([])
   const latestSelectedId = ref<string>(null)
 
+  const selectedIdsSet = computed(() => new Set(unref(selectedIds)))
+
   const selectedResources = computed(() => {
-    const selectedIdsSet = new Set(unref(selectedIds))
-    return unref(resources).filter((f) => selectedIdsSet.has(f.id))
+    return unref(resources).filter((f) => unref(selectedIdsSet).has(f.id))
   })
 
   const setSelection = (ids: string[]) => {
@@ -305,6 +306,7 @@ export const useResourcesStore = defineStore('resources', () => {
     clearResourceList,
 
     selectedIds,
+    selectedIdsSet,
     latestSelectedId,
     selectedResources,
     setSelection,

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -108,7 +108,8 @@ export const useResourcesStore = defineStore('resources', () => {
   const latestSelectedId = ref<string>(null)
 
   const selectedResources = computed(() => {
-    return unref(resources).filter((f) => unref(selectedIds).includes(f.id))
+    const selectedIdsSet = new Set(unref(selectedIds))
+    return unref(resources).filter((f) => selectedIdsSet.has(f.id))
   })
 
   const setSelection = (ids: string[]) => {

--- a/packages/web-pkg/src/composables/resources/useResourceViewDrag.ts
+++ b/packages/web-pkg/src/composables/resources/useResourceViewDrag.ts
@@ -5,11 +5,11 @@ import ResourceGhostElement from '../../components/FilesList/ResourceGhostElemen
 
 export const useResourceViewDrag = ({
   selectedIds,
-  selectedResources,
+  resources,
   emit
 }: {
   selectedIds: Ref<string[]>
-  selectedResources: Ref<Resource[]>
+  resources: Ref<Resource[]>
   emit: ReturnType<typeof defineEmits>
 }) => {
   const resourcesStore = useResourcesStore()
@@ -38,7 +38,9 @@ export const useResourceViewDrag = ({
   }
 
   const dragSelection = computed(() => {
-    return unref(selectedResources).filter(({ id }) => id !== unref(dragItem)?.id)
+    const selectedIdsSet = new Set(unref(selectedIds))
+    const draggedId = unref(dragItem)?.id
+    return unref(resources).filter(({ id }) => selectedIdsSet.has(id) && id !== draggedId)
   })
 
   const getFileDropPayload = (event: DragEvent) => {

--- a/packages/web-pkg/src/composables/resources/useResourceViewHelpers.ts
+++ b/packages/web-pkg/src/composables/resources/useResourceViewHelpers.ts
@@ -46,12 +46,10 @@ export const useResourceViewHelpers = ({
   const clipboardStore = useClipboardStore()
   const { resources: clipboardResources, action: clipboardAction } = storeToRefs(clipboardStore)
 
-  const selectedResources = computed(() => {
-    return unref(resources).filter((resource) => unref(selectedIds).includes(resource.id))
-  })
+  const selectedIdsSet = computed(() => new Set(unref(selectedIds)))
 
   const isResourceSelected = (item: Resource) => {
-    return unref(selectedIds).includes(item.id)
+    return unref(selectedIdsSet).has(item.id)
   }
 
   const isResourceInDeleteQueue = (id: string): boolean => {
@@ -222,7 +220,6 @@ export const useResourceViewHelpers = ({
   }
 
   return {
-    selectedResources,
     disabledResources,
     isResourceSelected,
     isResourceInDeleteQueue,
@@ -233,7 +230,7 @@ export const useResourceViewHelpers = ({
     fileNameClicked,
     fileCheckboxClicked,
     getResourceLink,
-    ...useResourceViewDrag({ selectedIds, selectedResources, emit }),
+    ...useResourceViewDrag({ selectedIds, resources, emit }),
     ...useResourceViewContextMenu({ isResourceDisabled, isResourceSelected, emit }),
     ...useResourceViewSelection({ resources, disabledResources, selectedIds, emit })
   }

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTile.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTile.spec.ts
@@ -26,7 +26,8 @@ describe('OcTile component', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
   it('renders selected resource correctly', () => {
-    const wrapper = getWrapper({ resource: getSpaceMock(), isResourceSelected: true })
+    const resource = getSpaceMock()
+    const wrapper = getWrapper({ resource }, { selectedIds: [resource.id] })
     expect(wrapper.find('.oc-tile-card-selected').exists()).toBeTruthy()
   })
   it.each(['size-12, size-22, size-42'])(
@@ -41,7 +42,7 @@ describe('OcTile component', () => {
     expect(wrapper.find('.oc-tile-card-loading-spinner').exists()).toBeTruthy()
   })
 
-  function getWrapper(props = {}) {
+  function getWrapper(props = {}, resourcesStore = {}) {
     const defaultMocks = defaultComponentMocks({
       currentRoute: mock<RouteLocation>({ name: 'files' })
     })
@@ -50,7 +51,9 @@ describe('OcTile component', () => {
       props,
       global: {
         plugins: [
-          ...defaultPlugins({ piniaOptions: { spacesState: { spaces: [getSpaceMock(false)] } } })
+          ...defaultPlugins({
+            piniaOptions: { spacesState: { spaces: [getSpaceMock(false)] }, resourcesStore }
+          })
         ],
         renderStubDefaultSlot: true,
         mocks: defaultMocks,

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -2,7 +2,7 @@ import { defaultComponentMocks, defaultPlugins, mount } from '@opencloud-eu/web-
 import ResourceTiles from '../../../../src/components/FilesList/ResourceTiles.vue'
 import { sortFields } from '../../../../src/helpers/ui/resourceTiles'
 import { Resource, SpaceResource, extractDomSelector } from '@opencloud-eu/web-client'
-import { computed } from 'vue'
+import { computed, nextTick } from 'vue'
 import {
   useCanBeOpenedWithSecureView,
   ResourceIndicator
@@ -138,7 +138,15 @@ describe('ResourceTiles component', () => {
     })
   })
 
-  it('emits update:selectedIds event on resource selection and sets the selection', async () => {
+  it('reflects the store selection on the resource tile', async () => {
+    const { wrapper } = getWrapper({ props: { resources: spacesResources } })
+    const resourcesStore = useResourcesStore()
+    resourcesStore.selectedIds = [spacesResources[0].id]
+    await nextTick()
+    expect(wrapper.find('.oc-tile-card-selected').exists()).toBeTruthy()
+  })
+
+  it('emits update:selectedIds event on resource selection', async () => {
     const { wrapper } = getWrapper({
       props: {
         resources: spacesResources,
@@ -146,9 +154,6 @@ describe('ResourceTiles component', () => {
       }
     })
     await wrapper.find('#tiles-view-select-all').trigger('click')
-    expect(
-      wrapper.findComponent({ name: 'resource-tile' }).props('isResourceSelected')
-    ).toBeTruthy()
     expect(wrapper.emitted('update:selectedIds')).toBeTruthy()
   })
 


### PR DESCRIPTION
`ResourceTile` now derives its own selected state from the resources store instead of receiving it as a prop and exposes it to the selection slot as a scoped prop. This removes all `selectedIds` reads from `ResourceTiles`' render, so a selection toggle no longer re-renders the whole list.

Further improves selection performance by using a Set-based O(1) membership checks instead of `Array.includes`/`indexOf` in `useResourceViewHelpers` (`isResourceSelected`) and the resources store.

refs https://github.com/opencloud-eu/web/issues/2937