### PR TITLE
fix: retry silent token renewal before logout on auth error

### DIFF
--- a/packages/web-client/src/sse/index.ts
+++ b/packages/web-client/src/sse/index.ts
@@ -150,3 +150,15 @@ export const sse = (baseURI: string, fetchOptions: FetchEventSourceInit): SSEAda
 
   return eventSource
 }
+
+/**
+ * Closes the current SSE connection and clears the singleton, so the next `sse()`
+ * call creates a fresh connection. Used on logout to stop the stream from
+ * reconnecting with a stale (removed) access token.
+ */
+export const resetSSE = (): void => {
+  if (eventSource) {
+    eventSource.close()
+    eventSource = null
+  }
+}

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -22,6 +22,18 @@ import { Ability } from '@opencloud-eu/web-client'
 import { Language } from 'vue3-gettext'
 import { PublicLinkType } from '@opencloud-eu/web-client'
 import { WebWorkersStore } from '@opencloud-eu/web-pkg'
+import { ErrorTimeout } from 'oidc-client-ts'
+import { resetSSE } from '@opencloud-eu/web-client/sse'
+
+/**
+ * Network-class errors during silent renewal are transient (e.g. the device just
+ * woke from sleep and the connection isn't back yet) and worth retrying. Any other
+ * error (most notably an OAuth error response) means the session is truly gone and
+ * must not be retried.
+ */
+function isTransientRenewError(error: unknown): boolean {
+  return error instanceof ErrorTimeout || error instanceof TypeError
+}
 
 export class AuthService implements AuthServiceInterface {
   private clientService: ClientService
@@ -38,6 +50,7 @@ export class AuthService implements AuthServiceInterface {
 
   private tokenTimerWorker: ReturnType<typeof useTokenTimerWorker>
   private tokenTimerInitialized = false
+  private silentRenewRetryPromise: Promise<boolean> | null = null
 
   // number of seconds before an access token is to expire to raise the accessTokenExpiring event
   private accessTokenExpiryThreshold = 10
@@ -289,28 +302,70 @@ export class AuthService implements AuthServiceInterface {
       })
     }
     if (isUserContextRequired(this.router, route) || isIdpContextRequired(this.router, route)) {
-      const throwAuthError = async () => {
-        await this.userManager.removeUser('authError')
-        this.tokenTimerWorker?.resetTokenTimer()
-      }
       const user = await this.userManager.getUser()
-      if (user?.expired === true) {
-        // token expired, attempt an immediate silent signin
-        try {
-          await this.userManager.signinSilent({ silentRequestTimeoutInSeconds: 2 })
-        } catch {
-          await throwAuthError()
-        }
+
+      // An auth error occurred: an expired token after the device woke from sleep,
+      // or a 401 on a request. Before logging the user out, attempt a silent
+      // renewal with retries. The server may have rejected a token the client
+      // still considers valid (e.g. clock skew after wake) or one that just
+      // expired, while the IdP session is usually still alive. Only log the user
+      // out if renewal ultimately fails (non-transient error or retries
+      // exhausted), so a brief interruption doesn't kill an otherwise-valid
+      // session.
+      if (user && (await this.renewTokenWithBackoff())) {
         return
       }
 
-      await throwAuthError()
+      await this.userManager.removeUser('authError')
+      this.tokenTimerWorker?.resetTokenTimer()
       return
     }
     // authGuard is taking care of redirecting the user to the
     // accessDenied page if hasAuthErrorOccurred is set to true
     // we can't push the route ourselves, see authGuard for details.
     this.hasAuthErrorOccurred = true
+  }
+
+  /**
+   * Attempts a silent token renewal, retrying transient network failures with
+   * exponential backoff. Resolves to `true` if a renewal succeeded, or `false` if
+   * it failed with a non-transient error or exhausted all retries.
+   *
+   * Concurrent callers share the same in-flight attempt to avoid overlapping
+   * silent renewals.
+   */
+  private renewTokenWithBackoff(): Promise<boolean> {
+    if (this.silentRenewRetryPromise) {
+      return this.silentRenewRetryPromise
+    }
+
+    const maxAttempts = 5
+    const baseDelayInMs = 1000
+
+    const run = async (): Promise<boolean> => {
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          await this.userManager.signinSilent()
+          return true
+        } catch (error) {
+          console.warn(
+            `silent token renewal failed (attempt ${attempt + 1}/${maxAttempts}, error: ${(error as Error)?.constructor?.name})`,
+            error
+          )
+          if (!isTransientRenewError(error) || attempt === maxAttempts - 1) {
+            return false
+          }
+          await new Promise((resolve) => setTimeout(resolve, baseDelayInMs * 2 ** attempt))
+        }
+      }
+      return false
+    }
+
+    this.silentRenewRetryPromise = run().finally(() => {
+      this.silentRenewRetryPromise = null
+    })
+
+    return this.silentRenewRetryPromise
   }
 
   public resolvePublicLink(
@@ -346,6 +401,8 @@ export class AuthService implements AuthServiceInterface {
     // TODO: create UserUnloadTask interface and allow registering unload-tasks in the authService
     this.userStore.reset()
     this.authStore.clearUserContext()
+    // stop the SSE stream from reconnecting with the now-removed access token
+    resetSSE()
   }
 
   public async getRefreshToken() {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -174,6 +174,15 @@ export class AuthService implements AuthServiceInterface {
             await this.userManager.updateContext(user.access_token, user.profile.sid, fetchUserData)
           } catch (e) {
             console.error(e)
+
+            if (this.silentRenewRetryPromise) {
+              // This event was raised by a silent renewal that is still in flight. Handling
+              // the error here would wait for that very renewal to finish (see
+              // `renewTokenWithBackoff`) and therefore deadlock. Let the renewal fail
+              // instead, its caller takes care of the error.
+              throw e
+            }
+
             await this.handleAuthError(unref(this.router.currentRoute))
           }
         })

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigStore, useAuthStore, useConfigStore } from '@opencloud-eu/web-pkg'
 import { mock } from 'vitest-mock-extended'
 import { Router } from 'vue-router'
+import { ErrorResponse, ErrorTimeout } from 'oidc-client-ts'
 import { AuthService } from '../../../../src/services/auth/authService'
 import { UserManager } from '../../../../src/services/auth/userManager'
 import { RouteLocation, createRouter, createTestingPinia } from '@opencloud-eu/web-test-helpers'
@@ -159,6 +160,133 @@ describe('AuthService', () => {
       await authService.initializeContext(mock<RouteLocation>({}))
 
       expect(mockUpdateContext).toHaveBeenCalledWith('access-token', 'session-id', true)
+    })
+  })
+
+  describe('handleAuthError', () => {
+    const userContextRoute = mock<RouteLocation>({ meta: { authContext: 'user' } })
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('retries a transient silent renewal and does not log the user out on eventual success', async () => {
+      const authService = new AuthService()
+      const signinSilent = vi
+        .fn()
+        .mockRejectedValueOnce(new ErrorTimeout('timeout'))
+        .mockResolvedValueOnce(undefined)
+      const removeUser = vi.fn()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue({ expired: true }),
+          signinSilent,
+          removeUser
+        })
+      })
+
+      initAuthService({ authService, router: createRouter() })
+
+      const promise = authService.handleAuthError(userContextRoute)
+      await vi.runAllTimersAsync()
+      await promise
+
+      expect(signinSilent).toHaveBeenCalledTimes(2)
+      expect(removeUser).not.toHaveBeenCalled()
+    })
+
+    it('logs the user out once transient retries are exhausted', async () => {
+      const authService = new AuthService()
+      const signinSilent = vi.fn().mockRejectedValue(new ErrorTimeout('timeout'))
+      const removeUser = vi.fn()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue({ expired: true }),
+          signinSilent,
+          removeUser
+        })
+      })
+
+      initAuthService({ authService, router: createRouter() })
+
+      const promise = authService.handleAuthError(userContextRoute)
+      await vi.runAllTimersAsync()
+      await promise
+
+      expect(signinSilent).toHaveBeenCalledTimes(5)
+      expect(removeUser).toHaveBeenCalledWith('authError')
+    })
+
+    it('attempts a silent renewal before logging out on a 401 even when the token is not client-side expired', async () => {
+      const authService = new AuthService()
+      const signinSilent = vi.fn().mockResolvedValue(undefined)
+      const removeUser = vi.fn()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue({ expired: false }),
+          signinSilent,
+          removeUser
+        })
+      })
+
+      initAuthService({ authService, router: createRouter() })
+
+      const promise = authService.handleAuthError(userContextRoute)
+      await vi.runAllTimersAsync()
+      await promise
+
+      expect(signinSilent).toHaveBeenCalledTimes(1)
+      expect(removeUser).not.toHaveBeenCalled()
+    })
+
+    it('logs the user out without attempting a renewal when no user is present', async () => {
+      const authService = new AuthService()
+      const signinSilent = vi.fn()
+      const removeUser = vi.fn()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue(null),
+          signinSilent,
+          removeUser
+        })
+      })
+
+      initAuthService({ authService, router: createRouter() })
+
+      await authService.handleAuthError(userContextRoute)
+
+      expect(signinSilent).not.toHaveBeenCalled()
+      expect(removeUser).toHaveBeenCalledWith('authError')
+    })
+
+    it('does not retry a non-transient silent renewal error and logs the user out immediately', async () => {
+      const authService = new AuthService()
+      const signinSilent = vi.fn().mockRejectedValue(new ErrorResponse({ error: 'invalid_grant' }))
+      const removeUser = vi.fn()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue({ expired: true }),
+          signinSilent,
+          removeUser
+        })
+      })
+
+      initAuthService({ authService, router: createRouter() })
+
+      const promise = authService.handleAuthError(userContextRoute)
+      await vi.runAllTimersAsync()
+      await promise
+
+      expect(signinSilent).toHaveBeenCalledTimes(1)
+      expect(removeUser).toHaveBeenCalledWith('authError')
     })
   })
 })

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -288,5 +288,48 @@ describe('AuthService', () => {
       expect(signinSilent).toHaveBeenCalledTimes(1)
       expect(removeUser).toHaveBeenCalledWith('authError')
     })
+
+    it('logs the user out when updating the context fails for the renewed token', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const authService = new AuthService()
+      let onUserLoaded: (user: unknown) => Promise<void>
+      const removeUser = vi.fn()
+      const updateContext = vi.fn().mockRejectedValue(new Error('network error'))
+      const signinSilent = vi
+        .fn()
+        .mockImplementation(() =>
+          onUserLoaded({ access_token: 'renewed-token', profile: { sid: 'session-id' } })
+        )
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue({ expired: false }),
+          areEventHandlersRegistered: false,
+          events: mock<UserManager['events']>({
+            addAccessTokenExpired: vi.fn(),
+            addAccessTokenExpiring: vi.fn(),
+            addUserLoaded: vi.fn().mockImplementation((cb) => (onUserLoaded = cb)),
+            addUserUnloaded: vi.fn(),
+            addSilentRenewError: vi.fn()
+          }),
+          updateContext,
+          signinSilent,
+          removeUser
+        })
+      })
+
+      initAuthService({ authService, router: createRouter() })
+      await authService.initializeContext(userContextRoute)
+
+      const promise = authService.handleAuthError(userContextRoute)
+      await vi.runAllTimersAsync()
+      await promise
+
+      // the failing context update must not trigger another renewal, otherwise the
+      // nested call would wait for the renewal it is running in and deadlock
+      expect(signinSilent).toHaveBeenCalledTimes(1)
+      expect(updateContext).toHaveBeenCalledTimes(1)
+      expect(removeUser).toHaveBeenCalledWith('authError')
+    })
   })
 })


### PR DESCRIPTION
## The fix

Attempt a silent renewal with exponential backoff on any auth error (not only when the client considers the token expired) before logging the user out. A `401` from the server is authoritative even when the client still thinks its token is valid (e.g. clock skew after waking a device from sleep), so gating renewal on the client-side expiry flag could kill an otherwise-valid session on a transient interruption.

Also close the SSE stream on logout so it stops reconnecting with the removed access token.

## How to test

- Reduce the token expiration time to e.g. 60 seconds by setting `IDP_ACCESS_TOKEN_EXPIRATION: 60`
- Add the `offline_access` scope by setting `WEB_OIDC_SCOPE: openid profile email offline_access`
- Recreate the OpenCloud container
- Login with Web
- Put your computer in standby
- Wait a few minutes
- Wake up from standby and use Web (keep navigating some folders in your personal space)

You shouldn't get logged out at any point. You *may* see a `404` error, which is related to an internal Docker clock-hiccup, since you've also put the containers into sleep.

Without this change, there is a high chance that you get logged out at some point (maybe on the first request, maybe after navigating a few folders). 

fixes opencloud-eu/opencloud#3165