### PR TITLE
fix: resolve hardcoded absolute image paths under a subpath deployment

### DIFF
--- a/packages/web-app-admin-settings/src/components/Extensions/ExtensionsList.vue
+++ b/packages/web-app-admin-settings/src/components/Extensions/ExtensionsList.vue
@@ -2,7 +2,7 @@
   <no-content-message
     v-if="!filteredExtensions.length"
     id="admin-settings-extensions-empty-filtered"
-    img-src="/images/empty-states/empty-extensions.svg"
+    img-src="images/empty-states/empty-extensions.svg"
   >
     <template #message>
       <span v-text="$gettext('No extensions found')" />

--- a/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
@@ -2,7 +2,7 @@
   <no-content-message
     v-if="!items.length"
     id="admin-settings-groups-empty"
-    img-src="/images/empty-states/empty-groups.svg"
+    img-src="images/empty-states/empty-groups.svg"
   >
     <template #message>
       <span v-text="$gettext('No groups found')" />

--- a/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
@@ -2,7 +2,7 @@
   <no-content-message
     v-if="!items.length"
     id="admin-settings-spaces-empty"
-    img-src="/images/empty-states/empty-spaces.svg"
+    img-src="images/empty-states/empty-spaces.svg"
   >
     <template #message>
       <span v-text="$gettext('No spaces found')" />

--- a/packages/web-app-admin-settings/src/views/Extensions.vue
+++ b/packages/web-app-admin-settings/src/views/Extensions.vue
@@ -24,7 +24,7 @@
       <no-content-message
         v-else-if="!extensions.length"
         id="admin-settings-extensions-empty"
-        img-src="/images/empty-states/empty-extensions.svg"
+        img-src="images/empty-states/empty-extensions.svg"
       >
         <template #message>
           <span v-text="$gettext('No extensions found')" />

--- a/packages/web-app-admin-settings/src/views/Groups.vue
+++ b/packages/web-app-admin-settings/src/views/Groups.vue
@@ -45,7 +45,7 @@
         <no-content-message
           v-if="!groups.length"
           id="admin-settings-groups-empty"
-          img-src="/images/empty-states/empty-groups.svg"
+          img-src="images/empty-states/empty-groups.svg"
         >
           <template #message>
             <span v-text="$gettext('No groups found')" />

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -39,7 +39,7 @@
         <no-content-message
           v-if="!spaces.length"
           id="admin-settings-spaces-empty"
-          img-src="/images/empty-states/empty-spaces.svg"
+          img-src="images/empty-states/empty-spaces.svg"
         >
           <template #message>
             <span v-text="$gettext('No spaces found')" />

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -97,7 +97,7 @@
         <template #noResults>
           <no-content-message
             v-if="isFilteringMandatory && !isFilteringActive"
-            img-src="/images/empty-states/empty-users.svg"
+            img-src="images/empty-states/empty-users.svg"
           >
             <template #message>
               <span v-text="$gettext('No users found')" />
@@ -106,7 +106,7 @@
               <span v-text="$gettext('Please specify a filter to see results')" />
             </template>
           </no-content-message>
-          <no-content-message v-else img-src="/images/empty-states/empty-users.svg">
+          <no-content-message v-else img-src="images/empty-states/empty-users.svg">
             <template #message>
               <span v-text="$gettext('No users found')" />
             </template>

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -33,7 +33,7 @@ exports[`Users view > list view > renders initially warning if filters are manda
             <!--v-if-->
           </div>
         </div>
-        <no-content-message-stub icon="" iconfilltype="fill" imgsrc="/images/empty-states/empty-users.svg"></no-content-message-stub>
+        <no-content-message-stub icon="" iconfilltype="fill" imgsrc="images/empty-states/empty-users.svg"></no-content-message-stub>
       </div>
     </div>
   </div>

--- a/packages/web-app-contacts/src/views/ContactDetails.vue
+++ b/packages/web-app-contacts/src/views/ContactDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <no-content-message v-if="!currentContact" img-src="/images/empty-states/empty-contacts.svg">
+  <no-content-message v-if="!currentContact" img-src="images/empty-states/empty-contacts.svg">
     <template #message>
       <span v-text="$gettext('No contact selected')" />
     </template>

--- a/packages/web-app-contacts/src/views/ContactsList.vue
+++ b/packages/web-app-contacts/src/views/ContactsList.vue
@@ -21,7 +21,7 @@
     <no-content-message
       v-if="!sortedContacts.length"
       id="contacts-empty"
-      img-src="/images/empty-states/empty-contacts.svg"
+      img-src="images/empty-states/empty-contacts.svg"
     >
       <template #message>
         <span v-text="$gettext('No contacts available yet.')" />
@@ -30,7 +30,7 @@
     <no-content-message
       v-else-if="!filteredContacts.length"
       id="contacts-search-empty"
-      img-src="/images/empty-states/empty-contacts.svg"
+      img-src="images/empty-states/empty-contacts.svg"
     >
       <template #message>
         <span v-text="$gettext('No contacts found.')" />

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -75,7 +75,7 @@
       <template v-else>
         <no-content-message
           v-if="!paginatedResources.length"
-          img-src="/images/empty-states/empty-search-results.svg"
+          img-src="images/empty-states/empty-search-results.svg"
         >
           <template #message>
             <p class="text-role-on-surface-variant">

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -8,7 +8,7 @@
     <no-content-message
       v-if="!items.length"
       class="files-empty"
-      img-src="/images/empty-states/empty-shared-with-me.svg"
+      img-src="images/empty-states/empty-shared-with-me.svg"
     >
       <template #message>
         <span v-text="$gettext('Nothing shared, yet')" />

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -7,7 +7,7 @@
         <no-content-message
           v-if="isEmpty"
           id="files-favorites-empty"
-          img-src="/images/empty-states/empty-favorites.svg"
+          img-src="images/empty-states/empty-favorites.svg"
         >
           <template #message>
             <span v-text="$gettext('Nothing marked as favorite, yet')" />

--- a/packages/web-app-files/src/views/shares/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/shares/SharedViaLink.vue
@@ -23,7 +23,7 @@
         <no-content-message
           v-if="isEmpty"
           id="files-shared-via-link-empty"
-          img-src="/images/empty-states/empty-shared-via-link.svg"
+          img-src="images/empty-states/empty-shared-via-link.svg"
         >
           <template #message>
             <span v-text="$gettext('Nothing shared, yet')" />

--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -47,7 +47,7 @@
         <no-content-message
           v-if="isEmpty"
           id="files-shared-with-others-empty"
-          img-src="/images/empty-states/empty-shared-with-others.svg"
+          img-src="images/empty-states/empty-shared-with-others.svg"
         >
           <template #message>
             <span v-text="$gettext('Nothing shared, yet')" />

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -25,7 +25,7 @@
             v-if="isCurrentFolderEmpty"
             id="files-space-empty"
             :class="{ 'h-[40vh]': isSpaceFrontpage }"
-            img-src="/images/empty-states/empty-folder.svg"
+            img-src="images/empty-states/empty-folder.svg"
           >
             <template #message>
               <span v-text="$gettext('No files found')" />

--- a/packages/web-app-files/src/views/spaces/GenericTrash.vue
+++ b/packages/web-app-files/src/views/spaces/GenericTrash.vue
@@ -28,7 +28,7 @@
         <no-content-message
           v-if="isEmpty"
           id="files-trashbin-empty"
-          img-src="/images/empty-states/empty-trash.svg"
+          img-src="images/empty-states/empty-trash.svg"
         >
           <template #message>
             <span v-text="$gettext('This trash bin is empty')" />

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -40,7 +40,7 @@
         <no-content-message
           v-if="!runtimeSpaces.length"
           id="files-spaces-empty"
-          img-src="/images/empty-states/empty-spaces.svg"
+          img-src="images/empty-states/empty-spaces.svg"
         >
           <template #message>
             <span v-text="$gettext('No spaces found')" />
@@ -53,7 +53,7 @@
           <no-content-message
             v-if="!items.length"
             id="files-spaces-empty"
-            img-src="/images/empty-states/empty-spaces.svg"
+            img-src="images/empty-states/empty-spaces.svg"
           >
             <template #message>
               <span v-text="$gettext('No spaces found')" />

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -30,7 +30,7 @@
           </div>
           <no-content-message
             v-if="!displaySpaces.length"
-            img-src="/images/empty-states/empty-trash.svg"
+            img-src="images/empty-states/empty-trash.svg"
           >
             <template #message>
               <span v-text="$gettext('No trash bins found')" />

--- a/packages/web-app-mail/src/components/MailDetails.vue
+++ b/packages/web-app-mail/src/components/MailDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <app-loading-spinner v-if="isLoading" />
   <template v-else>
-    <no-content-message v-if="!currentMail" img-src="/images/empty-states/empty-mails.svg">
+    <no-content-message v-if="!currentMail" img-src="images/empty-states/empty-mails.svg">
       <template #message>
         <span v-text="$gettext('No mail selected')" />
       </template>

--- a/packages/web-app-mail/src/components/MailList.vue
+++ b/packages/web-app-mail/src/components/MailList.vue
@@ -15,7 +15,7 @@
       <no-content-message
         v-if="!mails || !mails.length"
         class="mail-list-empty min-w-[306px]"
-        img-src="/images/empty-states/empty-mails.svg"
+        img-src="images/empty-states/empty-mails.svg"
       >
         <template #message>
           <span v-text="$gettext('No mails in this mailbox')" />

--- a/packages/web-app-rclone-crypt/src/views/UnlockVault.vue
+++ b/packages/web-app-rclone-crypt/src/views/UnlockVault.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="oc-vault-unlock flex justify-center h-full overflow-y-auto p-8">
-    <no-content-message v-if="!space" img-src="/images/vault.svg" class="my-auto">
+    <no-content-message v-if="!space" img-src="images/vault.svg" class="my-auto">
       <template #message>
         <span v-text="$gettext('Vault not found')" />
       </template>
@@ -18,7 +18,7 @@
         <span v-text="$gettext('End-to-end encrypted')" />
       </oc-tag>
       <div class="flex flex-col items-center text-center">
-        <inline-svg src="/images/vault.svg" class="h-30 w-30" aria-hidden="true" />
+        <inline-svg src="images/vault.svg" class="h-30 w-30" aria-hidden="true" />
         <p class="mt-0 text-sm break-all" data-testid="vault-name">
           <resource-name
             :name="vaultName"

--- a/packages/web-runtime/src/components/Account/AppTokens.vue
+++ b/packages/web-runtime/src/components/Account/AppTokens.vue
@@ -24,7 +24,7 @@
     />
     <no-content-message
       v-else-if="!appTokens.length"
-      img-src="/images/empty-states/empty-app-tokens.svg"
+      img-src="images/empty-states/empty-app-tokens.svg"
       data-testid="no-app-tokens-available"
     >
       <template #message>

--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -38,7 +38,7 @@ const backgroundImgStyle = computed(() => {
   return unref(backgroundImg) ? { backgroundImage: `url(${unref(backgroundImg)})` } : {}
 })
 const emblemSrc = computed(() => {
-  return unref(currentTheme).isDark ? '/images/icon-lilac.svg' : '/images/icon-petrol.svg'
+  return unref(currentTheme).isDark ? 'images/icon-lilac.svg' : 'images/icon-petrol.svg'
 })
 
 const pathIsRoot = computed(() => {

--- a/packages/web-runtime/src/pages/notFound.vue
+++ b/packages/web-runtime/src/pages/notFound.vue
@@ -1,5 +1,5 @@
 <template>
-  <no-content-message img-src="/images/empty-states/404.svg" class="page-not-found h-full">
+  <no-content-message img-src="images/empty-states/404.svg" class="page-not-found h-full">
     <template #message>
       <span v-text="$gettext('404')" />
     </template>


### PR DESCRIPTION
Every asset reference on these pages: index.html's own favicon, manifest.json, config.json, the design-system stylesheet --is relative, and relies on the server-templated <base href> to resolve under whatever root the app is deployed at (see the companion opencloud-eu/opencloud subpath-deployment-support patch, which is what makes that server-side templating work correctly under a subpath in the first place). 28 image references across 25 files didn't follow that convention and used an absolute, domain-root path instead:

- Every <no-content-message img-src="/images/empty-states/*.svg"> (every empty folder/trash/users/groups/contacts/mail/search-results/ spaces/shares/app-tokens view, plus the 404 page itself).
- The login page's emblem (layouts/Plain.vue: icon-lilac.svg / icon-petrol.svg, chosen by theme).
- The rclone-crypt vault-not-found empty state and vault icon (UnlockVault.vue).

Under a subpath deployment these always resolved to the domain root instead of the deployment root, 404ing regardless of <base href> (absolute paths ignore it entirely). Dropped the leading slash on all of them so they resolve the same way as everything else on the page. No component-level or build-level changes needed: both consumers of these paths (native <img src> for non-SVG, and vue-inline-svg's fetch()-based loading for .svg, which is all of these) resolve relative URLs against the document's base URL the same way, so the fix is purely mechanical.

Verified end to end: deployed a from-source build of this branch under a real subpath (/test/opencloud) behind a real nginx passthrough.

Testing: eslint clean on all changed files (0 errors; pre-existing, unrelated warnings only). Full unit suite (pnpm vitest run --config ./tests/unit/config/vitest.config.ts) passes, 2912 tests, one snapshot updated to match the corrected path.

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ X ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
