### PR TITLE
perf: improve render times with lots of paginated items

### DIFF
--- a/packages/web-pkg/src/composables/pagination/usePagination.ts
+++ b/packages/web-pkg/src/composables/pagination/usePagination.ts
@@ -1,4 +1,4 @@
-import { computed, ComputedRef, unref, MaybeRef } from 'vue'
+import { computed, ComputedRef, onBeforeUnmount, unref, MaybeRef } from 'vue'
 import { queryItemAsString } from '../appDefaults'
 import { useRouteQuery, useRouteQueryPersisted } from '../router'
 import { PaginationConstants } from './constants'
@@ -42,7 +42,7 @@ export function usePagination<T>(options: PaginationOptions<T>): PaginationResul
     return unref(options.items).slice(start, end)
   })
 
-  eventBus.subscribe(
+  const navigatePageToken = eventBus.subscribe(
     'app.files.navigate.page',
     ({
       resourceId,
@@ -66,6 +66,10 @@ export function usePagination<T>(options: PaginationOptions<T>): PaginationResul
       }
     }
   )
+
+  onBeforeUnmount(() => {
+    eventBus.unsubscribe('app.files.navigate.page', navigatePageToken)
+  })
 
   return {
     items,

--- a/packages/web-pkg/src/composables/pagination/usePagination.ts
+++ b/packages/web-pkg/src/composables/pagination/usePagination.ts
@@ -89,10 +89,17 @@ function createPerPageRef<T>(options: PaginationOptions<T>): ComputedRef<number>
     return computed(() => unref(options.perPage))
   }
 
+  const perPageDefault = options.perPageDefault || PaginationConstants.perPageDefault
   const perPageQuery = useRouteQueryPersisted({
     name: options.perPageQueryName || PaginationConstants.perPageQueryName,
-    defaultValue: options.perPageDefault || PaginationConstants.perPageDefault,
+    defaultValue: perPageDefault,
     storagePrefix: options.perPageStoragePrefix
   })
-  return computed(() => parseInt(queryItemAsString(unref(perPageQuery))))
+  return computed(() => {
+    // the route query is populated asynchronously, so it can still be missing on
+    // the first render. Falling back to the default keeps `items` from returning
+    // the whole (potentially huge) list for one render pass.
+    const perPage = parseInt(queryItemAsString(unref(perPageQuery)))
+    return isNaN(perPage) ? parseInt(perPageDefault) : perPage
+  })
 }

--- a/packages/web-pkg/src/composables/scrollTo/useScrollTo.ts
+++ b/packages/web-pkg/src/composables/scrollTo/useScrollTo.ts
@@ -1,4 +1,4 @@
-import { computed, unref } from 'vue'
+import { computed, onBeforeUnmount, unref } from 'vue'
 import { Resource } from '@opencloud-eu/web-client'
 import { queryItemAsString } from '../appDefaults/useAppNavigation'
 import { eventBus } from '../../services'
@@ -61,7 +61,7 @@ export const useScrollTo = (): ScrollToResult => {
     }
   }
 
-  eventBus.subscribe(
+  const navigateScrollToToken = eventBus.subscribe(
     'app.files.navigate.scrollTo',
     (data: { resourceId: string; forceScroll: boolean; topbarElement: string }) =>
       scrollToResource(data.resourceId, {
@@ -69,6 +69,10 @@ export const useScrollTo = (): ScrollToResult => {
         topbarElement: data.topbarElement
       })
   )
+
+  onBeforeUnmount(() => {
+    eventBus.unsubscribe('app.files.navigate.scrollTo', navigateScrollToToken)
+  })
 
   const scrollToResourceFromRoute = (resources: Resource[], topbarElement: null) => {
     if (!unref(scrollTo) || !resources.length) {

--- a/packages/web-pkg/tests/unit/composables/pagination/usePagination.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/pagination/usePagination.spec.ts
@@ -1,6 +1,6 @@
 import { ref, unref } from 'vue'
 import { usePagination } from '../../../../src/composables'
-import { getComposableWrapper } from '@opencloud-eu/web-test-helpers'
+import { createRouter, getComposableWrapper } from '@opencloud-eu/web-test-helpers'
 
 describe('usePagination', () => {
   describe('computed items', () => {
@@ -36,6 +36,28 @@ describe('usePagination', () => {
         currentPage: 1,
         itemsPerPage
       })
+    })
+  })
+  describe('computed perPage', () => {
+    it('falls back to the default while the route query is still unset', async () => {
+      const router = createRouter({ routes: [{ path: '/', redirect: null }] })
+      router.push('/')
+      await router.isReady()
+
+      const mocks = { $router: router }
+      getComposableWrapper(
+        () => {
+          const { items: paginatedItems, perPage } = usePagination({
+            items: ref([1, 2, 3, 4, 5, 6]),
+            perPageDefault: '2',
+            perPageStoragePrefix: 'unit-tests'
+          })
+
+          expect(unref(perPage)).toBe(2)
+          expect(unref(paginatedItems)).toEqual([1, 2])
+        },
+        { mocks, provide: mocks }
+      )
     })
   })
 })

--- a/packages/web-pkg/tests/unit/composables/pagination/usePagination.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/pagination/usePagination.spec.ts
@@ -1,5 +1,6 @@
 import { ref, unref } from 'vue'
 import { usePagination } from '../../../../src/composables'
+import { eventBus } from '../../../../src/services'
 import { createRouter, getComposableWrapper } from '@opencloud-eu/web-test-helpers'
 
 describe('usePagination', () => {
@@ -58,6 +59,27 @@ describe('usePagination', () => {
         },
         { mocks, provide: mocks }
       )
+    })
+  })
+  describe('event bus subscription', () => {
+    it('unsubscribes from the page navigation event on unmount', () => {
+      const subscribeSpy = vi.spyOn(eventBus, 'subscribe')
+      const unsubscribeSpy = vi.spyOn(eventBus, 'unsubscribe')
+
+      const { wrapper } = getWrapper({
+        setup: () => undefined,
+        items: [1, 2, 3],
+        currentPage: 1,
+        itemsPerPage: 2
+      })
+
+      const token = subscribeSpy.mock.results[0].value
+      expect(subscribeSpy).toHaveBeenCalledWith('app.files.navigate.page', expect.anything())
+      expect(unsubscribeSpy).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+
+      expect(unsubscribeSpy).toHaveBeenCalledWith('app.files.navigate.page', token)
     })
   })
 })


### PR DESCRIPTION
## Description

The `items-per-page` route query is written asynchronously, so on the first render `perPage` was NaN and `usePagination` returned the full list. With 6000 items (e.g. groups, users) that mounted all rows (~90k DOM nodes) before re-rendering with 50, blocking the main thread for ~5s. Fall back to the default when the query is not available yet.

Also makes sure that the navigate and scrollTo event handlers get unsubscribed on unmount.

## How has this been tested

- Create e.g. ~1000 groups
- Access the groups page in the admin-settings
- Watch it loading

## Benchmarks

Loading a list with ~6000 groups:

| Before | After |
|---|---|
| 5172 ms | 509 ms|


refs https://github.com/opencloud-eu/web/issues/1232