### PR TITLE
feat: add announcement banner

### DIFF
--- a/packages/design-system/src/components/OcSwitch/OcSwitch.spec.ts
+++ b/packages/design-system/src/components/OcSwitch/OcSwitch.spec.ts
@@ -20,4 +20,17 @@ describe('OcSwitch', () => {
 
     expect(wrapper.emitted('update:checked')[0][0]).toEqual(true)
   })
+
+  it('does not toggle when disabled', async () => {
+    const wrapper = shallowMount(Switch, {
+      props: { ...defaultProps, disabled: true }
+    })
+
+    const btn = wrapper.find('[data-testid="oc-switch-btn"]')
+    expect(btn.attributes('disabled')).toBeDefined()
+
+    await btn.trigger('click')
+
+    expect(wrapper.emitted('update:checked')).toBeUndefined()
+  })
 })

--- a/packages/design-system/src/components/OcSwitch/OcSwitch.vue
+++ b/packages/design-system/src/components/OcSwitch/OcSwitch.vue
@@ -1,13 +1,15 @@
 <template>
-  <span
-    :key="`oc-switch-${checked.toString()}`"
-    class="oc-switch items-center gap-2"
-    :class="{ 'opacity-40': disabled }"
-  >
-    <span :id="labelId" v-text="label" />
+  <span :key="`oc-switch-${checked.toString()}`" class="oc-switch items-center gap-2">
+    <span class="inline-flex items-center gap-1">
+      <!-- dim only the label + toggle when disabled, not the slot: an opacity on the whole
+           switch would create a stacking context that traps slotted popovers (e.g. a helper) -->
+      <span :id="labelId" v-text="label" :class="{ 'opacity-40': disabled }" />
+      <!-- @slot content rendered next to the label, e.g. a contextual helper -->
+      <slot />
+    </span>
     <button
       data-testid="oc-switch-btn"
-      class="oc-switch-btn block relative border border-role-outline rounded-3xl w-8 before:size-3 h-4.5 disabled:cursor-default"
+      class="oc-switch-btn block relative border border-role-outline rounded-3xl w-8 before:size-3 h-4.5 disabled:cursor-default disabled:opacity-40"
       :class="{ 'cursor-pointer': !disabled }"
       role="switch"
       :aria-checked="checked"

--- a/packages/design-system/src/components/OcSwitch/OcSwitch.vue
+++ b/packages/design-system/src/components/OcSwitch/OcSwitch.vue
@@ -1,12 +1,18 @@
 <template>
-  <span :key="`oc-switch-${checked.toString()}`" class="oc-switch items-center gap-2">
+  <span
+    :key="`oc-switch-${checked.toString()}`"
+    class="oc-switch items-center gap-2"
+    :class="{ 'opacity-40': disabled }"
+  >
     <span :id="labelId" v-text="label" />
     <button
       data-testid="oc-switch-btn"
-      class="oc-switch-btn block relative border border-role-outline rounded-3xl w-8 before:size-3 h-4.5 cursor-pointer"
+      class="oc-switch-btn block relative border border-role-outline rounded-3xl w-8 before:size-3 h-4.5 disabled:cursor-default"
+      :class="{ 'cursor-pointer': !disabled }"
       role="switch"
       :aria-checked="checked"
       :aria-labelledby="labelId"
+      :disabled="disabled"
       @click="toggle"
     />
   </span>
@@ -28,6 +34,10 @@ export interface Props {
    * @docs The element ID of the label.
    */
   labelId?: string
+  /**
+   * @docs Determines if the switch is disabled.
+   */
+  disabled?: boolean
 }
 
 export interface Emits {
@@ -37,11 +47,19 @@ export interface Emits {
   (e: 'update:checked', value: boolean): void
 }
 
-const { checked = false, label, labelId = uniqueId('oc-switch-label-') } = defineProps<Props>()
+const {
+  checked = false,
+  label,
+  labelId = uniqueId('oc-switch-label-'),
+  disabled = false
+} = defineProps<Props>()
 
 const emit = defineEmits<Emits>()
 
 const toggle = () => {
+  if (disabled) {
+    return
+  }
   emit('update:checked', !checked)
 }
 </script>

--- a/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
+++ b/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
@@ -75,6 +75,7 @@ const stored = ref<StoredAnnouncement>({ enabled: false, bannerText: '', infoTex
 const infoEditor = useTextEditor({
   contentType: 'markdown',
   modelValue: toRef(() => unref(infoText)),
+  ariaLabel: $gettext('Info text'),
   // no image insertion via the UI: base64 uploads would bloat the public config.json,
   // and anyone who really needs an image can add safe Markdown by hand
   excludeActions: ['image', 'image-upload', 'image-url'],

--- a/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
+++ b/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
@@ -4,27 +4,55 @@
       <h2 class="text-lg font-semibold" v-text="$gettext('Announcement banner')" />
       <oc-switch
         :checked="enabled"
-        :label="$gettext('Enabled')"
+        :label="$gettext('Show banner')"
         class="inline-flex"
         :disabled="isBusy || !stored.bannerText"
         @update:checked="onToggleEnabled"
-      />
+      >
+        <oc-contextual-helper
+          :title="$gettext('Show banner')"
+          :text="
+            $gettext(
+              'Show the banner to all users. It can only be enabled once a banner text has been saved.'
+            )
+          "
+        />
+      </oc-switch>
     </div>
     <p class="text-role-on-surface-variant mb-3">
-      {{
-        $gettext(
-          'Shown above the top bar for all users, including on the login page before sign-in. Do not include sensitive information.'
-        )
-      }}
-      <br />
-      {{
-        $gettext(
-          'The banner text is shown in the bar. The info text is shown in a dialog when users click the banner. It is only public while enabled.'
-        )
-      }}
+      {{ $gettext('Shows a banner on top for all users. Do not include sensitive information.') }}
     </p>
-    <oc-text-input v-model="bannerText" :label="$gettext('Banner text')" class="mb-3" />
-    <span class="inline-block mb-0.5" v-text="$gettext('Info text')" />
+    <oc-text-input
+      :id="bannerInputId"
+      v-model="bannerText"
+      :label="$gettext('Banner')"
+      class="mb-3"
+    >
+      <template #label>
+        <span class="mb-0.5 flex items-center gap-1">
+          <label :for="bannerInputId">{{ $gettext('Banner') }}</label>
+          <oc-contextual-helper
+            :title="$gettext('Banner')"
+            :text="
+              $gettext(
+                'Displayed text in the banner. Clicking it opens the details dialog. Visible only when Show banner is enabled. Users can dismiss it until the page is reloaded.'
+              )
+            "
+          />
+        </span>
+      </template>
+    </oc-text-input>
+    <span class="mb-0.5 flex items-center gap-1">
+      {{ $gettext('Banner details') }}
+      <oc-contextual-helper
+        :title="$gettext('Banner details')"
+        :text="
+          $gettext(
+            'The details are shown in a dialog when users click the banner. They can be formatted using Markdown. Leave empty to make the banner non-clickable.'
+          )
+        "
+      />
+    </span>
     <div class="border border-role-outline-variant rounded-lg overflow-hidden">
       <text-editor-provider :editor="infoEditor">
         <text-editor-toolbar />
@@ -72,10 +100,12 @@ const bannerText = ref('')
 const infoText = ref('')
 const stored = ref<StoredAnnouncement>({ enabled: false, bannerText: '', infoText: '' })
 
+const bannerInputId = 'announcement-banner-text'
+
 const infoEditor = useTextEditor({
   contentType: 'markdown',
   modelValue: toRef(() => unref(infoText)),
-  ariaLabel: $gettext('Info text'),
+  ariaLabel: $gettext('Banner details'),
   // no image insertion via the UI: base64 uploads would bloat the public config.json,
   // and anyone who really needs an image can add safe Markdown by hand
   excludeActions: ['image', 'image-upload', 'image-url'],

--- a/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
+++ b/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
@@ -6,7 +6,7 @@
         :checked="enabled"
         :label="$gettext('Enabled')"
         class="inline-flex"
-        :class="{ 'pointer-events-none opacity-60': isBusy }"
+        :disabled="isBusy || !stored.bannerText"
         @update:checked="onToggleEnabled"
       />
     </div>
@@ -193,11 +193,7 @@ const toggleTask = useTask(function* () {
 }).drop()
 
 function onToggleEnabled(value: boolean) {
-  // there is nothing to enable until a banner text has been saved
-  if (value && !stored.value.bannerText) {
-    showMessage({ title: $gettext('Add a banner text and save it first') })
-    return
-  }
+  // the switch is disabled until a banner text has been saved, so there is nothing to guard here
   enabled.value = value
   toggleTask.perform()
 }

--- a/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
+++ b/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
@@ -110,9 +110,22 @@ function apply(a: StoredAnnouncement) {
   reflectLiveBanner(a)
 }
 
-function showWriteError(e: unknown, title: string) {
+// map known HTTP statuses to an actionable message, falling back to a generic one
+function writeErrorTitle(e: unknown, fallback: string): string {
+  const status = (e as { response?: { status?: number } })?.response?.status
+  switch (status) {
+    case 413:
+      return $gettext('The announcement is too large. Please shorten the info text.')
+    case 403:
+      return $gettext('You are not allowed to manage the announcement banner.')
+    default:
+      return fallback
+  }
+}
+
+function showWriteError(e: unknown, fallback: string) {
   console.error(e)
-  showErrorMessage({ title, errors: [e as HttpError] })
+  showErrorMessage({ title: writeErrorTitle(e, fallback), errors: [e as HttpError] })
 }
 
 const loadTask = useTask(function* () {

--- a/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
+++ b/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="max-w-2xl">
+    <div class="flex items-center justify-between gap-4 mb-1">
+      <h2 class="text-lg font-semibold" v-text="$gettext('Announcement banner')" />
+      <oc-switch
+        :checked="enabled"
+        :label="$gettext('Enabled')"
+        class="inline-flex"
+        :class="{ 'pointer-events-none opacity-60': isBusy }"
+        @update:checked="onToggleEnabled"
+      />
+    </div>
+    <p class="text-role-on-surface-variant mb-3">
+      {{
+        $gettext(
+          'Shown above the top bar for all users, including on the login page before sign-in. Do not include sensitive information.'
+        )
+      }}
+      <br />
+      {{
+        $gettext(
+          'The banner text is shown in the bar. The info text is shown in a dialog when users click the banner. It is only public while enabled.'
+        )
+      }}
+    </p>
+    <oc-text-input v-model="bannerText" :label="$gettext('Banner text')" class="mb-3" />
+    <span class="inline-block mb-0.5" v-text="$gettext('Info text')" />
+    <div class="border border-role-outline-variant rounded-lg overflow-hidden">
+      <text-editor-provider :editor="infoEditor">
+        <text-editor-toolbar />
+        <text-editor-content class="min-h-[32rem] max-h-[48rem] px-3 py-2 overflow-auto" />
+      </text-editor-provider>
+    </div>
+    <div class="flex items-center justify-between gap-2 mt-3">
+      <oc-button appearance="outline" :disabled="!canPreview || isBusy" @click="preview">
+        {{ $gettext('Preview') }}
+      </oc-button>
+      <oc-button
+        appearance="filled"
+        :disabled="!isDirty || isBusy"
+        :show-spinner="saveTask.isRunning"
+        @click="saveTask.perform()"
+      >
+        {{ $gettext('Save') }}
+      </oc-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, toRef, unref } from 'vue'
+import { useTask } from 'vue-concurrency'
+import { HttpError } from '@opencloud-eu/web-client'
+import { useClientService, useConfigStore, useMessages } from '@opencloud-eu/web-pkg'
+import {
+  useTextEditor,
+  TextEditorProvider,
+  TextEditorContent,
+  TextEditorToolbar
+} from '@opencloud-eu/web-pkg/editor'
+import { useGettext } from 'vue3-gettext'
+
+type StoredAnnouncement = { enabled: boolean; bannerText: string; infoText: string }
+
+const { $gettext } = useGettext()
+const configStore = useConfigStore()
+const clientService = useClientService()
+const { showMessage, showErrorMessage } = useMessages()
+
+const enabled = ref(false)
+const bannerText = ref('')
+const infoText = ref('')
+const stored = ref<StoredAnnouncement>({ enabled: false, bannerText: '', infoText: '' })
+
+const infoEditor = useTextEditor({
+  contentType: 'markdown',
+  modelValue: toRef(() => unref(infoText)),
+  // no image insertion via the UI: base64 uploads would bloat the public config.json,
+  // and anyone who really needs an image can add safe Markdown by hand
+  excludeActions: ['image', 'image-upload', 'image-url'],
+  onUpdate: (content) => {
+    infoText.value = content
+  }
+})
+
+// only the text fields make the form dirty; the enabled switch persists on its own
+const isDirty = computed(
+  () =>
+    unref(bannerText).trim() !== stored.value.bannerText ||
+    unref(infoText).trim() !== stored.value.infoText
+)
+const canPreview = computed(() => !!unref(bannerText).trim())
+
+// update the live banner in the running session (shown only while enabled and a banner text is set)
+function reflectLiveBanner(a: StoredAnnouncement) {
+  configStore.options.announcement =
+    a.enabled && a.bannerText ? { bannerText: a.bannerText, infoText: a.infoText } : undefined
+}
+
+// apply a persisted state to the form, the stored snapshot and the live banner
+function apply(a: StoredAnnouncement) {
+  enabled.value = a.enabled
+  bannerText.value = a.bannerText
+  infoText.value = a.infoText
+  // push into the editor explicitly: the modelValue watch is skipped while the editor is
+  // focused (it auto-focuses on mount), so async-loaded content would otherwise not show
+  infoEditor.setContent(a.infoText)
+  stored.value = { ...a }
+  reflectLiveBanner(a)
+}
+
+function showWriteError(e: unknown, title: string) {
+  console.error(e)
+  showErrorMessage({ title, errors: [e as HttpError] })
+}
+
+const loadTask = useTask(function* () {
+  try {
+    const { data } = yield clientService.httpAuthenticated.get<StoredAnnouncement>('announcement')
+    apply({
+      enabled: !!data?.enabled,
+      bannerText: data?.bannerText ?? '',
+      infoText: data?.infoText ?? ''
+    })
+  } catch (e) {
+    showWriteError(e, $gettext('Failed to load the announcement banner'))
+  }
+}).drop()
+
+// Save persists the text fields, keeping the current enabled state. An empty banner text
+// removes the announcement entirely. It does not change the enabled state.
+const saveTask = useTask(function* () {
+  const bannerTextValue = unref(bannerText).trim()
+  // an empty banner text removes the announcement entirely (the backend deletes the record)
+  const payload: StoredAnnouncement = bannerTextValue
+    ? { enabled: unref(enabled), bannerText: bannerTextValue, infoText: unref(infoText).trim() }
+    : { enabled: false, bannerText: '', infoText: '' }
+  try {
+    yield clientService.httpAuthenticated.put('announcement', payload)
+    apply(payload)
+    showMessage({
+      title: bannerTextValue
+        ? $gettext('Announcement banner updated')
+        : $gettext('Announcement banner removed')
+    })
+  } catch (e) {
+    showWriteError(e, $gettext('Failed to update the announcement banner'))
+  }
+}).drop()
+
+// The switch persists on its own and only flips the enabled state on the saved announcement.
+// Text edits are not published by toggling, use Save for that.
+const toggleTask = useTask(function* () {
+  const value = unref(enabled)
+  const payload: StoredAnnouncement = {
+    enabled: value,
+    bannerText: stored.value.bannerText,
+    infoText: stored.value.infoText
+  }
+  try {
+    yield clientService.httpAuthenticated.put('announcement', payload)
+    stored.value = { ...payload }
+    reflectLiveBanner(payload)
+    showMessage({
+      title: value
+        ? $gettext('Announcement banner enabled')
+        : $gettext('Announcement banner disabled')
+    })
+  } catch (e) {
+    enabled.value = !value
+    showWriteError(e, $gettext('Failed to update the announcement banner'))
+  }
+}).drop()
+
+function onToggleEnabled(value: boolean) {
+  // there is nothing to enable until a banner text has been saved
+  if (value && !stored.value.bannerText) {
+    showMessage({ title: $gettext('Add a banner text and save it first') })
+    return
+  }
+  enabled.value = value
+  toggleTask.perform()
+}
+
+// show the current form in this session only, without persisting or enabling it,
+// so the banner and dialog can be tested before going live
+function preview() {
+  configStore.options.announcement = {
+    bannerText: unref(bannerText).trim(),
+    infoText: unref(infoText).trim()
+  }
+  showMessage({ title: $gettext('Previewing in this session only, not saved') })
+}
+
+const isBusy = computed(() => loadTask.isRunning || saveTask.isRunning || toggleTask.isRunning)
+
+onMounted(() => {
+  loadTask.perform()
+})
+</script>

--- a/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
+++ b/packages/web-app-admin-settings/src/components/General/AnnouncementSection.vue
@@ -146,8 +146,14 @@ const loadTask = useTask(function* () {
 const saveTask = useTask(function* () {
   const bannerTextValue = unref(bannerText).trim()
   // an empty banner text removes the announcement entirely (the backend deletes the record)
+  // read the editor directly: onUpdate is debounced, so unref(infoText) can lag a save that
+  // happens within the debounce window
   const payload: StoredAnnouncement = bannerTextValue
-    ? { enabled: unref(enabled), bannerText: bannerTextValue, infoText: unref(infoText).trim() }
+    ? {
+        enabled: unref(enabled),
+        bannerText: bannerTextValue,
+        infoText: infoEditor.getContent().trim()
+      }
     : { enabled: false, bannerText: '', infoText: '' }
   try {
     yield clientService.httpAuthenticated.put('announcement', payload)
@@ -201,7 +207,7 @@ function onToggleEnabled(value: boolean) {
 function preview() {
   configStore.options.announcement = {
     bannerText: unref(bannerText).trim(),
-    infoText: unref(infoText).trim()
+    infoText: infoEditor.getContent().trim()
   }
   showMessage({ title: $gettext('Previewing in this session only, not saved') })
 }

--- a/packages/web-app-admin-settings/src/views/General.vue
+++ b/packages/web-app-admin-settings/src/views/General.vue
@@ -9,8 +9,9 @@
     ]"
   >
     <template #mainContent>
-      <div class="px-4">
+      <div class="px-4 flex flex-col gap-8">
         <InfoSection />
+        <AnnouncementSection />
       </div>
     </template>
   </app-template>
@@ -19,4 +20,5 @@
 <script setup lang="ts">
 import AppTemplate from '../components/AppTemplate.vue'
 import InfoSection from '../components/General/InfoSection.vue'
+import AnnouncementSection from '../components/General/AnnouncementSection.vue'
 </script>

--- a/packages/web-app-admin-settings/src/views/General.vue
+++ b/packages/web-app-admin-settings/src/views/General.vue
@@ -11,14 +11,19 @@
     <template #mainContent>
       <div class="px-4 flex flex-col gap-8">
         <InfoSection />
-        <AnnouncementSection />
+        <AnnouncementSection v-if="canManageAnnouncement" />
       </div>
     </template>
   </app-template>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useAbility } from '@opencloud-eu/web-pkg'
 import AppTemplate from '../components/AppTemplate.vue'
 import InfoSection from '../components/General/InfoSection.vue'
 import AnnouncementSection from '../components/General/AnnouncementSection.vue'
+
+const { can } = useAbility()
+const canManageAnnouncement = computed(() => can('read-all', 'Announcement'))
 </script>

--- a/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
@@ -1,0 +1,171 @@
+import AnnouncementSection from '../../../../src/components/General/AnnouncementSection.vue'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from '@opencloud-eu/web-test-helpers'
+import { mockDeep } from 'vitest-mock-extended'
+import { ClientService, useConfigStore, useMessages } from '@opencloud-eu/web-pkg'
+
+// avoid spinning up a real TipTap editor in the unit test
+vi.mock('@opencloud-eu/web-pkg/editor', () => ({
+  useTextEditor: vi.fn(() => ({ editor: { value: null }, setContent: vi.fn() })),
+  TextEditorProvider: { name: 'TextEditorProvider', template: '<div><slot /></div>' },
+  TextEditorContent: { name: 'TextEditorContent', template: '<div />' },
+  TextEditorToolbar: { name: 'TextEditorToolbar', template: '<div />' }
+}))
+
+type StoredAnnouncement = { enabled: boolean; bannerText: string; infoText: string }
+
+// script-setup bindings accessed for testing; not part of the component's public type
+type AnnouncementVm = {
+  enabled: boolean
+  bannerText: string
+  infoText: string
+  loadTask: { last: Promise<unknown> }
+  saveTask: { perform: () => void; last: Promise<unknown> }
+  toggleTask: { last: Promise<unknown> }
+  onToggleEnabled: (value: boolean) => void
+  preview: () => void
+}
+
+describe('AnnouncementSection', () => {
+  it('loads the stored announcement on mount and mirrors the live banner when enabled', async () => {
+    const { vm } = getWrapper({ enabled: true, bannerText: 'Hi', infoText: 'Details' })
+    await vm.loadTask.last
+
+    expect(vm.enabled).toBe(true)
+    expect(vm.bannerText).toBe('Hi')
+    expect(useConfigStore().options.announcement).toEqual({ bannerText: 'Hi', infoText: 'Details' })
+  })
+
+  it('saves the text via PUT while keeping the current (disabled) state hidden', async () => {
+    const { vm, clientService } = getWrapper()
+    await vm.loadTask.last
+
+    vm.bannerText = 'Maintenance'
+    vm.infoText = 'Details'
+    vm.saveTask.perform()
+    await vm.saveTask.last
+
+    expect(clientService.httpAuthenticated.put).toHaveBeenCalledWith('announcement', {
+      enabled: false,
+      bannerText: 'Maintenance',
+      infoText: 'Details'
+    })
+    // still disabled, so not exposed in the live banner
+    expect(useConfigStore().options.announcement).toBeUndefined()
+    expect(useMessages().showMessage).toHaveBeenCalled()
+  })
+
+  it('removes the announcement when saving with an empty banner text', async () => {
+    const { vm, clientService } = getWrapper({ enabled: true, bannerText: 'Hi', infoText: 'x' })
+    await vm.loadTask.last
+
+    vm.bannerText = ''
+    vm.saveTask.perform()
+    await vm.saveTask.last
+
+    expect(clientService.httpAuthenticated.put).toHaveBeenCalledWith('announcement', {
+      enabled: false,
+      bannerText: '',
+      infoText: ''
+    })
+    expect(useConfigStore().options.announcement).toBeUndefined()
+  })
+
+  it('enables the saved announcement via the switch without publishing unsaved edits', async () => {
+    const { vm, clientService } = getWrapper({
+      enabled: false,
+      bannerText: 'Hi',
+      infoText: 'Details'
+    })
+    await vm.loadTask.last
+
+    // unsaved edit in the form
+    vm.bannerText = 'Unsaved edit'
+    vm.onToggleEnabled(true)
+    await vm.toggleTask.last
+
+    // toggle persisted the stored text, not the unsaved edit
+    expect(clientService.httpAuthenticated.put).toHaveBeenCalledWith('announcement', {
+      enabled: true,
+      bannerText: 'Hi',
+      infoText: 'Details'
+    })
+    expect(useConfigStore().options.announcement).toEqual({ bannerText: 'Hi', infoText: 'Details' })
+  })
+
+  it('does not enable when nothing has been saved yet', async () => {
+    const { vm, clientService } = getWrapper()
+    await vm.loadTask.last
+
+    vm.bannerText = 'Typed but not saved'
+    vm.onToggleEnabled(true)
+
+    expect(vm.enabled).toBe(false)
+    expect(clientService.httpAuthenticated.put).not.toHaveBeenCalled()
+  })
+
+  it('reverts the switch when the toggle request fails', async () => {
+    const { vm, clientService } = getWrapper({ enabled: false, bannerText: 'Hi', infoText: 'x' })
+    await vm.loadTask.last
+    clientService.httpAuthenticated.put.mockRejectedValue(new Error('boom'))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    vm.onToggleEnabled(true)
+    await vm.toggleTask.last
+
+    expect(vm.enabled).toBe(false)
+    expect(useMessages().showErrorMessage).toHaveBeenCalled()
+  })
+
+  it('previews in the session only without persisting', async () => {
+    const { vm, clientService } = getWrapper()
+    await vm.loadTask.last
+
+    vm.bannerText = 'Maintenance'
+    vm.infoText = 'Details'
+    vm.preview()
+
+    expect(useConfigStore().options.announcement).toEqual({
+      bannerText: 'Maintenance',
+      infoText: 'Details'
+    })
+    expect(clientService.httpAuthenticated.put).not.toHaveBeenCalled()
+  })
+
+  it('shows an error message when saving fails', async () => {
+    const { vm, clientService } = getWrapper()
+    await vm.loadTask.last
+    clientService.httpAuthenticated.put.mockRejectedValue(new Error('boom'))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    vm.bannerText = 'Maintenance'
+    vm.saveTask.perform()
+    await vm.saveTask.last
+
+    expect(useMessages().showErrorMessage).toHaveBeenCalled()
+  })
+})
+
+function getWrapper(stored?: Partial<StoredAnnouncement>) {
+  const clientService = mockDeep<ClientService>()
+  clientService.httpAuthenticated.get.mockResolvedValue({
+    data: { enabled: false, bannerText: '', infoText: '', ...stored }
+  } as any)
+  clientService.httpAuthenticated.put.mockResolvedValue({} as any)
+
+  const mocks = { ...defaultComponentMocks(), $clientService: clientService }
+
+  const wrapper = shallowMount(AnnouncementSection, {
+    global: {
+      plugins: [...defaultPlugins()],
+      mocks,
+      provide: mocks
+    }
+  })
+
+  return {
+    mocks,
+    clientService,
+    wrapper,
+    vm: wrapper.vm as unknown as AnnouncementVm
+  }
+}

--- a/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
@@ -3,9 +3,17 @@ import { defaultComponentMocks, defaultPlugins, shallowMount } from '@opencloud-
 import { mockDeep } from 'vitest-mock-extended'
 import { ClientService, useConfigStore, useMessages } from '@opencloud-eu/web-pkg'
 
-// avoid spinning up a real TipTap editor in the unit test
+// avoid spinning up a real TipTap editor; getContent/setContent are backed by a shared value so
+// tests can drive the editor content that the save/preview paths read
+const { editorState } = vi.hoisted(() => ({ editorState: { content: '' } }))
 vi.mock('@opencloud-eu/web-pkg/editor', () => ({
-  useTextEditor: vi.fn(() => ({ editor: { value: null }, setContent: vi.fn() })),
+  useTextEditor: vi.fn(() => ({
+    editor: { value: null },
+    setContent: vi.fn((content: string) => {
+      editorState.content = content
+    }),
+    getContent: vi.fn(() => editorState.content)
+  })),
   TextEditorProvider: { name: 'TextEditorProvider', template: '<div><slot /></div>' },
   TextEditorContent: { name: 'TextEditorContent', template: '<div />' },
   TextEditorToolbar: { name: 'TextEditorToolbar', template: '<div />' }
@@ -26,6 +34,10 @@ type AnnouncementVm = {
 }
 
 describe('AnnouncementSection', () => {
+  beforeEach(() => {
+    editorState.content = ''
+  })
+
   it('loads the stored announcement on mount and mirrors the live banner when enabled', async () => {
     const { vm } = getWrapper({ enabled: true, bannerText: 'Hi', infoText: 'Details' })
     await vm.loadTask.last
@@ -40,7 +52,7 @@ describe('AnnouncementSection', () => {
     await vm.loadTask.last
 
     vm.bannerText = 'Maintenance'
-    vm.infoText = 'Details'
+    editorState.content = 'Details'
     vm.saveTask.perform()
     await vm.saveTask.last
 
@@ -121,7 +133,7 @@ describe('AnnouncementSection', () => {
     await vm.loadTask.last
 
     vm.bannerText = 'Maintenance'
-    vm.infoText = 'Details'
+    editorState.content = 'Details'
     vm.preview()
 
     expect(useConfigStore().options.announcement).toEqual({

--- a/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
@@ -143,6 +143,23 @@ describe('AnnouncementSection', () => {
 
     expect(useMessages().showErrorMessage).toHaveBeenCalled()
   })
+
+  it('shows a size-specific error when the announcement is too large', async () => {
+    const { vm, clientService } = getWrapper()
+    await vm.loadTask.last
+    clientService.httpAuthenticated.put.mockRejectedValue({ response: { status: 413 } })
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    vm.bannerText = 'Maintenance'
+    vm.saveTask.perform()
+    await vm.saveTask.last
+
+    expect(useMessages().showErrorMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'The announcement is too large. Please shorten the info text.'
+      })
+    )
+  })
 })
 
 function getWrapper(stored?: Partial<StoredAnnouncement>) {

--- a/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/General/AnnouncementSection.spec.ts
@@ -104,15 +104,12 @@ describe('AnnouncementSection', () => {
     expect(useConfigStore().options.announcement).toEqual({ bannerText: 'Hi', infoText: 'Details' })
   })
 
-  it('does not enable when nothing has been saved yet', async () => {
-    const { vm, clientService } = getWrapper()
+  it('disables the switch until a banner text has been saved', async () => {
+    const { vm, wrapper } = getWrapper()
     await vm.loadTask.last
 
-    vm.bannerText = 'Typed but not saved'
-    vm.onToggleEnabled(true)
-
-    expect(vm.enabled).toBe(false)
-    expect(clientService.httpAuthenticated.put).not.toHaveBeenCalled()
+    // nothing saved yet -> the switch cannot be toggled
+    expect(wrapper.findComponent({ name: 'OcSwitch' }).props('disabled')).toBe(true)
   })
 
   it('reverts the switch when the toggle request fails', async () => {

--- a/packages/web-app-admin-settings/tests/unit/views/General.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/General.spec.ts
@@ -1,18 +1,27 @@
 import General from '../../../src/views/General.vue'
+import AnnouncementSection from '../../../src/components/General/AnnouncementSection.vue'
+import { AbilityRule } from '@opencloud-eu/web-client'
 import { defaultPlugins, shallowMount } from '@opencloud-eu/web-test-helpers'
 
 describe('General view', () => {
-  it('renders component', () => {
+  it('hides the announcement section without the Announcement permission', () => {
     const { wrapper } = getWrapper()
-    expect(wrapper.html()).toMatchSnapshot()
+    expect(wrapper.findComponent(AnnouncementSection).exists()).toBe(false)
+  })
+
+  it('shows the announcement section with the Announcement permission', () => {
+    const { wrapper } = getWrapper([{ action: 'read-all', subject: 'Announcement' }])
+    expect(wrapper.findComponent(AnnouncementSection).exists()).toBe(true)
   })
 })
 
-function getWrapper() {
+function getWrapper(abilities: AbilityRule[] = []) {
   return {
     wrapper: shallowMount(General, {
       global: {
-        plugins: [...defaultPlugins()]
+        plugins: [...defaultPlugins({ abilities })],
+        // render the mainContent slot so the gated sections end up in the tree
+        stubs: { AppTemplate: { template: '<div><slot name="mainContent" /></div>' } }
       }
     })
   }

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/General.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/General.spec.ts.snap
@@ -1,3 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`General view > renders component 1`] = `"<app-template-stub breadcrumbs="[object Object]" sidebaravailablepanels="" sidebarpanelcontext="[object Object]" loading="false" sidebarloading="false" showviewoptions="false" showbatchactions="false" batchactionitems="" batchactions=""></app-template-stub>"`;

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -17,6 +17,7 @@ export type AbilityActions =
 
 export type AbilitySubjects =
   | 'Account'
+  | 'Announcement'
   | 'Drive'
   | 'Favorite'
   | 'Group'

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -44,6 +44,12 @@ const ScriptConfigSchema = z.object({
 export type ScriptConfig = z.infer<typeof ScriptConfigSchema>
 
 const OptionsConfigSchema = z.object({
+  announcement: z
+    .object({
+      bannerText: z.string().optional(),
+      infoText: z.string().optional()
+    })
+    .optional(),
   openFilesInNewTab: z.boolean().optional(),
   concurrentRequests: z
     .object({

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -85,9 +85,12 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
     editorOptions.contentType = strategy.editorContentType()
   }
 
-  // the editor renders a role="textbox" element, which needs an accessible name
+  // the editor is a bare contenteditable div. When it gets an accessible name, also give it a
+  // textbox role (+ aria-multiline) so the aria-label is valid and it reads as a multiline text field
   const editorAttributes: Record<string, string> = {}
   if (options.ariaLabel) {
+    editorAttributes.role = 'textbox'
+    editorAttributes['aria-multiline'] = 'true'
     editorAttributes['aria-label'] = options.ariaLabel
   }
   if (options.placeholder) {

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -9,6 +9,7 @@ import type {
   TextEditorLinkPanelRequest,
   TextEditorState
 } from '../types'
+import type { EditorAction, EditorActionGroup } from './useEditorActions'
 import { SlashCommands } from '../extensions'
 import { useContentStrategy } from './useContentStrategy'
 import { findLinkRange, requestLinkPanel } from '../helpers/link'
@@ -25,12 +26,29 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
   const readonly = ref(options.readonly ?? false)
   const strategy = resolveStrategy(options.contentType, state)
 
+  // Filter out excluded actions (by id) from toolbar and slash commands, including
+  // nested dropdown children (e.g. exclude 'image-upload' but keep 'image-url').
+  const excludeActions = options.excludeActions ?? []
+  const filterActions = (actions: EditorAction[]): EditorAction[] =>
+    actions
+      .filter((action) => !excludeActions.includes(action.id))
+      .map((action) =>
+        action.childActions
+          ? { ...action, childActions: filterActions(action.childActions) }
+          : action
+      )
+  const editorActionGroups = (): EditorActionGroup[] =>
+    strategy.editorActionGroups().map((group) => ({
+      ...group,
+      actions: filterActions(group.actions)
+    }))
+
   // Debounce onUpdate to avoid firing on every keystroke while typing.
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
   const extensions = strategy.extensions()
   if (options.slashCommands !== false) {
-    const resolvedGroups = strategy.editorActionGroups()
+    const resolvedGroups = editorActionGroups()
     const hasSlashCommandItems = resolvedGroups.some((group) =>
       group.actions.some((action) => action.showInSlashCommands !== false)
     )
@@ -207,8 +225,9 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
     editor,
     contentType,
     readonly,
-    actionGroups: strategy.editorActionGroups,
+    actionGroups: editorActionGroups,
     getContent,
+    setContent,
     isEmpty,
     isFocused,
     focus,

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -85,13 +85,18 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
     editorOptions.contentType = strategy.editorContentType()
   }
 
+  // the editor renders a role="textbox" element, which needs an accessible name
+  const editorAttributes: Record<string, string> = {}
+  if (options.ariaLabel) {
+    editorAttributes['aria-label'] = options.ariaLabel
+  }
+  if (options.placeholder) {
+    editorAttributes['aria-placeholder'] = options.placeholder
+    editorAttributes['aria-multiline'] = 'true'
+  }
+
   editorOptions.editorProps = {
-    attributes: {
-      ...(options.placeholder && {
-        'aria-placeholder': options.placeholder,
-        'aria-multiline': 'true'
-      })
-    },
+    attributes: editorAttributes,
     handleDOMEvents: {
       auxclick(view: Editor['view'], event: Event) {
         const target = event.target

--- a/packages/web-pkg/src/editor/types.ts
+++ b/packages/web-pkg/src/editor/types.ts
@@ -11,6 +11,11 @@ export interface TextEditorOptions {
   readonly?: boolean
   slashCommands?: boolean
   placeholder?: string
+  /**
+   * Action ids to exclude from the toolbar and slash commands (e.g. 'image-upload'),
+   * including nested dropdown children.
+   */
+  excludeActions?: string[]
   onUpdate?: (content: string) => void
   onRequestLinkUrl?: (currentUrl?: string) => Promise<string | null>
 }
@@ -35,6 +40,7 @@ export interface TextEditorInstance {
   readonly: Ref<boolean>
   actionGroups(): EditorActionGroup[]
   getContent(): string
+  setContent(value: string): void
   isEmpty: ComputedRef<boolean>
   isFocused: ComputedRef<boolean>
   focus(): void

--- a/packages/web-pkg/src/editor/types.ts
+++ b/packages/web-pkg/src/editor/types.ts
@@ -11,6 +11,8 @@ export interface TextEditorOptions {
   readonly?: boolean
   slashCommands?: boolean
   placeholder?: string
+  /** Accessible name for the editor's role="textbox" element (aria-label). */
+  ariaLabel?: string
   /**
    * Action ids to exclude from the toolbar and slash commands (e.g. 'image-upload'),
    * including nested dropdown children.

--- a/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
@@ -312,6 +312,8 @@ describe('useTextEditor', () => {
       const { result } = createEditor({ ariaLabel: 'Info text' })
       const attributes = (result.editor.value?.options.editorProps as any)?.attributes
       expect(attributes?.['aria-label']).toBe('Info text')
+      expect(attributes?.role).toBe('textbox')
+      expect(attributes?.['aria-multiline']).toBe('true')
     })
 
     it('does not add aria attributes when no aria-label or placeholder is given', () => {

--- a/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
@@ -274,4 +274,36 @@ describe('useTextEditor', () => {
       expect(onUpdate).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('excludeActions', () => {
+    const collectIds = (groups: { actions: { id: string; childActions?: any[] }[] }[]) => {
+      const ids: string[] = []
+      const walk = (actions: { id: string; childActions?: any[] }[]) => {
+        for (const action of actions) {
+          ids.push(action.id)
+          if (action.childActions) {
+            walk(action.childActions)
+          }
+        }
+      }
+      groups.forEach((group) => walk(group.actions))
+      return ids
+    }
+
+    it('keeps image actions by default', () => {
+      const { result } = createEditor({ contentType: 'markdown' })
+      expect(collectIds(result.actionGroups())).toContain('image')
+    })
+
+    it('removes excluded actions including nested dropdown children', () => {
+      const { result } = createEditor({
+        contentType: 'markdown',
+        excludeActions: ['image', 'image-upload', 'image-url']
+      })
+      const ids = collectIds(result.actionGroups())
+      expect(ids).not.toContain('image')
+      expect(ids).not.toContain('image-upload')
+      expect(ids).not.toContain('image-url')
+    })
+  })
 })

--- a/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
@@ -306,4 +306,19 @@ describe('useTextEditor', () => {
       expect(ids).not.toContain('image-url')
     })
   })
+
+  describe('ariaLabel', () => {
+    it('sets an aria-label on the editor textbox element', () => {
+      const { result } = createEditor({ ariaLabel: 'Info text' })
+      const attributes = (result.editor.value?.options.editorProps as any)?.attributes
+      expect(attributes?.['aria-label']).toBe('Info text')
+    })
+
+    it('does not add aria attributes when no aria-label or placeholder is given', () => {
+      const { result } = createEditor()
+      const attributes = (result.editor.value?.options.editorProps as any)?.attributes
+      expect(attributes?.['aria-label']).toBeUndefined()
+      expect(attributes?.role).toBeUndefined()
+    })
+  })
 })

--- a/packages/web-runtime/src/components/Announcement.vue
+++ b/packages/web-runtime/src/components/Announcement.vue
@@ -1,0 +1,84 @@
+<template>
+  <div
+    v-if="isVisible"
+    class="announcement flex items-center gap-3 px-4 py-2 bg-amber-400 text-amber-950"
+    role="status"
+  >
+    <button
+      v-if="hasInfo"
+      type="button"
+      class="grow flex items-center justify-center gap-2 min-w-0 cursor-pointer text-amber-950"
+      aria-haspopup="dialog"
+      @click="openModal"
+    >
+      <oc-icon
+        name="information"
+        fill-type="line"
+        size="small"
+        color="var(--color-amber-950)"
+        class="shrink-0"
+      />
+      <span
+        class="text-sm font-medium underline-offset-2 hover:underline truncate"
+        v-text="bannerText"
+      />
+    </button>
+    <div v-else class="grow flex items-center justify-center gap-2 min-w-0">
+      <oc-icon
+        name="error-warning"
+        fill-type="line"
+        size="small"
+        color="var(--color-amber-950)"
+        class="shrink-0"
+      />
+      <span class="text-sm font-medium truncate" v-text="bannerText" />
+    </div>
+    <oc-button
+      appearance="raw"
+      no-hover
+      class="shrink-0"
+      :aria-label="$gettext('Dismiss announcement')"
+      @click="dismissed = true"
+    >
+      <oc-icon name="close" fill-type="line" color="var(--color-amber-950)" />
+    </oc-button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, markRaw, ref, unref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useConfigStore, useModals } from '@opencloud-eu/web-pkg'
+import { useGettext } from 'vue3-gettext'
+import AnnouncementModal from './AnnouncementModal.vue'
+
+const { $gettext } = useGettext()
+
+const configStore = useConfigStore()
+const { options } = storeToRefs(configStore)
+const { dispatchModal } = useModals()
+
+// dismissal is intentionally not persisted, so the banner reappears on reload
+const dismissed = ref(false)
+
+const announcement = computed(() => unref(options).announcement)
+const bannerText = computed(() => unref(announcement)?.bannerText)
+const infoText = computed(() => unref(announcement)?.infoText)
+const hasInfo = computed(() => !!unref(infoText))
+const isVisible = computed(() => !!unref(bannerText) && !unref(dismissed))
+
+// a new or changed announcement (e.g. a fresh preview) should show again, even after a dismiss
+watch(announcement, () => {
+  dismissed.value = false
+})
+
+function openModal() {
+  dispatchModal({
+    title: unref(bannerText) || $gettext('Announcement'),
+    customComponent: markRaw(AnnouncementModal),
+    customComponentAttrs: () => ({ infoText: unref(infoText) }),
+    confirmText: $gettext('Close'),
+    hideCancelButton: true
+  })
+}
+</script>

--- a/packages/web-runtime/src/components/AnnouncementModal.vue
+++ b/packages/web-runtime/src/components/AnnouncementModal.vue
@@ -1,0 +1,17 @@
+<template>
+  <text-editor-content :editor="editor" class="announcement-modal" />
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue'
+import type { Modal } from '@opencloud-eu/web-pkg'
+import { useTextEditor, TextEditorContent } from '@opencloud-eu/web-pkg/editor'
+
+const { infoText = '' } = defineProps<{ modal: Modal; infoText?: string }>()
+
+const editor = useTextEditor({
+  contentType: 'markdown',
+  modelValue: toRef(() => infoText),
+  readonly: true
+})
+</script>

--- a/packages/web-runtime/src/components/AnnouncementModal.vue
+++ b/packages/web-runtime/src/components/AnnouncementModal.vue
@@ -6,12 +6,16 @@
 import { toRef } from 'vue'
 import type { Modal } from '@opencloud-eu/web-pkg'
 import { useTextEditor, TextEditorContent } from '@opencloud-eu/web-pkg/editor'
+import { useGettext } from 'vue3-gettext'
 
 const { infoText = '' } = defineProps<{ modal: Modal; infoText?: string }>()
+
+const { $gettext } = useGettext()
 
 const editor = useTextEditor({
   contentType: 'markdown',
   modelValue: toRef(() => infoText),
+  ariaLabel: $gettext('Announcement details'),
   readonly: true
 })
 </script>

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -4,6 +4,7 @@
       <custom-component-target :extension-point="progressBarExtensionPoint" />
     </div>
     <div id="web-content-header" class="shrink basis-auto grow-0">
+      <announcement />
       <div v-if="isIE11" class="bg-role-surface-container text-center py-4">
         <p class="m-0" v-text="ieDeprecationWarning" />
       </div>
@@ -56,6 +57,7 @@ import {
 } from '@opencloud-eu/web-pkg'
 import { useIsMobile } from '@opencloud-eu/design-system/composables'
 import TopBar from '../components/Topbar/TopBar.vue'
+import Announcement from '../components/Announcement.vue'
 import MessageBar from '../components/MessageBar.vue'
 import SidebarNav from '../components/SidebarNav/SidebarNav.vue'
 import UploadInfo from '../components/UploadInfo.vue'

--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -4,6 +4,7 @@
       <oc-spinner size="large" :aria-label="$gettext('Loading')" />
     </div>
     <template v-else>
+      <announcement class="relative z-1" />
       <h1 class="sr-only" v-text="pageTitle" />
       <router-view class="relative z-1" />
       <img
@@ -22,6 +23,7 @@ import { computed, unref } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { useRouteMeta, useThemeStore } from '@opencloud-eu/web-pkg'
 import { useRoute } from 'vue-router'
+import Announcement from '../components/Announcement.vue'
 
 const { $gettext } = useGettext()
 const themeStore = useThemeStore()

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -11,6 +11,10 @@ export const getAbilities = (
       { action: 'read-all', subject: 'Account' },
       { action: 'update-all', subject: 'Account' }
     ],
+    'Announcement.ReadWrite.all': [
+      { action: 'read-all', subject: 'Announcement' },
+      { action: 'update-all', subject: 'Announcement' }
+    ],
     'Favorites.List.own': [{ action: 'read', subject: 'Favorite' }],
     'Favorites.Write.own': [
       { action: 'create', subject: 'Favorite' },

--- a/packages/web-runtime/tests/unit/components/Announcement.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Announcement.spec.ts
@@ -1,0 +1,76 @@
+import { nextTick } from 'vue'
+import Announcement from '../../../src/components/Announcement.vue'
+import { useConfigStore, useModals } from '@opencloud-eu/web-pkg'
+import { defaultPlugins, shallowMount } from '@opencloud-eu/web-test-helpers'
+
+describe('Announcement component', () => {
+  it('renders the banner with the banner text', () => {
+    const { wrapper } = getWrapper({ bannerText: 'Maintenance tonight' })
+    expect(wrapper.find('.announcement').exists()).toBe(true)
+    expect(wrapper.find('.announcement').text()).toContain('Maintenance tonight')
+  })
+
+  it('does not render when no announcement is set', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.find('.announcement').exists()).toBe(false)
+  })
+
+  it('does not render when the banner text is empty', () => {
+    const { wrapper } = getWrapper({ bannerText: '' })
+    expect(wrapper.find('.announcement').exists()).toBe(false)
+  })
+
+  it('hides the banner when dismissed', async () => {
+    const { wrapper } = getWrapper({ bannerText: 'Maintenance tonight' })
+    expect(wrapper.find('.announcement').exists()).toBe(true)
+
+    await wrapper.find('oc-button-stub').trigger('click')
+
+    expect(wrapper.find('.announcement').exists()).toBe(false)
+  })
+
+  it('opens the info dialog when info text is present', async () => {
+    const { wrapper } = getWrapper({ bannerText: 'Maintenance', infoText: '# Details' })
+    const { dispatchModal } = useModals()
+
+    await wrapper.find('button').trigger('click')
+
+    expect(dispatchModal).toHaveBeenCalled()
+  })
+
+  it('is not clickable when no info text is present', () => {
+    const { wrapper } = getWrapper({ bannerText: 'Maintenance' })
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('shows again when the announcement changes after being dismissed', async () => {
+    const { wrapper } = getWrapper({ bannerText: 'First' })
+    expect(wrapper.find('.announcement').exists()).toBe(true)
+
+    await wrapper.find('oc-button-stub').trigger('click')
+    expect(wrapper.find('.announcement').exists()).toBe(false)
+
+    // a fresh preview / changed announcement arrives
+    useConfigStore().options.announcement = { bannerText: 'Second' }
+    await nextTick()
+
+    expect(wrapper.find('.announcement').exists()).toBe(true)
+    expect(wrapper.find('.announcement').text()).toContain('Second')
+  })
+})
+
+function getWrapper(announcement?: { bannerText?: string; infoText?: string }) {
+  return {
+    wrapper: shallowMount(Announcement, {
+      global: {
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              configState: { options: announcement ? { announcement } : {} }
+            }
+          })
+        ]
+      }
+    })
+  }
+}

--- a/packages/web-runtime/tests/unit/components/AnnouncementModal.spec.ts
+++ b/packages/web-runtime/tests/unit/components/AnnouncementModal.spec.ts
@@ -1,0 +1,25 @@
+import AnnouncementModal from '../../../src/components/AnnouncementModal.vue'
+import { useTextEditor } from '@opencloud-eu/web-pkg/editor'
+import { defaultPlugins, mount } from '@opencloud-eu/web-test-helpers'
+
+vi.mock('@opencloud-eu/web-pkg/editor', () => ({
+  useTextEditor: vi.fn(() => ({ editor: { value: null } })),
+  TextEditorContent: {
+    name: 'TextEditorContent',
+    template: '<div class="text-editor-content-stub" />'
+  }
+}))
+
+describe('AnnouncementModal', () => {
+  it('renders a read-only markdown editor for the info text', () => {
+    const wrapper = mount(AnnouncementModal, {
+      props: { modal: {} as any, infoText: '# Details' },
+      global: { plugins: [...defaultPlugins()] }
+    })
+
+    expect(vi.mocked(useTextEditor)).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'markdown', readonly: true })
+    )
+    expect(wrapper.find('.text-editor-content-stub').exists()).toBe(true)
+  })
+})

--- a/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
@@ -10,6 +10,13 @@ describe('getAbilities', () => {
     const expectedActions = ['create-all', 'delete-all', 'read-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Account' })))
   })
+  it('gets correct abilities for subject "Announcement"', function () {
+    const abilities = getAbilities(['Announcement.ReadWrite.all'])
+    const expectedActions = ['read-all', 'update-all']
+    expect(abilities).toEqual(
+      expectedActions.map((action) => ({ action, subject: 'Announcement' }))
+    )
+  })
   it('gets correct abilities for subject "Group"', function () {
     const abilities = getAbilities(['Groups.ReadWrite.all'])
     const expectedActions = ['create-all', 'delete-all', 'read-all', 'update-all']


### PR DESCRIPTION
Announcement banner shown above the top bar to all users (including the login page), with a dialog showing Markdown detail text, plus an admin UI to manage it.

- The banner reads `options.announcement.{bannerText, infoText}` from `config.json`; clicking it opens a dialog that renders `infoText` as read-only Markdown (via the shared TipTap editor).
- Admin settings (General): loads the full state via an authenticated `GET /announcement`, edits `bannerText` + a Markdown `infoText` editor (image insertion disabled), an instant `Enabled` switch, a session-only `Preview`, and `Save`. An empty banner text removes the announcement.
- Adds a reusable `excludeActions` option to `useTextEditor`.

Backend: opencloud-eu/opencloud#3189
fixes https://github.com/opencloud-eu/web/issues/2977

<img width="2369" height="1217" alt="Screenshot_20260729_004439" src="https://github.com/user-attachments/assets/ee060684-772d-4fac-8779-2bf975ee7a96" />

