### PR TITLE
feat: expose the active theme as html[data-theme]

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -121,6 +121,10 @@ export const useThemeStore = defineStore('theme', () => {
     }
 
     document.documentElement.style.colorScheme = theme.isDark ? 'dark' : 'light'
+    // expose the active theme on the DOM so deployment CSS (a global stylesheet or
+    // theme.json) can attach structural styles (borders, radii, ...) that the
+    // design-token system alone cannot express
+    document.documentElement.dataset.theme = theme.label
     const customizableDesignTokens = [
       { name: 'roles', prefix: 'role' },
       { name: 'colorPalette', prefix: 'color' }

--- a/packages/web-pkg/tests/unit/composables/piniaStores/theme.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/theme.spec.ts
@@ -60,4 +60,13 @@ describe('useThemeStore', () => {
       })
     })
   })
+
+  describe('setAndApplyTheme', () => {
+    it('exposes the active theme label on the html element', () => {
+      const store = useThemeStore()
+      store.setAndApplyTheme({ label: 'my-theme', designTokens: {}, isDark: false })
+
+      expect(document.documentElement.dataset.theme).toBe('my-theme')
+    })
+  })
 })


### PR DESCRIPTION
Sets the active theme's label on the `html` element (`html[data-theme="..."]`) so deployment CSS can attach structural styles (borders, radii, ...) that the design-token system alone cannot express.

Together with the existing global theme.json customization and global stylesheets (`options.styles`), a deployment can ship theme-scoped structural CSS without any app-specific machinery.

Split out of #2964 (which is superseded): this is the single, generally useful change from that draft, without the app-distribution complexity.