### PR TITLE
fix: getting resource link for folder extensions

### DIFF
--- a/packages/web-pkg/src/composables/resources/useResourceLink.ts
+++ b/packages/web-pkg/src/composables/resources/useResourceLink.ts
@@ -1,17 +1,34 @@
-import { Ref, unref } from 'vue'
+import { computed, Ref, unref } from 'vue'
 import { Resource, SpaceResource } from '@opencloud-eu/web-client'
 import { useGetMatchingSpace } from '../spaces'
 import { useFileActions } from '../actions'
 import { useFolderLink } from '../folderLink'
+import { useAppsStore } from '../piniaStores'
 
 export const useResourceLink = ({ space }: { space: Ref<SpaceResource> }) => {
+  const appsStore = useAppsStore()
   const { getDefaultAction } = useFileActions()
   const { getFolderLink } = useFolderLink({ space })
   const { getMatchingSpace } = useGetMatchingSpace()
 
+  const appFolderExtensions = computed(() => {
+    return new Set(
+      appsStore.fileExtensions
+        .filter((e) => e.type === 'folder' && e.extension)
+        .map((e) => e.extension.toLowerCase())
+    )
+  })
+
+  const isAppFolder = (resource: Resource) => {
+    return !!resource.extension && unref(appFolderExtensions).has(resource.extension.toLowerCase())
+  }
+
   const getResourceLink = (resource: Resource) => {
-    if (resource.isFolder || resource.type === 'folder') {
-      // skip the `getDefaultAction` call down below for folders, which is quite expensive
+    const isFolder = resource.isFolder || resource.type === 'folder'
+    // the `getDefaultAction` call down below is quite expensive, so skip it for
+    // plain folders. Folders claimed by an app (e.g. `.ocnb` notebooks) still
+    // need it to resolve to the app's route instead of folder navigation.
+    if (isFolder && !isAppFolder(resource)) {
       return getFolderLink(resource)
     }
 
@@ -22,7 +39,7 @@ export const useResourceLink = ({ space }: { space: Ref<SpaceResource> }) => {
 
     const action = getDefaultAction({ resources: [resource], space: matchingSpace })
     if (!action?.route) {
-      return
+      return isFolder ? getFolderLink(resource) : undefined
     }
 
     return action.route({ space: matchingSpace, resources: [resource] })

--- a/packages/web-pkg/tests/unit/composables/resources/useResourceLink.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useResourceLink.spec.ts
@@ -1,0 +1,146 @@
+import { ref } from 'vue'
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource } from '@opencloud-eu/web-client'
+import { getComposableWrapper } from '@opencloud-eu/web-test-helpers'
+import { useResourceLink } from '../../../../src/composables/resources'
+import { ApplicationFileExtension } from '../../../../src/apps'
+
+const { getDefaultActionMock, getFolderLinkMock } = vi.hoisted(() => ({
+  getDefaultActionMock: vi.fn(),
+  getFolderLinkMock: vi.fn()
+}))
+
+vi.mock('../../../../src/composables/actions/files/useFileActions', () => ({
+  useFileActions: () => ({ getDefaultAction: getDefaultActionMock })
+}))
+vi.mock('../../../../src/composables/folderLink/useFolderLink', () => ({
+  useFolderLink: () => ({ getFolderLink: getFolderLinkMock })
+}))
+
+const folderLink = { name: 'files-spaces-generic' }
+const actionLink = { name: 'external-apps' }
+
+describe('useResourceLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getFolderLinkMock.mockReturnValue(folderLink)
+  })
+
+  describe('getResourceLink', () => {
+    it('returns the folder link for plain folders without resolving the default action', () => {
+      getWrapper({
+        setup: ({ getResourceLink }) => {
+          const resource = mock<Resource>({ isFolder: true, type: 'folder', extension: '' })
+
+          expect(getResourceLink(resource)).toEqual(folderLink)
+          expect(getDefaultActionMock).not.toHaveBeenCalled()
+        }
+      })
+    })
+
+    it('returns the default action route for folders claimed by an app', () => {
+      getWrapper({
+        fileExtensions: [{ extension: 'ocnb', type: 'folder' }],
+        setup: ({ getResourceLink }) => {
+          const resource = mock<Resource>({
+            isFolder: true,
+            type: 'folder',
+            extension: 'ocnb'
+          })
+          getDefaultActionMock.mockReturnValue({ route: () => actionLink })
+
+          expect(getResourceLink(resource)).toEqual(actionLink)
+        }
+      })
+    })
+
+    it('matches app folder extensions case-insensitively', () => {
+      getWrapper({
+        fileExtensions: [{ extension: 'ocnb', type: 'folder' }],
+        setup: ({ getResourceLink }) => {
+          const resource = mock<Resource>({
+            isFolder: true,
+            type: 'folder',
+            extension: 'OCNB'
+          })
+          getDefaultActionMock.mockReturnValue({ route: () => actionLink })
+
+          expect(getResourceLink(resource)).toEqual(actionLink)
+        }
+      })
+    })
+
+    it('returns the folder link for folders whose extension is only registered for files', () => {
+      getWrapper({
+        fileExtensions: [{ extension: 'ocnb', type: 'file' }],
+        setup: ({ getResourceLink }) => {
+          const resource = mock<Resource>({
+            isFolder: true,
+            type: 'folder',
+            extension: 'ocnb'
+          })
+
+          expect(getResourceLink(resource)).toEqual(folderLink)
+          expect(getDefaultActionMock).not.toHaveBeenCalled()
+        }
+      })
+    })
+
+    it('falls back to the folder link if an app folder has no default action route', () => {
+      getWrapper({
+        fileExtensions: [{ extension: 'ocnb', type: 'folder' }],
+        setup: ({ getResourceLink }) => {
+          const resource = mock<Resource>({
+            isFolder: true,
+            type: 'folder',
+            extension: 'ocnb'
+          })
+          getDefaultActionMock.mockReturnValue(undefined)
+
+          expect(getResourceLink(resource)).toEqual(folderLink)
+        }
+      })
+    })
+
+    it('returns the default action route for files', () => {
+      getWrapper({
+        setup: ({ getResourceLink }) => {
+          const resource = mock<Resource>({ isFolder: false, type: 'file', extension: 'txt' })
+          getDefaultActionMock.mockReturnValue({ route: () => actionLink })
+
+          expect(getResourceLink(resource)).toEqual(actionLink)
+        }
+      })
+    })
+
+    it('returns undefined for files without a default action route', () => {
+      getWrapper({
+        setup: ({ getResourceLink }) => {
+          const resource = mock<Resource>({ isFolder: false, type: 'file', extension: 'txt' })
+          getDefaultActionMock.mockReturnValue(undefined)
+
+          expect(getResourceLink(resource)).toBeUndefined()
+          expect(getFolderLinkMock).not.toHaveBeenCalled()
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup,
+  fileExtensions = []
+}: {
+  setup: (instance: ReturnType<typeof useResourceLink>) => void
+  fileExtensions?: ApplicationFileExtension[]
+}) {
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useResourceLink({ space: ref(mock<SpaceResource>()) })
+        setup(instance)
+      },
+      { pluginOptions: { piniaOptions: { appsState: { fileExtensions } } } }
+    )
+  }
+}


### PR DESCRIPTION
Make sure that `useResourceLink().getResourceLink` returns the correct link for folders with extensions that can be opened a registered action. E.g. `.ocnb` folders should be opened with the notes extension per default.

fixes a regression from ff3be40e9a4d577ebc44f169d556393fd6840965