### PR TITLE
feat(vault): use integrity id as passphrase verifier

### DIFF
--- a/packages/design-system/src/components/OcSwitch/OcSwitch.vue
+++ b/packages/design-system/src/components/OcSwitch/OcSwitch.vue
@@ -3,7 +3,7 @@
     <span class="inline-flex items-center gap-1">
       <!-- dim only the label + toggle when disabled, not the slot: an opacity on the whole
            switch would create a stacking context that traps slotted popovers (e.g. a helper) -->
-      <span :id="labelId" v-text="label" :class="{ 'opacity-40': disabled }" />
+      <span :id="labelId" :class="{ 'opacity-40': disabled }" v-text="label" />
       <!-- @slot content rendered next to the label, e.g. a contextual helper -->
       <slot />
     </span>

--- a/packages/web-app-rclone-crypt/package.json
+++ b/packages/web-app-rclone-crypt/package.json
@@ -5,14 +5,18 @@
   "description": "OpenCloud Web plugin: browse, edit and upload rclone-crypt encrypted folder vaults",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@fyears/rclone-crypt": "^0.0.7",
-    "vue-inline-svg": "^4.0.1"
+    "@fyears/rclone-crypt": "^0.0.7"
+  },
+  "devDependencies": {
+    "@opencloud-eu/web-test-helpers": "workspace:*"
   },
   "peerDependencies": {
     "@opencloud-eu/web-client": "workspace:*",
     "@opencloud-eu/web-pkg": "workspace:*",
     "pinia": "4.0.2",
+    "uuid": "^14.0.0",
     "vue": "^3.5.0",
+    "vue-inline-svg": "^4.0.1",
     "vue3-gettext": "^4.0.0-beta.1"
   }
 }

--- a/packages/web-app-rclone-crypt/src/crypto/engine.ts
+++ b/packages/web-app-rclone-crypt/src/crypto/engine.ts
@@ -1,5 +1,7 @@
 import { Cipher } from '@fyears/rclone-crypt'
+import { v4 as uuidV4 } from 'uuid'
 import { FolderVaultEngine } from '@opencloud-eu/web-pkg'
+import { fromBase64, toBase64 } from '../integrity'
 
 export function createEngine(vaultRoot: string, password: string): FolderVaultEngine {
   // Derive the cipher once per engine. rclone-crypt's EME filename encryption
@@ -34,10 +36,36 @@ export function createEngine(vaultRoot: string, password: string): FolderVaultEn
       const cipher = await cipherPromise
       return cipher.decryptFileName(relativePath)
     },
-    async verifyKey(sampleEncryptedSegment: string): Promise<boolean> {
-      // rclone-crypt throws on bad password (PKCS#7 unpad fails, UTF-8 decode
-      // fails, or the decoded segment contains control chars). Treat any
-      // throw as "key doesn't match".
+    async createIntegrityToken(): Promise<string> {
+      const cipher = await cipherPromise
+      // A random uuid encrypted with the vault's own content cipher, in the very
+      // same rclone-crypt file format the vault's files use.
+      const ciphertext = await cipher.encryptData(
+        new TextEncoder().encode(uuidV4()),
+        // nonce omitted → lib generates a fresh random nonce
+        undefined
+      )
+      return toBase64(ciphertext)
+    },
+    async verifyIntegrityToken(token: string): Promise<boolean> {
+      // Each rclone-crypt block carries a Poly1305 tag, so decryptData throws on
+      // a wrong key ("failed to authenticate decrypted block"). That makes this a
+      // real cryptographic check - no need to inspect the recovered plaintext.
+      try {
+        const cipher = await cipherPromise
+        await cipher.decryptData(fromBase64(token))
+        return true
+      } catch {
+        return false
+      }
+    },
+    async verifySegment(sampleEncryptedSegment: string): Promise<boolean> {
+      // EME filename encryption carries no authentication tag, so all we can do
+      // is decrypt and see whether the result is plausible: rclone-crypt throws
+      // when PKCS#7 unpadding fails, UTF-8 decoding fails, or the segment holds
+      // control chars. A wrong passphrase clears all three often enough to
+      // matter (roughly 2% for a short name), which is why the integrity token
+      // exists and why we backfill one as soon as this check passes.
       try {
         const cipher = await cipherPromise
         const decrypted = await cipher.decryptSegment(sampleEncryptedSegment)

--- a/packages/web-app-rclone-crypt/src/integrity.ts
+++ b/packages/web-app-rclone-crypt/src/integrity.ts
@@ -1,0 +1,33 @@
+/**
+ * Name of the WebDAV property holding a vault's integrity token.
+ *
+ * Deliberately owned by this app rather than web-pkg. The generic layer only
+ * knows that a vault *has* an opaque token, and never what it looks like or
+ * where it is stored. This app's token is an rclone-crypt content blob that
+ * gets stored as arbitrary metadata.
+ *
+ * The `ocrclone` prefix names this app and doubles as the namespace, so the
+ * property is stored under `ocrclone/integrity-id`. It cannot live in the
+ * `oc` namespace because the server answers unknown `oc` local names with
+ * `404 Not Found`.
+ */
+export const INTEGRITY_ID_PROP = 'ocrclone:integrity-id'
+
+/** Encode raw ciphertext so it can live in an XML text node. */
+export function toBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+/** Counterpart to `toBase64`. Throws on input that isn't valid base64. */
+export function fromBase64(value: string): Uint8Array {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}

--- a/packages/web-app-rclone-crypt/src/unlock.ts
+++ b/packages/web-app-rclone-crypt/src/unlock.ts
@@ -1,0 +1,200 @@
+import { Resource, SpaceResource } from '@opencloud-eu/web-client'
+import { WebDAV } from '@opencloud-eu/web-client/webdav'
+import { FolderVaultEngine, streamToArrayBuffer } from '@opencloud-eu/web-pkg'
+import { createEngine } from './crypto/engine'
+import { INTEGRITY_ID_PROP } from './integrity'
+
+export type VaultTarget = {
+  webdav: WebDAV
+  space: SpaceResource
+  vaultRoot: string
+}
+
+export type UnlockResult =
+  /** The passphrase holds up; `engine` is the one to stash for the session. */
+  | { status: 'unlocked'; engine: FolderVaultEngine }
+  /** Cryptographically ruled out, as opposed to a request that simply failed. */
+  | { status: 'wrong-passphrase' }
+
+/**
+ * An rclone-crypt file is a 32-byte header (magic + nonce) followed by
+ * Poly1305-sealed blocks. At exactly 32 bytes there are no blocks, so nothing is
+ * authenticated and *any* key "decrypts" it - such a file proves nothing.
+ */
+const FILE_HEADER_SIZE = 32
+
+/** One sealed rclone-crypt block: 64 KiB of data plus its 16-byte Poly1305 tag. */
+const BLOCK_SIZE = 16 + 64 * 1024
+
+/** Read the vault root itself, with the integrity token property requested. */
+function readVaultRoot({ webdav, space, vaultRoot }: VaultTarget): Promise<Resource | undefined> {
+  return webdav.getFileInfo(space, { path: vaultRoot }, { extraProps: [INTEGRITY_ID_PROP] })
+}
+
+function integrityTokenOf(root: Resource | undefined): string | null {
+  return (root?.extraProps?.[INTEGRITY_ID_PROP] as string) || null
+}
+
+/**
+ * Retrieve an encrypted file name and file from the server, if any, to verify
+ * a passphrase against. The name is cheap to get but only plausibly proves a
+ * passphrase, while the file content carries a cryptographic proof.
+ * This gets used when there is no integrity token, or one that doesn't match
+ * the passphrase.
+ */
+export async function readVaultSamples(
+  { webdav, space, vaultRoot }: VaultTarget,
+  root?: Resource
+): Promise<{
+  /** Any encrypted child name, for the cheap `verifySegment` pre-check. */
+  name: string | undefined
+  /** Smallest file whose content is actually authenticated, if the vault has one. */
+  file: Resource | undefined
+}> {
+  const { children } = await webdav.listFiles(
+    space,
+    root?.id ? { fileId: root.id } : { path: vaultRoot }
+  )
+  const list = children ?? []
+  return {
+    name: list.find((c) => c?.name)?.name,
+    // Cheapest definitive evidence: smallest is fine.
+    file: list
+      .filter((c) => c && !c.isFolder && Number(c.size) > FILE_HEADER_SIZE)
+      .sort((a, b) => Number(a.size) - Number(b.size))[0]
+  }
+}
+
+/**
+ * Prove a passphrase against a file's content. Unlike a name, content carries a
+ * Poly1305 tag, so a successful decrypt is cryptographic proof rather than a
+ * plausibility guess - the same strength as the integrity token itself.
+ */
+async function verifyAgainstContent(
+  { webdav, space }: VaultTarget,
+  engine: FolderVaultEngine,
+  file: Resource
+): Promise<boolean> {
+  // Fetch outside the try: a transport error is not a wrong passphrase, so let it
+  // reach the caller and its "please try again" message. The vault is still
+  // locked, so the decorator hands back raw ciphertext and `file.path` is already
+  // the encrypted server path.
+  //
+  // Only the file header plus the first sealed block is asked for: that block
+  // authenticates on its own, so anything beyond it would be a download (and a
+  // decrypt) of a whole - possibly huge - file for no extra proof. A server that
+  // ignores the range simply hands back the entire file, which still decrypts.
+  const { body } = await webdav.getFileContents(
+    space,
+    { fileId: file.id },
+    {
+      responseType: 'arraybuffer',
+      headers: { Range: `bytes=0-${FILE_HEADER_SIZE + BLOCK_SIZE - 1}` }
+    }
+  )
+  try {
+    await streamToArrayBuffer(engine.decryptContent(new Blob([body]).stream()))
+    return true
+  } catch {
+    // Failed Poly1305 tag - the passphrase is definitively wrong.
+    return false
+  }
+}
+
+/** Commit the vault to this engine's passphrase by storing its integrity token. */
+async function writeIntegrityToken(
+  { webdav, space, vaultRoot }: VaultTarget,
+  engine: FolderVaultEngine
+): Promise<void> {
+  const token = await engine.createIntegrityToken()
+  await webdav.setProperties(
+    space,
+    { path: vaultRoot },
+    { [INTEGRITY_ID_PROP]: token },
+    { extraProps: [INTEGRITY_ID_PROP] }
+  )
+}
+
+/** Whether the vault still needs setup and is without a passphrase (= new vault). */
+export async function probeVaultNeedsSetup(target: VaultTarget): Promise<boolean> {
+  const root = await readVaultRoot(target)
+  if (integrityTokenOf(root)) {
+    // A token means we can safely assume the vault is set up.
+    return false
+  }
+  // No token: the vault might still be set up (e.g. outside of Web, hence no token).
+  // Check for any content if this is the case.
+  return !(await readVaultSamples(target, root)).name
+}
+
+/**
+ * Verify `passphrase` against the vault and, where that proves it, commit the
+ * vault to it by writing an integrity token.
+ *
+ * Throws on anything that isn't a verdict on the passphrase - a failed request,
+ * or a brand new vault whose token could not be written - so callers can offer a
+ * retry instead of blaming the passphrase.
+ */
+export async function unlockVault(target: VaultTarget, passphrase: string): Promise<UnlockResult> {
+  // Re-read the token against the live server rather than trusting an earlier
+  // probe. The engine built here is also the one handed back, so it doubles as
+  // the session's unlocked engine.
+  const root = await readVaultRoot(target)
+  const token = integrityTokenOf(root)
+  const engine = createEngine(target.vaultRoot, passphrase)
+
+  // A verified token is a cryptographic proof of the passphrase.
+  if (token && (await engine.verifyIntegrityToken(token))) {
+    return { status: 'unlocked', engine }
+  }
+
+  // No token, or one that doesn't match. A mismatch is not the final word: the
+  // token lives in a property that anyone with write access to the vault root
+  // can overwrite, and a setup race between two clients leaves one behind that
+  // the other's passphrase never verifies. File content carries its own
+  // Poly1305 tag, so it outranks the token - where a file decrypts, the
+  // passphrase is proven and the token is the thing that is wrong.
+  const { name, file } = await readVaultSamples(target, root)
+
+  const vaultIsEmpty = !name
+  if (vaultIsEmpty) {
+    if (token) {
+      // An empty vault holds nothing to overrule the token with, and writing a
+      // fresh one would let any passphrase take the vault over.
+      return { status: 'wrong-passphrase' }
+    }
+    // Brand new vault. Writing the token is what commits the passphrase, so let
+    // a failure surface - otherwise the user could silently pick a different
+    // passphrase next time, which is the confusion tokens prevent.
+    await writeIntegrityToken(target, engine)
+    return { status: 'unlocked', engine }
+  }
+
+  if (!file) {
+    // Nothing authenticated to check against (only folders, or empty files), so
+    // all that's left is decrypting a name - a plausibility check. Weak enough
+    // that it may neither commit a token nor overrule one that failed above.
+    return !token && (await engine.verifySegment(name))
+      ? { status: 'unlocked', engine }
+      : { status: 'wrong-passphrase' }
+  }
+
+  // A vault with content: let the content decide. This is 100% proof, so it is
+  // also what a token gets written from - committing one off the back of the
+  // name check could lock the user out with a passphrase that merely looked
+  // plausible.
+  if (!(await verifyAgainstContent(target, engine, file))) {
+    return { status: 'wrong-passphrase' }
+  }
+
+  // Writing properties needs write permission, which a viewer on a shared vault
+  // or a public-link visitor doesn't have. The passphrase is proven by now, so
+  // failing here must not keep the user out -> catch and log the error only.
+  try {
+    await writeIntegrityToken(target, engine)
+  } catch (e) {
+    console.warn('[rclone-crypt] could not store the vault integrity token', e)
+  }
+
+  return { status: 'unlocked', engine }
+}

--- a/packages/web-app-rclone-crypt/src/views/UnlockVault.vue
+++ b/packages/web-app-rclone-crypt/src/views/UnlockVault.vue
@@ -32,9 +32,9 @@
         <p class="mb-4 text-sm" v-text="vaultDescription" />
       </div>
       <div
-        v-if="isEmpty === true"
+        v-if="needsSetup === true"
         class="mb-4 rounded-xl border border-yellow-300 bg-yellow-100 p-4"
-        data-testid="empty-vault-hint"
+        data-testid="vault-setup-hint"
       >
         <div class="flex items-start gap-2">
           <oc-icon
@@ -71,7 +71,7 @@
           autocomplete="off"
         />
         <oc-text-input
-          v-if="isEmpty === true"
+          v-if="needsSetup === true"
           id="vault-passphrase-confirm"
           v-model="confirmPassword"
           :error-message="confirmErrorMessage"
@@ -122,8 +122,8 @@ import {
   useRouter,
   useSpacesStore
 } from '@opencloud-eu/web-pkg'
-import { createEngine } from '../crypto/engine'
-import { isShareSpaceResource } from '@opencloud-eu/web-client'
+import { probeVaultNeedsSetup, unlockVault, VaultTarget } from '../unlock'
+import { isShareSpaceResource, urlJoin } from '@opencloud-eu/web-client'
 
 InlineSvg.name = 'inline-svg'
 
@@ -137,17 +137,16 @@ const resourcesStore = useResourcesStore()
 
 const passwordInput = useTemplateRef<HTMLInputElement>('passwordInput')
 const password = ref('')
-// Only used while setting up a still-empty vault: the passphrase is committed by
-// the first upload and can't be changed from within OpenCloud, so we make the
-// user type it twice to catch typos before it's locked in for good.
+// Only used while setting up a vault: submitting writes the integrity token,
+// which commits the passphrase for good - it can't be changed from within
+// OpenCloud - so we make the user type it twice to catch typos first.
 const confirmPassword = ref('')
 const verifying = ref(false)
 const errorMessage = ref<string | null>(null)
 // `null` = we haven't probed the server yet, `true` = the vault has no
-// encrypted entries we could verify the passphrase against (any passphrase
-// is accepted and effectively committed by the first upload), `false` =
-// there's content to verify against.
-const isEmpty = ref<boolean | null>(null)
+// passphrase committed yet, so the user is choosing one now, `false` = there's
+// an integrity token or content to verify the passphrase against.
+const needsSetup = ref<boolean | null>(null)
 
 const spaceId = computed(() => queryItemAsString(unref(route).query.spaceId))
 const vaultRoot = computed(() => queryItemAsString(unref(route).query.vaultRoot))
@@ -162,7 +161,7 @@ const vaultName = computed(() => {
 })
 
 const vaultDescription = computed(() =>
-  unref(isEmpty) === true
+  unref(needsSetup) === true
     ? $gettext(
         'Files are encrypted on your device before they upload, and only your passphrase can unlock them.'
       )
@@ -170,21 +169,21 @@ const vaultDescription = computed(() =>
 )
 
 const cardTitle = computed(() =>
-  unref(isEmpty) === true ? $gettext('Set Up Encrypted Vault') : $gettext('Unlock vault')
+  unref(needsSetup) === true ? $gettext('Set Up Encrypted Vault') : $gettext('Unlock vault')
 )
 
 const passphraseLabel = computed(() =>
-  unref(isEmpty) === true ? $gettext('Choose a passphrase') : $gettext('Vault passphrase')
+  unref(needsSetup) === true ? $gettext('Choose a passphrase') : $gettext('Vault passphrase')
 )
 
 const submitLabel = computed(() =>
-  unref(isEmpty) === true ? $gettext('Set passphrase') : $gettext('Unlock')
+  unref(needsSetup) === true ? $gettext('Set passphrase') : $gettext('Unlock')
 )
 
 // Surface the mismatch only once the user has started typing the confirmation,
 // so the field doesn't show an error before they've had a chance to fill it.
 const confirmErrorMessage = computed(() =>
-  unref(isEmpty) === true && unref(confirmPassword) && unref(password) !== unref(confirmPassword)
+  unref(needsSetup) === true && unref(confirmPassword) && unref(password) !== unref(confirmPassword)
     ? $gettext('Passphrases do not match')
     : null
 )
@@ -194,45 +193,37 @@ const submitDisabled = computed(() => {
     return true
   }
   // Setting up a vault requires both fields to match before we lock it in.
-  return unref(isEmpty) === true && unref(password) !== unref(confirmPassword)
+  return unref(needsSetup) === true && unref(password) !== unref(confirmPassword)
 })
 
 const space = computed(() => spacesStore.spaces.find((s) => s.id === unref(spaceId)))
 
-const onSubmit = async () => {
+const vaultTarget = computed<VaultTarget>(() => ({
+  webdav: clientService.webdav,
+  space: unref(space),
+  vaultRoot: unref(vaultRoot)
+}))
+
+async function onSubmit() {
   errorMessage.value = null
   // Guard against a programmatic submit slipping past the disabled button.
-  if (unref(isEmpty) === true && unref(password) !== unref(confirmPassword)) {
+  if (unref(needsSetup) === true && unref(password) !== unref(confirmPassword)) {
     errorMessage.value = $gettext('Passphrases do not match.')
     return
   }
   verifying.value = true
   try {
-    // 1. Fetch the vault root listing to grab a sample encrypted name we can
-    //    verify the key against. Doesn't decrypt anything - names stay raw.
-    //    rclone-crypt's filename encryption is deterministic; one valid
-    //    decrypt is a strong signal that the key fits.
-    const { children } = await clientService.webdav.listFiles(unref(space), {
-      path: unref(vaultRoot)
-    })
-    const sample = (children ?? []).find((c) => c?.name)?.name
-
-    // Build the engine with the supplied passphrase and ask it to decrypt our
-    // sample. Empty vault → trust the passphrase (nothing to disagree with).
-    // Otherwise success here means "this is the right key". The very same engine
-    // is what we stash, so it doubles as the session's unlocked engine.
-    const engine = createEngine(unref(vaultRoot), unref(password))
-    const keyOk = sample ? await engine.verifyKey(sample) : true
-    if (!keyOk) {
+    const result = await unlockVault(unref(vaultTarget), unref(password))
+    if (result.status === 'wrong-passphrase') {
       errorMessage.value = $gettext('Incorrect passphrase.')
       return
     }
 
-    vaultStore.setEngine(unref(spaceId), unref(vaultRoot), engine)
+    vaultStore.setEngine(unref(spaceId), unref(vaultRoot), result.engine)
 
     const target = unref(redirectUrl)
     // router.push accepts a full URL string and parses path + query for us.
-    await router.push(target || `/files/spaces${unref(vaultRoot)}`)
+    await router.push(target || urlJoin('/files/spaces', unref(vaultRoot)))
   } catch (e) {
     console.error(e)
     errorMessage.value = $gettext('Unlocking failed. Please try again')
@@ -243,39 +234,36 @@ const onSubmit = async () => {
 
 onMounted(async () => {
   unref(passwordInput)?.focus?.()
-  // Probe the vault root listing once to decide if we should switch to
-  // "empty vault, any passphrase wins" wording. We don't gate the submit
-  // button on this - onSubmit re-checks against the live listing.
+  // Probe once to pick between the "set up" and "unlock" wording. We don't gate
+  // the submit button on this - onSubmit re-reads the live state.
+  if (!unref(space) || !unref(vaultRoot)) {
+    needsSetup.value = false
+    return
+  }
   try {
-    const targetSpace = unref(space)
-    const root = unref(vaultRoot)
-    if (!targetSpace || !root) {
-      isEmpty.value = false
-      return
-    }
-    const { children } = await clientService.webdav.listFiles(targetSpace, { path: root })
-    isEmpty.value = (children ?? []).length === 0
+    needsSetup.value = await probeVaultNeedsSetup(unref(vaultTarget))
   } catch (e) {
     console.warn('[UnlockVault] could not probe vault contents', e)
-    isEmpty.value = false
+    needsSetup.value = false
   }
 })
 
-const onCancel = async () => {
+async function onCancel() {
   // Walk one level above the vault root so the user lands back in the folder
   // they came from instead of inside the locked vault - clicking the vault
   // would otherwise just kick them back to this unlock page.
   const root = unref(vaultRoot) || '/'
-  const parent = root.replace(/\/[^/]+$/, '') || '/'
-  const space = unref(spacesStore.spaces).find((s) => s.id === unref(spaceId))
-  if (isShareSpaceResource(space) && root === '/') {
+  // Empty for a vault sitting directly in the space root - urlJoin drops it.
+  const parent = root.replace(/\/[^/]+$/, '')
+  const targetSpace = unref(space)
+  if (isShareSpaceResource(targetSpace) && root === '/') {
     await router.push(createLocationShares('files-shares-with-me'))
     return
   }
-  if (space) {
+  if (targetSpace) {
     await router.push({
-      path: `/files/spaces/${space.driveAlias}${parent === '/' ? '' : parent}`,
-      ...(isShareSpaceResource(space) && { query: { shareId: space.id } })
+      path: urlJoin('/files/spaces', targetSpace.driveAlias, parent),
+      ...(isShareSpaceResource(targetSpace) && { query: { shareId: targetSpace.id } })
     })
     return
   }

--- a/packages/web-app-rclone-crypt/tests/unit/crypto/engine.spec.ts
+++ b/packages/web-app-rclone-crypt/tests/unit/crypto/engine.spec.ts
@@ -1,5 +1,6 @@
 import { encryptVaultPath } from '@opencloud-eu/web-pkg'
 import { createEngine } from '../../../src/crypto/engine'
+import { fromBase64 } from '../../../src/integrity'
 
 async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
   const reader = stream.getReader()
@@ -92,18 +93,64 @@ describe('rclone-crypt engine', () => {
     })
   })
 
-  describe('verifyKey', () => {
+  describe('verifySegment', () => {
     it('accepts a sample segment that decrypts under the engine key', async () => {
-      expect(await engine.verifyKey('unq54c7b9fj4lam8t82q1hofdo')).toBe(true)
+      expect(await engine.verifySegment('unq54c7b9fj4lam8t82q1hofdo')).toBe(true)
     })
 
     it('rejects a sample segment that belongs to a different password', async () => {
       const wrong = createEngine('/my.vault', 'not-the-passphrase')
-      expect(await wrong.verifyKey('unq54c7b9fj4lam8t82q1hofdo')).toBe(false)
+      expect(await wrong.verifySegment('unq54c7b9fj4lam8t82q1hofdo')).toBe(false)
     })
 
     it('rejects a segment that is not valid ciphertext at all', async () => {
-      expect(await engine.verifyKey('!!! not base32 !!!')).toBe(false)
+      expect(await engine.verifySegment('!!! not base32 !!!')).toBe(false)
+    })
+  })
+
+  describe('integrity token', () => {
+    it('verifies a token it minted itself', async () => {
+      expect(await engine.verifyIntegrityToken(await engine.createIntegrityToken())).toBe(true)
+    })
+
+    it('rejects a token minted under a different passphrase', async () => {
+      const wrong = createEngine('/my.vault', 'not-the-passphrase')
+
+      expect(await wrong.verifyIntegrityToken(await engine.createIntegrityToken())).toBe(false)
+      expect(await engine.verifyIntegrityToken(await wrong.createIntegrityToken())).toBe(false)
+    })
+
+    it('rejects garbage, truncated and non-base64 tokens', async () => {
+      const token = await engine.createIntegrityToken()
+
+      expect(await engine.verifyIntegrityToken('')).toBe(false)
+      expect(await engine.verifyIntegrityToken('!!! not base64 !!!')).toBe(false)
+      // A truncated token loses the Poly1305 tag, so authentication has to fail.
+      expect(await engine.verifyIntegrityToken(token.slice(0, 20))).toBe(false)
+    })
+
+    it('mints a different token on every call', async () => {
+      // A fresh random nonce per token, so the property never leaks whether two
+      // vaults share a passphrase.
+      const [first, second] = await Promise.all([
+        engine.createIntegrityToken(),
+        engine.createIntegrityToken()
+      ])
+
+      expect(first).not.toBe(second)
+      expect(await engine.verifyIntegrityToken(first)).toBe(true)
+      expect(await engine.verifyIntegrityToken(second)).toBe(true)
+    })
+
+    it('carries a uuid as its plaintext', async () => {
+      const token = await engine.createIntegrityToken()
+      const plaintext = new TextDecoder().decode(
+        await collect(engine.decryptContent(streamOf(fromBase64(token))))
+      )
+
+      expect(plaintext).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      )
     })
   })
 })

--- a/packages/web-app-rclone-crypt/tests/unit/unlock.spec.ts
+++ b/packages/web-app-rclone-crypt/tests/unit/unlock.spec.ts
@@ -1,0 +1,343 @@
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource } from '@opencloud-eu/web-client'
+import { WebDAV } from '@opencloud-eu/web-client/webdav'
+import { streamToArrayBuffer } from '@opencloud-eu/web-pkg'
+import { probeVaultNeedsSetup, unlockVault, VaultTarget } from '../../src/unlock'
+import { createEngine } from '../../src/crypto/engine'
+import { INTEGRITY_ID_PROP } from '../../src/integrity'
+
+const vaultRoot = '/my.vault'
+const passphrase = 'foobar'
+// "report.txt" encrypted with the passphrase above - the sample `verifySegment`
+// decrypts when a vault carries no integrity token.
+const encryptedChildName = 'unq54c7b9fj4lam8t82q1hofdo'
+
+function tokenFor(password: string): Promise<string> {
+  return createEngine(vaultRoot, password).createIntegrityToken()
+}
+
+/** Real rclone-crypt ciphertext for `content`, as the server would hold it. */
+function encryptedFile(password: string, content: string): Promise<ArrayBuffer> {
+  const engine = createEngine(vaultRoot, password)
+  return streamToArrayBuffer(engine.encryptContent(new Blob([content]).stream()))
+}
+
+type Child = { name: string; isFolder?: boolean; size?: number }
+
+async function createTarget({
+  token = null,
+  children = [],
+  /** Ciphertext the sampled file returns; defaults to a blob under `passphrase`. */
+  fileContent,
+  rootId = 'id-root',
+  driveType = 'project'
+}: {
+  token?: string | null
+  children?: Child[]
+  fileContent?: ArrayBuffer
+  rootId?: string
+  driveType?: string
+} = {}) {
+  const webdav = mock<WebDAV>()
+
+  // The vault root alone (depth 0) carries the integrity token...
+  webdav.getFileInfo.mockResolvedValue({
+    id: rootId,
+    path: vaultRoot,
+    ...(token && { extraProps: { [INTEGRITY_ID_PROP]: token } })
+  } as unknown as Resource)
+  // ...and the listing is only needed when there is no token.
+  webdav.listFiles.mockResolvedValue({
+    resource: { path: vaultRoot } as unknown as Resource,
+    children: children.map(
+      ({ name, isFolder = false, size = 1024 }) =>
+        ({
+          id: `id-${name}`,
+          name,
+          path: `${vaultRoot}/${name}`,
+          isFolder,
+          size: String(size)
+        }) as unknown as Resource
+    )
+  })
+  webdav.getFileContents.mockResolvedValue({
+    body: fileContent ?? (await encryptedFile(passphrase, 'hello vault'))
+  } as never)
+  webdav.setProperties.mockResolvedValue(undefined as never)
+
+  const space = mock<SpaceResource>({ id: 'space-1', driveType })
+
+  return { target: { webdav, space, vaultRoot } as VaultTarget, webdav, space }
+}
+
+/** The token handed to setProperties, so tests can verify it independently. */
+function writtenToken(webdav: WebDAV): string {
+  const [, , properties] = vi.mocked(webdav.setProperties).mock.calls[0]
+  return (properties as Record<string, string>)[INTEGRITY_ID_PROP]
+}
+
+describe('unlockVault', () => {
+  describe('a vault carrying an integrity token', () => {
+    it('unlocks with the right passphrase and writes nothing', async () => {
+      const { target, webdav } = await createTarget({ token: await tokenFor(passphrase) })
+
+      const result = await unlockVault(target, passphrase)
+
+      expect(result.status).toBe('unlocked')
+      // The passphrase is already committed - nothing to write on a plain unlock.
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('rejects a wrong passphrase without overwriting the token', async () => {
+      const { target, webdav } = await createTarget({
+        token: await tokenFor(passphrase),
+        children: [{ name: encryptedChildName }]
+      })
+
+      const result = await unlockVault(target, 'definitely-wrong')
+
+      expect(result.status).toBe('wrong-passphrase')
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('unlocks and repairs a token that no passphrase verifies', async () => {
+      // The token sits in a property anyone with write access to the vault root
+      // can overwrite, and a setup race between two clients leaves one behind
+      // that the other's passphrase never verifies. Content is authenticated,
+      // so it outranks the token - otherwise the owner is locked out for good.
+      const { target, webdav } = await createTarget({
+        token: await tokenFor('someone-elses-passphrase'),
+        children: [{ name: encryptedChildName }]
+      })
+
+      const result = await unlockVault(target, passphrase)
+
+      expect(result.status).toBe('unlocked')
+      const engine = createEngine(vaultRoot, passphrase)
+      expect(await engine.verifyIntegrityToken(writtenToken(webdav))).toBe(true)
+    })
+
+    it('rejects a wrong passphrase against a token an empty vault cannot overrule', async () => {
+      const { target, webdav } = await createTarget({ token: await tokenFor(passphrase) })
+
+      const result = await unlockVault(target, 'definitely-wrong')
+
+      expect(result.status).toBe('wrong-passphrase')
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('rejects a wrong passphrase when the vault holds no authenticated content', async () => {
+      // Only a name to go by, and decrypting one is a plausibility guess with no
+      // tag behind it - far too weak to overrule a token.
+      const { target, webdav } = await createTarget({
+        token: await tokenFor('someone-elses-passphrase'),
+        children: [{ name: encryptedChildName, isFolder: true }]
+      })
+
+      const result = await unlockVault(target, passphrase)
+
+      expect(result.status).toBe('wrong-passphrase')
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('asks for the token per request and never lists the children', async () => {
+      // The token answers everything, so the common case stays at depth 0. The
+      // prop is requested per call rather than registered globally, so no other
+      // PROPFIND in the app carries it.
+      const { target, webdav, space } = await createTarget({ token: await tokenFor(passphrase) })
+
+      await unlockVault(target, passphrase)
+
+      expect(webdav.getFileInfo).toHaveBeenCalledWith(
+        space,
+        { path: vaultRoot },
+        { extraProps: [INTEGRITY_ID_PROP] }
+      )
+      expect(webdav.listFiles).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('a vault with content but no token', () => {
+    it('proves the passphrase against file content, then backfills a token', async () => {
+      const { target, webdav, space } = await createTarget({
+        children: [{ name: encryptedChildName }]
+      })
+
+      const result = await unlockVault(target, passphrase)
+
+      expect(result.status).toBe('unlocked')
+      expect(webdav.setProperties).toHaveBeenCalledWith(
+        space,
+        { path: vaultRoot },
+        expect.objectContaining({ [INTEGRITY_ID_PROP]: expect.any(String) }),
+        // Required, or the prop is written as `oc:ocrclone:integrity-id` and can
+        // never be read back - a 207 that silently loses the passphrase.
+        { extraProps: [INTEGRITY_ID_PROP] }
+      )
+      // The backfilled token has to verify under the passphrase we just used.
+      const engine = createEngine(vaultRoot, passphrase)
+      expect(await engine.verifyIntegrityToken(writtenToken(webdav))).toBe(true)
+    })
+
+    it('rejects a wrong passphrase and backfills nothing', async () => {
+      const { target, webdav } = await createTarget({ children: [{ name: encryptedChildName }] })
+
+      const result = await unlockVault(target, 'not-the-passphrase')
+
+      expect(result.status).toBe('wrong-passphrase')
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('rejects a wrong passphrase that slips past the name check', async () => {
+      // `verifySegment` has no authentication tag, and this exact passphrase is a
+      // known false accept against this exact name. Content decryption is what
+      // catches it - without that, we would write a token for the wrong passphrase
+      // and lock the real one out permanently.
+      const { target, webdav } = await createTarget({ children: [{ name: encryptedChildName }] })
+      const engine = createEngine(vaultRoot, 'definitely-wrong')
+      expect(await engine.verifySegment(encryptedChildName)).toBe(true)
+
+      const result = await unlockVault(target, 'definitely-wrong')
+
+      expect(result.status).toBe('wrong-passphrase')
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('unlocks without a token when there is no authenticated content', async () => {
+      // Only folders and an empty file. A 32-byte rclone-crypt file is a bare
+      // header sealing no blocks, so *any* key "decrypts" it - it proves nothing,
+      // and must not be treated as evidence worth committing a token from.
+      const { target, webdav } = await createTarget({
+        children: [
+          { name: encryptedChildName, isFolder: true },
+          { name: 'kj4hg2mnb5vcx8qwe7rty1uiop', size: 32 }
+        ]
+      })
+
+      const result = await unlockVault(target, passphrase)
+
+      expect(result.status).toBe('unlocked')
+      expect(webdav.getFileContents).not.toHaveBeenCalled()
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('samples the smallest file that actually seals a block', async () => {
+      // First child carries the real ciphertext so the cheap name check passes;
+      // the sampled file should still be the smallest one above the bare header.
+      const { target, webdav, space } = await createTarget({
+        children: [
+          { name: encryptedChildName, size: 900 },
+          { name: 'empty-file', size: 32 },
+          { name: 'smallest-sealed', size: 200 }
+        ]
+      })
+
+      await unlockVault(target, passphrase)
+
+      // Fetched by fileId, not path: that makes the webdav decorator hand back raw
+      // ciphertext regardless of whether the vault happens to be unlocked already.
+      expect(webdav.getFileContents).toHaveBeenCalledWith(
+        space,
+        { fileId: 'id-smallest-sealed' },
+        { responseType: 'arraybuffer', headers: { Range: 'bytes=0-65583' } }
+      )
+    })
+
+    it('only downloads the header and the first sealed block', async () => {
+      // A vault whose smallest file is huge must not pull the whole thing into
+      // memory - one block authenticates just as well as a thousand.
+      const { target, webdav } = await createTarget({
+        children: [{ name: encryptedChildName, size: 8 * 1024 * 1024 * 1024 }]
+      })
+
+      await unlockVault(target, passphrase)
+
+      // 32-byte file header + one 64 KiB block + its 16-byte Poly1305 tag.
+      expect(webdav.getFileContents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ headers: { Range: `bytes=0-${32 + 16 + 64 * 1024 - 1}` } })
+      )
+    })
+
+    it('lists the children by fileId', async () => {
+      // The webdav decorator keys its name decryption off the path, so a listing
+      // by path comes back with cleartext names once this session has the vault
+      // unlocked - and the encrypted name is what the checks here need. A fileId
+      // listing carries no vault path for the decorator to claim.
+      const { target, webdav, space } = await createTarget({
+        children: [{ name: encryptedChildName }]
+      })
+
+      await unlockVault(target, passphrase)
+
+      expect(webdav.listFiles).toHaveBeenCalledWith(space, { fileId: 'id-root' })
+    })
+
+    it('throws on a fetch failure rather than blaming the passphrase', async () => {
+      const { target, webdav } = await createTarget({ children: [{ name: encryptedChildName }] })
+      webdav.getFileContents.mockRejectedValue(new Error('network'))
+
+      await expect(unlockVault(target, passphrase)).rejects.toThrow('network')
+      expect(webdav.setProperties).not.toHaveBeenCalled()
+    })
+
+    it('still unlocks when the backfill is rejected', async () => {
+      // A viewer on a shared vault or a public-link visitor cannot write
+      // properties. The passphrase is verified by then, so keep them in.
+      const { target, webdav } = await createTarget({ children: [{ name: encryptedChildName }] })
+      webdav.setProperties.mockRejectedValue(new Error('403'))
+
+      const result = await unlockVault(target, passphrase)
+
+      expect(result.status).toBe('unlocked')
+    })
+  })
+
+  describe('a brand new vault', () => {
+    it('commits the passphrase by writing a token, then unlocks', async () => {
+      const { target, webdav } = await createTarget()
+
+      const result = await unlockVault(target, passphrase)
+
+      expect(result.status).toBe('unlocked')
+      const engine = createEngine(vaultRoot, passphrase)
+      expect(await engine.verifyIntegrityToken(writtenToken(webdav))).toBe(true)
+    })
+
+    it('throws when the token cannot be written', async () => {
+      // Unlocking without a stored token would leave the passphrase uncommitted,
+      // which is the very confusion this is meant to end.
+      const { target, webdav } = await createTarget()
+      webdav.setProperties.mockRejectedValue(new Error('403'))
+
+      await expect(unlockVault(target, passphrase)).rejects.toThrow('403')
+    })
+  })
+})
+
+describe('probeVaultNeedsSetup', () => {
+  it('asks to unlock rather than to set up when a token exists, even for an empty vault', async () => {
+    // The regression this token exists for: an empty vault used to re-offer
+    // "Set Up Encrypted Vault" and silently accept a different passphrase.
+    const { target, webdav } = await createTarget({
+      token: await tokenFor(passphrase),
+      children: []
+    })
+
+    expect(await probeVaultNeedsSetup(target)).toBe(false)
+    expect(webdav.listFiles).not.toHaveBeenCalled()
+  })
+
+  it('asks to unlock for a vault holding content but no token', async () => {
+    const { target } = await createTarget({ children: [{ name: encryptedChildName }] })
+
+    expect(await probeVaultNeedsSetup(target)).toBe(false)
+  })
+
+  it('asks to set up for an empty vault without a token', async () => {
+    const { target } = await createTarget()
+
+    expect(await probeVaultNeedsSetup(target)).toBe(true)
+  })
+})

--- a/packages/web-app-rclone-crypt/tests/unit/views/UnlockVault.spec.ts
+++ b/packages/web-app-rclone-crypt/tests/unit/views/UnlockVault.spec.ts
@@ -1,0 +1,228 @@
+import { flushPromises } from '@vue/test-utils'
+import { mock } from 'vitest-mock-extended'
+import { FolderVaultEngine, useFolderVaultStore } from '@opencloud-eu/web-pkg'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from '@opencloud-eu/web-test-helpers'
+import UnlockVault from '../../../src/views/UnlockVault.vue'
+import { probeVaultNeedsSetup, unlockVault } from '../../../src/unlock'
+
+vi.mock('../../../src/unlock', () => ({
+  probeVaultNeedsSetup: vi.fn(),
+  unlockVault: vi.fn()
+}))
+
+const spaceId = 'space-1'
+const vaultRoot = '/my.vault'
+const passphrase = 'foobar'
+
+type Space = { id: string; driveType?: string; driveAlias?: string; name?: string }
+
+function mountUnlockVault({
+  needsSetup = false,
+  spaces = [{ id: spaceId, driveType: 'personal', driveAlias: 'personal/admin', name: 'Admin' }],
+  query = { spaceId, vaultRoot }
+}: { needsSetup?: boolean; spaces?: Space[]; query?: Record<string, string> } = {}) {
+  vi.mocked(probeVaultNeedsSetup).mockResolvedValue(needsSetup)
+  vi.mocked(unlockVault).mockResolvedValue({
+    status: 'unlocked',
+    engine: mock<FolderVaultEngine>()
+  })
+
+  const mocks = defaultComponentMocks({
+    currentRoute: { query, path: '/', meta: {} } as never
+  })
+
+  const wrapper = shallowMount(UnlockVault, {
+    global: {
+      plugins: [
+        ...defaultPlugins({
+          piniaOptions: { spacesState: { spaces: spaces as never } }
+        })
+      ],
+      mocks,
+      provide: mocks
+    }
+  })
+
+  return { wrapper, mocks, vaultStore: useFolderVaultStore() }
+}
+
+type Wrapper = ReturnType<typeof mountUnlockVault>
+
+/** Mount and let the onMounted probe settle so `needsSetup` reflects the server. */
+async function mountProbed(options?: Parameters<typeof mountUnlockVault>[0]) {
+  const result = mountUnlockVault(options)
+  await flushPromises()
+  return result
+}
+
+async function submit(wrapper: Wrapper['wrapper'], password = passphrase) {
+  const vm = wrapper.vm as any
+  vm.password = password
+  vm.confirmPassword = password
+  await vm.onSubmit()
+}
+
+describe('UnlockVault', () => {
+  describe('wording', () => {
+    it('asks to set up a vault that has no passphrase committed yet', async () => {
+      const { wrapper } = await mountProbed({ needsSetup: true })
+      const vm = wrapper.vm as any
+
+      expect(vm.needsSetup).toBe(true)
+      expect(vm.cardTitle).toBe('Set Up Encrypted Vault')
+      expect(vm.passphraseLabel).toBe('Choose a passphrase')
+      expect(vm.submitLabel).toBe('Set passphrase')
+    })
+
+    it('asks to unlock a vault whose passphrase is already committed', async () => {
+      const { wrapper } = await mountProbed()
+      const vm = wrapper.vm as any
+
+      expect(vm.needsSetup).toBe(false)
+      expect(vm.cardTitle).toBe('Unlock vault')
+      expect(vm.passphraseLabel).toBe('Vault passphrase')
+      expect(vm.submitLabel).toBe('Unlock')
+    })
+
+    it('falls back to unlock wording when the vault cannot be probed', async () => {
+      vi.mocked(probeVaultNeedsSetup).mockRejectedValue(new Error('network'))
+      const { wrapper } = await mountProbed()
+
+      expect((wrapper.vm as any).needsSetup).toBe(false)
+    })
+
+    it('does not probe a vault it cannot address', async () => {
+      const { wrapper } = await mountProbed({ spaces: [] })
+
+      expect(probeVaultNeedsSetup).not.toHaveBeenCalled()
+      expect(wrapper.find('no-content-message-stub').exists()).toBe(true)
+    })
+
+    it('shows the cleartext folder name rather than the whole path', async () => {
+      const { wrapper } = await mountProbed({
+        query: { spaceId, vaultRoot: '/some/where/my.vault' }
+      })
+
+      expect((wrapper.vm as any).vaultName).toBe('my.vault')
+    })
+  })
+
+  describe('submitting', () => {
+    it('stashes the engine for the session and leaves the unlock page', async () => {
+      const { wrapper, mocks, vaultStore } = await mountProbed()
+      await submit(wrapper)
+
+      expect((wrapper.vm as any).errorMessage).toBeNull()
+      expect(vaultStore.setEngine).toHaveBeenCalledWith(spaceId, vaultRoot, expect.anything())
+      expect(mocks.$router.push).toHaveBeenCalledWith(`/files/spaces${vaultRoot}`)
+    })
+
+    it('returns to where the user was sent from', async () => {
+      const redirectUrl = '/files/spaces/personal/admin/my.vault/sub'
+      const { wrapper, mocks } = await mountProbed({ query: { spaceId, vaultRoot, redirectUrl } })
+      await submit(wrapper)
+
+      expect(mocks.$router.push).toHaveBeenCalledWith(redirectUrl)
+    })
+
+    it('blames the passphrase only when it is cryptographically ruled out', async () => {
+      const { wrapper, mocks, vaultStore } = await mountProbed()
+      vi.mocked(unlockVault).mockResolvedValue({ status: 'wrong-passphrase' })
+      await submit(wrapper)
+
+      expect((wrapper.vm as any).errorMessage).toBe('Incorrect passphrase.')
+      expect(vaultStore.setEngine).not.toHaveBeenCalled()
+      expect(mocks.$router.push).not.toHaveBeenCalled()
+    })
+
+    it('offers a retry when unlocking fails for any other reason', async () => {
+      const { wrapper, mocks, vaultStore } = await mountProbed()
+      vi.mocked(unlockVault).mockRejectedValue(new Error('network'))
+      await submit(wrapper)
+
+      expect((wrapper.vm as any).errorMessage).toBe('Unlocking failed. Please try again')
+      expect(vaultStore.setEngine).not.toHaveBeenCalled()
+      expect(mocks.$router.push).not.toHaveBeenCalled()
+    })
+
+    it('never commits a passphrase the user only typed once', async () => {
+      // The disabled button covers this in the UI; the guard covers a programmatic
+      // submit slipping past it. Committing a typo would lock the vault for good.
+      const { wrapper } = await mountProbed({ needsSetup: true })
+      const vm = wrapper.vm as any
+      vm.password = passphrase
+      vm.confirmPassword = 'something-else'
+      await vm.onSubmit()
+
+      expect(vm.errorMessage).toBe('Passphrases do not match.')
+      expect(unlockVault).not.toHaveBeenCalled()
+    })
+
+    it('keeps the submit button disabled until both fields match', async () => {
+      const { wrapper } = await mountProbed({ needsSetup: true })
+      const vm = wrapper.vm as any
+
+      expect(vm.submitDisabled).toBe(true)
+
+      vm.password = passphrase
+      await flushPromises()
+      expect(vm.submitDisabled).toBe(true)
+      expect(vm.confirmErrorMessage).toBeNull()
+
+      vm.confirmPassword = 'typo'
+      await flushPromises()
+      expect(vm.confirmErrorMessage).toBe('Passphrases do not match')
+
+      vm.confirmPassword = passphrase
+      await flushPromises()
+      expect(vm.submitDisabled).toBe(false)
+    })
+  })
+
+  describe('cancelling', () => {
+    it('lands the user in the folder above the vault', async () => {
+      // Not inside the vault itself - clicking it would just kick them back here.
+      const { wrapper, mocks } = await mountProbed({
+        query: { spaceId, vaultRoot: '/some/where/my.vault' }
+      })
+      await (wrapper.vm as any).onCancel()
+
+      expect(mocks.$router.push).toHaveBeenCalledWith({
+        path: '/files/spaces/personal/admin/some/where'
+      })
+    })
+
+    it('keeps the share id when leaving a shared vault', async () => {
+      const { wrapper, mocks } = await mountProbed({
+        spaces: [{ id: spaceId, driveType: 'share', driveAlias: 'shares/my.vault' }],
+        query: { spaceId, vaultRoot: '/sub/my.vault' }
+      })
+      await (wrapper.vm as any).onCancel()
+
+      expect(mocks.$router.push).toHaveBeenCalledWith({
+        path: '/files/spaces/shares/my.vault/sub',
+        query: { shareId: spaceId }
+      })
+    })
+
+    it('falls back to the shares overview for a directly shared vault', async () => {
+      // A share space whose root *is* the vault has no parent folder to return to.
+      const { wrapper, mocks } = await mountProbed({
+        spaces: [{ id: spaceId, driveType: 'share', driveAlias: 'shares/my.vault' }],
+        query: { spaceId, vaultRoot: '/' }
+      })
+      await (wrapper.vm as any).onCancel()
+
+      expect(mocks.$router.push).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'files-shares-with-me' })
+      )
+    })
+
+    it('falls back to the personal space when the space is unknown', async () => {
+      const { wrapper, mocks } = await mountProbed({ spaces: [] })
+      await (wrapper.vm as any).onCancel()
+
+      expect(mocks.$router.push).toHaveBeenCalledWith('/files/spaces/personal')
+    })
+  })
+})

--- a/packages/web-client/src/webdav/client/builders.ts
+++ b/packages/web-client/src/webdav/client/builders.ts
@@ -1,10 +1,35 @@
 import { XMLBuilder } from 'fast-xml-parser'
-import { DavProperties, DavPropertyValue } from '../constants'
+import { DavNamespaces, DavProperties, DavPropertyValue } from '../constants'
 
-const getNamespacedDavProps = (
-  obj: Partial<Record<DavPropertyValue, unknown>>,
-  extraProps: string[]
-) => {
+export type DavPropertyRecord = Partial<Record<DavPropertyValue, unknown>> & Record<string, unknown>
+
+/**
+ * The `xmlns:*` attributes for a request body: the two well-known namespaces,
+ * plus one for every prefix appearing in `extraProps`.
+ *
+ * An app's own prefix is declared as its own namespace, so `myapp:my-prop`
+ * is stored and looked up under `myapp/my-prop`. That keeps prefixes
+ * self-describing and lets any app introduce one without touching this package -
+ * at the price of the namespace not being a URI, which nothing here needs.
+ *
+ * `d` and `oc` always keep their real URIs; an extra prop using either prefix
+ * cannot override them.
+ */
+const buildNamespaceDeclarations = (extraProps: string[]) => {
+  const declarations: Record<string, string> = Object.fromEntries(
+    Object.entries(DavNamespaces).map(([prefix, uri]) => [`@@xmlns:${prefix}`, uri])
+  )
+  for (const name of extraProps) {
+    const [prefix] = name.split(':')
+    // Unprefixed extra props need no declaration - they land in the default namespace.
+    if (prefix && prefix !== name && !(`@@xmlns:${prefix}` in declarations)) {
+      declarations[`@@xmlns:${prefix}`] = prefix
+    }
+  }
+  return declarations
+}
+
+const getNamespacedDavProps = (obj: DavPropertyRecord, extraProps: string[]) => {
   return Object.fromEntries(
     Object.entries(obj).map(([name, value]) => {
       if (extraProps.includes(name)) {
@@ -27,7 +52,7 @@ export const buildPropFindBody = (
     extraProps = []
   }: {
     pattern?: string
-    filterRules?: Partial<Record<DavPropertyValue, unknown>>
+    filterRules?: DavPropertyRecord
     limit?: number
     extraProps: string[]
   }
@@ -56,8 +81,7 @@ export const buildPropFindBody = (
   const xmlObj = {
     [bodyType]: {
       'd:prop': props,
-      '@@xmlns:d': 'DAV:',
-      '@@xmlns:oc': 'http://owncloud.org/ns',
+      ...buildNamespaceDeclarations(extraProps),
       ...(pattern && {
         'oc:search': { 'oc:pattern': pattern, 'oc:limit': limit }
       }),
@@ -78,13 +102,13 @@ export const buildPropFindBody = (
 }
 
 export const buildPropPatchBody = (
-  properties: Partial<Record<DavPropertyValue, unknown>>
+  properties: DavPropertyRecord,
+  extraProps: string[] = []
 ): string => {
   const xmlObj = {
     'd:propertyupdate': {
-      'd:set': { 'd:prop': getNamespacedDavProps(properties, []) },
-      '@@xmlns:d': 'DAV:',
-      '@@xmlns:oc': 'http://owncloud.org/ns'
+      'd:set': { 'd:prop': getNamespacedDavProps(properties, extraProps) },
+      ...buildNamespaceDeclarations(extraProps)
     }
   }
 

--- a/packages/web-client/src/webdav/client/dav.ts
+++ b/packages/web-client/src/webdav/client/dav.ts
@@ -9,7 +9,7 @@ import {
 import { v4 as uuidV4 } from 'uuid'
 import { encodePath, urlJoin } from '../../utils'
 import { DavMethod, DavPropertyValue } from '../constants'
-import { buildPropFindBody, buildPropPatchBody } from './builders'
+import { buildPropFindBody, buildPropPatchBody, DavPropertyRecord } from './builders'
 import { parseError, parseMultiStatus, parseTusHeaders } from './parsers'
 import { WebDavResponseResource } from '../../helpers'
 import { DavHttpError } from '../../errors'
@@ -52,14 +52,20 @@ export class DAV {
     {
       depth = 1,
       properties = [],
+      extraProps = [],
       headers = {},
       ...opts
-    }: { depth?: number; properties?: DavPropertyValue[] } & DAVRequestOptions = {}
+    }: {
+      depth?: number
+      properties?: DavPropertyValue[]
+      /** Namespaced props for this request only, on top of the globally registered ones. */
+      extraProps?: string[]
+    } & DAVRequestOptions = {}
   ) {
     const requestHeaders = { ...headers, Depth: depth.toString() }
     const { body, result } = await this.request(path, {
       method: DavMethod.propfind,
-      data: buildPropFindBody(properties, { extraProps: this.extraProps }),
+      data: buildPropFindBody(properties, { extraProps: [...this.extraProps, ...extraProps] }),
       headers: requestHeaders,
       ...opts
     })
@@ -169,10 +175,19 @@ export class DAV {
 
   public propPatch(
     path: string,
-    properties: Partial<Record<DavPropertyValue, unknown>>,
-    opts: DAVRequestOptions = {}
+    properties: DavPropertyRecord,
+    {
+      extraProps = [],
+      ...opts
+    }: {
+      /** Namespaced props for this request only, on top of the globally registered ones. */
+      extraProps?: string[]
+    } & DAVRequestOptions = {}
   ) {
-    const body = buildPropPatchBody(properties)
+    // Extra props keep their own namespace prefix instead of being forced into
+    // `oc:`, same as in PROPFIND. A name that isn't listed here would be written
+    // as `oc:<name>`, which the server stores but no PROPFIND can read back.
+    const body = buildPropPatchBody(properties, [...this.extraProps, ...extraProps])
     return this.request(path, { method: DavMethod.proppatch, data: body, ...opts })
   }
 

--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -123,6 +123,19 @@ export type DavFileInfoResponse = {
 
 export type DavPropertyValue = (typeof DavProperty)[keyof typeof DavProperty]
 
+/**
+ * The two well-known namespaces, declared on every PROPFIND / PROPPATCH body and
+ * keyed by the prefix used in property names.
+ *
+ * Deliberately just these two. Prefixes belonging to an app's own props are
+ * declared automatically from the names it passes as extra props, so apps can
+ * bring their own namespace without anything being registered here.
+ */
+export const DavNamespaces = {
+  d: 'DAV:',
+  oc: 'http://owncloud.org/ns'
+} as const
+
 export abstract class DavProperties {
   static readonly Default: DavPropertyValue[] = [
     DavProperty.Permissions,

--- a/packages/web-client/src/webdav/index.ts
+++ b/packages/web-client/src/webdav/index.ts
@@ -19,6 +19,7 @@ import { GetPathForFileIdFactory } from './getPathForFileId'
 import { DAV } from './client/dav'
 import { ListFileVersionsFactory } from './listFileVersions'
 import { SetFavoriteFactory } from './setFavorite'
+import { SetPropertiesFactory } from './setProperties'
 
 export * from './constants'
 export * from './types'
@@ -78,6 +79,7 @@ export const webdav = (baseURI: string, headers?: () => Headers): WebDAV => {
   const { search } = SearchFactory(dav, options)
 
   const { setFavorite } = SetFavoriteFactory(dav, options)
+  const { setProperties } = SetPropertiesFactory(dav, options)
 
   return {
     copyFiles,
@@ -98,6 +100,7 @@ export const webdav = (baseURI: string, headers?: () => Headers): WebDAV => {
     clearTrashBin,
     search,
     setFavorite,
+    setProperties,
 
     registerExtraProp
   }

--- a/packages/web-client/src/webdav/listFiles.ts
+++ b/packages/web-client/src/webdav/listFiles.ts
@@ -20,6 +20,15 @@ import { getWebDavPath } from './utils'
 export type ListFilesOptions = {
   depth?: number
   davProperties?: DavPropertyValue[]
+  /**
+   * Namespaced props to request for this call only, e.g. `myapp:my-prop`, on top
+   * of anything registered globally via `registerExtraProp`. Names keep their own
+   * prefix instead of being forced into `oc:`, the prefix is declared for you, and
+   * the value lands on `Resource.extraProps` under the name you passed. Use this
+   * for props only one caller cares about, so every other PROPFIND in the app
+   * doesn't pay for them.
+   */
+  extraProps?: string[]
   isTrash?: boolean
 } & DAVRequestOptions
 
@@ -32,13 +41,17 @@ export const ListFilesFactory = (
     async listFiles(
       space: SpaceResource,
       { path, fileId }: { path?: string; fileId?: string } = {},
-      { depth = 1, davProperties, isTrash = false, ...opts }: ListFilesOptions = {}
+      { depth = 1, davProperties, extraProps = [], isTrash = false, ...opts }: ListFilesOptions = {}
     ): Promise<ListFilesResult> {
+      // Globally registered props plus this call's own, for both the request body
+      // and the resources built from the response.
+      const extraPropNames = [...dav.extraProps, ...extraProps]
       let webDavResources: WebDavResponseResource[]
       if (isPublicSpaceResource(space)) {
         webDavResources = await dav.propfind(urlJoin(space.webDavPath, path), {
           depth,
           properties: davProperties || DavProperties.PublicLink,
+          extraProps,
           ...opts
         })
 
@@ -93,16 +106,16 @@ export const ListFilesFactory = (
               webDavPath: space.webDavPath,
               publicLinkType: publicLinkType
             }),
-            children: children.map((c) => buildResource(c, dav.extraProps))
+            children: children.map((c) => buildResource(c, extraPropNames))
           } as ListFilesResult
         }
-        const resources = webDavResources.map((r) => buildResource(r, dav.extraProps))
+        const resources = webDavResources.map((r) => buildResource(r, extraPropNames))
         return { resource: resources[0], children: resources.slice(1) } as ListFilesResult
       }
 
       const listFilesCorrectedPath = async () => {
         const correctPath = await pathForFileIdFactory.getPathForFileId(fileId)
-        return this.listFiles(space, { path: correctPath }, { depth, davProperties })
+        return this.listFiles(space, { path: correctPath }, { depth, davProperties, extraProps })
       }
 
       try {
@@ -116,16 +129,17 @@ export const ListFilesFactory = (
         webDavResources = await dav.propfind(webDavPath, {
           depth,
           properties: davProperties || DavProperties.Default,
+          extraProps,
           ...opts
         })
         if (isTrash) {
           return {
-            resource: buildResource(webDavResources[0], dav.extraProps),
+            resource: buildResource(webDavResources[0], extraPropNames),
             children: webDavResources.slice(1).map(buildDeletedResource)
           } as ListFilesResult
         }
 
-        const resources = webDavResources.map((r) => buildResource(r, dav.extraProps))
+        const resources = webDavResources.map((r) => buildResource(r, extraPropNames))
 
         const resourceIsSpace = fileId === space.id
         if (fileId && !resourceIsSpace && resources[0].fileId && fileId !== resources[0].fileId) {

--- a/packages/web-client/src/webdav/setProperties.ts
+++ b/packages/web-client/src/webdav/setProperties.ts
@@ -1,0 +1,26 @@
+import { urlJoin } from '../utils'
+import { SpaceResource } from '../helpers'
+import { WebDavOptions } from './types'
+import { DAV, DAVRequestOptions, DavPropertyRecord } from './client'
+
+export const SetPropertiesFactory = (dav: DAV, options: WebDavOptions) => {
+  return {
+    /**
+     * Write WebDAV properties onto a resource via PROPPATCH.
+     *
+     * Property names are namespaced the same way as in PROPFIND: DAV standard
+     * props get `d:`, anything listed in `extraProps` (or registered globally via
+     * `registerExtraProp`) keeps its own prefix, everything else falls back to
+     * `oc:`. A custom prop must be listed, otherwise it is written as
+     * `oc:<name>` - which the server accepts but no PROPFIND can read back.
+     */
+    setProperties(
+      space: SpaceResource,
+      { path }: { path: string },
+      properties: DavPropertyRecord,
+      opts: { extraProps?: string[] } & DAVRequestOptions = {}
+    ) {
+      return dav.propPatch(urlJoin(space.webDavPath, path), properties, opts)
+    }
+  }
+}

--- a/packages/web-client/src/webdav/types.ts
+++ b/packages/web-client/src/webdav/types.ts
@@ -15,6 +15,7 @@ import { ClearTrashBinFactory } from './clearTrashBin'
 import { SearchFactory } from './search'
 import { GetPathForFileIdFactory } from './getPathForFileId'
 import { SetFavoriteFactory } from './setFavorite'
+import { SetPropertiesFactory } from './setProperties'
 
 import { AxiosInstance } from 'axios'
 import { Headers } from 'webdav'
@@ -44,6 +45,7 @@ export interface WebDAV {
   clearTrashBin: ReturnType<typeof ClearTrashBinFactory>['clearTrashBin']
   search: ReturnType<typeof SearchFactory>['search']
   setFavorite: ReturnType<typeof SetFavoriteFactory>['setFavorite']
+  setProperties: ReturnType<typeof SetPropertiesFactory>['setProperties']
 
   // register prop that will be added to resource.extraProps if available in a response
   // because of a limitation in our WebDAV library, we cannot differentiate between

--- a/packages/web-client/tests/unit/webdav/client/builders.spec.ts
+++ b/packages/web-client/tests/unit/webdav/client/builders.spec.ts
@@ -1,0 +1,76 @@
+import { buildPropFindBody, buildPropPatchBody } from '../../../../src/webdav/client/builders'
+import { DavNamespaces, DavProperty } from '../../../../src/webdav/constants'
+
+describe('buildPropFindBody', () => {
+  it('declares the well-known namespaces', () => {
+    const body = buildPropFindBody([DavProperty.FileId], { extraProps: [] })
+
+    for (const [prefix, uri] of Object.entries(DavNamespaces)) {
+      expect(body).toContain(`xmlns:${prefix}="${uri}"`)
+    }
+  })
+
+  it('prefixes DAV standard props with d: and everything else with oc:', () => {
+    const body = buildPropFindBody([DavProperty.ETag, DavProperty.FileId], { extraProps: [] })
+
+    expect(body).toContain('<d:getetag/>')
+    expect(body).toContain('<oc:fileid/>')
+  })
+
+  it('declares an unknown prefix from the extra props it is given', () => {
+    // No app namespace is registered in this package - passing the name is enough.
+    const body = buildPropFindBody([DavProperty.FileId], { extraProps: ['myapp:my-prop'] })
+
+    expect(body).toContain('xmlns:myapp="myapp"')
+    expect(body).toContain('<myapp:my-prop/>')
+    expect(body).not.toContain('oc:myapp')
+  })
+
+  it('declares each distinct prefix once', () => {
+    const body = buildPropFindBody([], { extraProps: ['one:a', 'one:b', 'two:c'] })
+
+    expect(body.match(/xmlns:one=/g)).toHaveLength(1)
+    expect(body).toContain('xmlns:two="two"')
+  })
+
+  it('never lets an extra prop override a well-known namespace', () => {
+    const body = buildPropFindBody([], { extraProps: ['oc:something', 'd:other'] })
+
+    expect(body).toContain(`xmlns:oc="${DavNamespaces.oc}"`)
+    expect(body).toContain(`xmlns:d="${DavNamespaces.d}"`)
+    expect(body).not.toContain('xmlns:oc="oc"')
+    expect(body).not.toContain('xmlns:d="d"')
+  })
+
+  it('leaves an unprefixed extra prop undeclared', () => {
+    const body = buildPropFindBody([], { extraProps: ['bare-prop'] })
+
+    expect(body).toContain('<bare-prop/>')
+    expect(body).not.toContain('xmlns:bare-prop')
+  })
+})
+
+describe('buildPropPatchBody', () => {
+  it('falls back to the oc namespace for unregistered props', () => {
+    const body = buildPropPatchBody({ [DavProperty.IsFavorite]: 'true' })
+
+    expect(body).toContain(`xmlns:oc="${DavNamespaces.oc}"`)
+    expect(body).toContain('<oc:favorite>true</oc:favorite>')
+  })
+
+  it('writes an extra prop under its own declared prefix', () => {
+    // The write side has to namespace names exactly like the read side, or the
+    // value ends up under a key no PROPFIND can address.
+    const body = buildPropPatchBody({ 'myapp:my-prop': 'dG9rZW4=' }, ['myapp:my-prop'])
+
+    expect(body).toContain('xmlns:myapp="myapp"')
+    expect(body).toContain('<myapp:my-prop>dG9rZW4=</myapp:my-prop>')
+    expect(body).not.toContain('oc:myapp')
+  })
+
+  it('forces the oc namespace on a custom prop that was never listed', () => {
+    const body = buildPropPatchBody({ 'my-prop': 'dG9rZW4=' })
+
+    expect(body).toContain('<oc:my-prop>dG9rZW4=</oc:my-prop>')
+  })
+})

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
@@ -139,13 +139,36 @@ export interface FolderVaultEngine {
    */
   encryptContent: (plaintext: ReadableStream<Uint8Array>) => ReadableStream<Uint8Array>
   /**
-   * Try to decrypt a sample encrypted segment to verify the key actually
-   * matches the data on the server. Returns true if the decryption looks
-   * like cleartext, false if it errored out or produced garbage.
-   * Empty vaults can't be verified - callers should treat that case as
-   * "trust the key" since there's nothing to disagree with yet.
+   * Mint an integrity token that commits the vault to this engine's key. The
+   * token is opaque to callers - its format is the engine's business - but it
+   * must be a string, since it gets stored as a WebDAV property on the vault
+   * root and read back through `verifyIntegrityToken`.
+   *
+   * Callers write it exactly once, when a vault's passphrase is first set. Its
+   * presence on the server is what makes the passphrase permanent.
    */
-  verifyKey: (sampleEncryptedSegment: string) => Promise<boolean>
+  createIntegrityToken: () => Promise<string>
+  /**
+   * Verify a passphrase against a token from `createIntegrityToken`. This is
+   * the authoritative check: implementations should authenticate the token
+   * cryptographically rather than guessing from the shape of the plaintext.
+   */
+  verifyIntegrityToken: (token: string) => Promise<boolean>
+  /**
+   * Fallback for vaults that carry no integrity token, either because they were
+   * created outside OpenCloud Web (e.g. an rclone-managed vault).
+   * Tries to decrypt a sample encrypted segment and returns true if the result
+   * looks like cleartext, false if it errored out or produced garbage.
+   *
+   * Substantially weaker than `verifyIntegrityToken`: there is no authentication
+   * tag, only a plausibility check on the decrypted bytes, and the segment's
+   * plaintext is an arbitrary name the engine can't predict. A wrong passphrase
+   * passes this check a low but non-negligible fraction of the time. Prefer the
+   * token whenever one is available, and backfill one once this check has passed.
+   *
+   * Empty vaults can't be verified this way because there is no sample to decrypt.
+   */
+  verifySegment: (sampleEncryptedSegment: string) => Promise<boolean>
 }
 
 export interface FolderVaultClaim {

--- a/packages/web-pkg/src/services/client/vaultWebDav.ts
+++ b/packages/web-pkg/src/services/client/vaultWebDav.ts
@@ -29,9 +29,9 @@ import { streamToArrayBuffer } from '../../helpers/streams'
  *
  * Scope: every webdav method that carries a path or content - listFiles,
  * getFileInfo, createFolder, deleteFile, moveFiles, copyFiles,
- * restoreFileVersion, and the content methods getFileContents / putFileContents
- * (which add a body transform, decryptContent / encryptContent, on top of the
- * path one).
+ * restoreFileVersion, setProperties, and the content methods getFileContents /
+ * putFileContents (which add a body transform, decryptContent / encryptContent,
+ * on top of the path one).
  *
  * What the decorator genuinely cannot reach is anything that doesn't ride the
  * webdav client at all: signed-URL downloads (getFileUrl returns a URL, not
@@ -201,6 +201,15 @@ export function createVaultWebDav(inner: WebDAV): WebDAV {
         space,
         { ...resource, path: await toServerPathForWrite(space, resource?.path) },
         versionId,
+        opts
+      )
+    },
+
+    async setProperties(space, resource, properties, opts) {
+      return inner.setProperties(
+        space,
+        { ...resource, path: await toServerPathForWrite(space, resource?.path) },
+        properties,
         opts
       )
     },

--- a/packages/web-pkg/tests/unit/helpers/vaultEngine.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/vaultEngine.spec.ts
@@ -10,7 +10,9 @@ function fakeEngine(vaultRoot: string): FolderVaultEngine {
     decryptPath: (relative) => Promise.resolve(`D(${relative})`),
     encryptContent: (s) => s,
     decryptContent: (s) => s,
-    verifyKey: () => Promise.resolve(true)
+    verifySegment: () => Promise.resolve(true),
+    createIntegrityToken: () => Promise.resolve('token'),
+    verifyIntegrityToken: () => Promise.resolve(true)
   }
 }
 

--- a/packages/web-pkg/tests/unit/services/client/vaultWebDav.spec.ts
+++ b/packages/web-pkg/tests/unit/services/client/vaultWebDav.spec.ts
@@ -53,6 +53,7 @@ function makeInner(overrides: Partial<WebDAV> = {}): WebDAV {
     moveFiles: vi.fn().mockResolvedValue(undefined),
     copyFiles: vi.fn().mockResolvedValue(undefined),
     restoreFileVersion: vi.fn().mockResolvedValue(undefined),
+    setProperties: vi.fn().mockResolvedValue(undefined),
     getFileContents: vi.fn(),
     search: vi.fn(),
     registerExtraProp: vi.fn(),
@@ -184,6 +185,21 @@ describe('createVaultWebDav', () => {
       )
     })
 
+    it('encrypts the path when setting a property on vault content', async () => {
+      vi.mocked(resolveFolderVault).mockResolvedValue(fakeEngine('/my.vault') as any)
+      const inner = makeInner()
+      const dav = createVaultWebDav(inner)
+
+      await dav.setProperties(space, { path: '/my.vault/f.txt' }, { 'x:p': '1' })
+
+      expect(inner.setProperties).toHaveBeenCalledWith(
+        space,
+        { path: '/my.vault/ENC(f.txt)' },
+        { 'x:p': '1' },
+        undefined
+      )
+    })
+
     it('resolves each vault engine once for a listing spanning multiple vaults', async () => {
       vi.mocked(resolveFolderVault).mockImplementation((_r, _s, path) =>
         Promise.resolve(fakeEngine(path as string) as any)
@@ -246,6 +262,23 @@ describe('createVaultWebDav', () => {
       expect(inner.createFolder).toHaveBeenCalledWith(space, { path: '/my.vault' })
     })
 
+    it('leaves the vault root untranslated for setProperties', async () => {
+      // Where the integrity token goes: the root's name is clear text on the
+      // server, so it must reach the wire exactly as given.
+      vi.mocked(resolveFolderVault).mockResolvedValue(null)
+      const inner = makeInner()
+      const dav = createVaultWebDav(inner)
+
+      await dav.setProperties(space, { path: '/my.vault' }, { 'x:p': '1' }, { extraProps: ['x:p'] })
+
+      expect(inner.setProperties).toHaveBeenCalledWith(
+        space,
+        { path: '/my.vault' },
+        { 'x:p': '1' },
+        { extraProps: ['x:p'] }
+      )
+    })
+
     it('refuses to create a folder in a locked vault (fail closed)', async () => {
       vi.mocked(resolveFolderVault).mockResolvedValue(null)
       const inner = makeInner()
@@ -255,6 +288,18 @@ describe('createVaultWebDav', () => {
         /locked vault/
       )
       expect(inner.createFolder).not.toHaveBeenCalled()
+    })
+
+    it('refuses to set a property on content in a locked vault (fail closed)', async () => {
+      // The vault root is still fine while locked - see the pass-through test.
+      vi.mocked(resolveFolderVault).mockResolvedValue(null)
+      const inner = makeInner()
+      const dav = createVaultWebDav(inner)
+
+      await expect(
+        dav.setProperties(space, { path: '/my.vault/f.txt' }, { 'x:p': '1' })
+      ).rejects.toThrow(/locked vault/)
+      expect(inner.setProperties).not.toHaveBeenCalled()
     })
 
     it('refuses to move a path into/out of a locked vault (fail closed)', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,6 +705,9 @@ importers:
       pinia:
         specifier: 4.0.2
         version: 4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.1
       vue:
         specifier: ^3.5.0
         version: 3.5.40(typescript@6.0.3)
@@ -714,6 +717,10 @@ importers:
       vue3-gettext:
         specifier: ^4.0.0-beta.1
         version: 4.0.1(vue@3.5.40(typescript@6.0.3))
+    devDependencies:
+      '@opencloud-eu/web-test-helpers':
+        specifier: workspace:*
+        version: link:../web-test-helpers
 
   packages/web-app-search:
     dependencies:


### PR DESCRIPTION
Stores a random uuid, encrypted with the vault's content cipher, as the `ocrclone:integrity-id` property on the vault root when a passphrase is first set. This means an empty vault no longer re-offers setup. It also has the added benefits of a) having a cryptographically safe way to validate a passphrase (it wasn't before) and 2) less server load because we don't need to list all files inside a vault.

The old mechanism is kept as fallback however to ensure full compatibility with vaults created outside of Web (e.g. via rclone-crypt cli).

The webdav property lives in its own `ocrclone` namespace rather than the `oc` one because the server answers unknown `oc` local names with `404`. Also, the client has been extend to support extra properties on a per-request basis as well a `setProperties` method for writing arbitrary WebDAV properties via `PROPPATCH`.

closes https://github.com/opencloud-eu/web/issues/3009