### PR TITLE
fix(e2e): wait for login form after logout to avoid teardown hang

### DIFF
--- a/tests/e2e/support/environment/actor/actors.ts
+++ b/tests/e2e/support/environment/actor/actors.ts
@@ -40,7 +40,7 @@ export class ActorsEnvironment extends EventEmitter {
   }
 
   public async close(): Promise<void> {
-    await Promise.all([...actorStore.values()].map((actor) => actor.close()))
+    await Promise.allSettled([...actorStore.values()].map((actor) => actor.close()))
   }
 
   public generateNamespace(user: string): string {

--- a/tests/e2e/support/objects/runtime/session.ts
+++ b/tests/e2e/support/objects/runtime/session.ts
@@ -49,5 +49,9 @@ export class Session {
   async logout(): Promise<void> {
     await this.#page.locator('#_userMenuButton').click()
     await this.#page.locator('#oc-topbar-account-logout').click()
+    const loginForm = this.#page
+      .locator('#oc-login-username')
+      .or(this.#page.locator('#username'))
+    await loginForm.waitFor({ timeout: 5000 }).catch(() => {})
   }
 }

--- a/tests/e2e/support/objects/runtime/session.ts
+++ b/tests/e2e/support/objects/runtime/session.ts
@@ -49,9 +49,7 @@ export class Session {
   async logout(): Promise<void> {
     await this.#page.locator('#_userMenuButton').click()
     await this.#page.locator('#oc-topbar-account-logout').click()
-    const loginForm = this.#page
-      .locator('#oc-login-username')
-      .or(this.#page.locator('#username'))
+    const loginForm = this.#page.locator('#oc-login-username').or(this.#page.locator('#username'))
     await loginForm.waitFor({ timeout: 5000 }).catch(() => {})
   }
 }


### PR DESCRIPTION


strange fail during the logout, see here -> https://ci.opencloud.rocks/repos/3/pipeline/1109/435

Solution: 
- wait login page after logout
- when it doesn't happens -> 5sec -> close browser context