### PR TITLE
fix(sort): explorer-like ordering for leading-zero prefixes

### DIFF
--- a/packages/web-pkg/src/composables/sort/useSort.ts
+++ b/packages/web-pkg/src/composables/sort/useSort.ts
@@ -158,6 +158,47 @@ export const sortHelper = <T extends SortableItem>(
   )
 }
 
+const pureLeadingZeroPrefixRegex = /^(0+)(?!\d)(.*)$/
+
+function compareNamesWithLeadingZeroPrefix(
+  aName: string,
+  bName: string,
+  collator: Intl.Collator
+): number | null {
+  const aMatch = pureLeadingZeroPrefixRegex.exec(aName)
+  const bMatch = pureLeadingZeroPrefixRegex.exec(bName)
+
+  if (!aMatch || !bMatch) {
+    return null
+  }
+
+  const aPrefixLength = aMatch[1].length
+  const bPrefixLength = bMatch[1].length
+  const aSuffix = aMatch[2]
+  const bSuffix = bMatch[2]
+  const aIsPureZero = aSuffix.length === 0
+  const bIsPureZero = bSuffix.length === 0
+
+  if (aPrefixLength !== bPrefixLength) {
+    return bPrefixLength - aPrefixLength
+  }
+
+  if (aIsPureZero && bIsPureZero) {
+    return collator.compare(aName, bName)
+  }
+
+  if (aIsPureZero !== bIsPureZero) {
+    return aIsPureZero ? -1 : 1
+  }
+
+  const restComparison = collator.compare(aSuffix, bSuffix)
+  if (restComparison !== 0) {
+    return restComparison
+  }
+
+  return collator.compare(aName, bName)
+}
+
 const compare = (
   a: SortableItem,
   b: SortableItem,
@@ -184,13 +225,13 @@ const compare = (
     }
   }
 
-  if (!isNaN(aValue) && !isNaN(bValue)) {
+  if (sortBy !== 'name' && !isNaN(aValue) && !isNaN(bValue)) {
     return (aValue - bValue) * modifier
   }
 
   // For name sorting, extract basename (without extension) for comparison
-  let aCompare = (aValue || '').toString()
-  let bCompare = (bValue || '').toString()
+  const aCompare = (aValue || '').toString()
+  const bCompare = (bValue || '').toString()
 
   if (sortBy === 'name') {
     const getBasename = (name: string) => {
@@ -207,8 +248,8 @@ const compare = (
     const aExt = getExtension(aCompare)
     const bExt = getExtension(bCompare)
 
-    // Compare basename first
-    const baseComparison = collator.compare(aBase, bBase)
+    const baseComparison =
+      compareNamesWithLeadingZeroPrefix(aBase, bBase, collator) ?? collator.compare(aBase, bBase)
     if (baseComparison !== 0) {
       return baseComparison * modifier
     }

--- a/packages/web-pkg/tests/unit/composables/sort/useSort.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/sort/useSort.spec.ts
@@ -64,7 +64,16 @@ describe('useSort', () => {
       { id: '20', name: 'apfel.txt', path: '', webDavPath: '', mdate: '20' },
       { id: '21', name: 'Apfel.txt', path: '', webDavPath: '', mdate: '21' },
       { id: '22', name: 'äpfel.txt', path: '', webDavPath: '', mdate: '22' },
-      { id: '23', name: 'Äpfel.txt', path: '', webDavPath: '', mdate: '23' }
+      { id: '23', name: 'Äpfel.txt', path: '', webDavPath: '', mdate: '23' },
+      { id: '24', name: 'file1', path: '', webDavPath: '', mdate: '24' },
+      { id: '25', name: 'file2', path: '', webDavPath: '', mdate: '25' },
+      { id: '26', name: 'file3', path: '', webDavPath: '', mdate: '26' },
+      { id: '27', name: 'file01', path: '', webDavPath: '', mdate: '27' },
+      { id: '28', name: 'file02', path: '', webDavPath: '', mdate: '28' },
+      { id: '29', name: 'file03', path: '', webDavPath: '', mdate: '29' },
+      { id: '30', name: 'file001', path: '', webDavPath: '', mdate: '30' },
+      { id: '31', name: 'file002', path: '', webDavPath: '', mdate: '31' },
+      { id: '32', name: 'file003', path: '', webDavPath: '', mdate: '32' }
     ]
 
     it('sorts resources by name', () => {
@@ -108,6 +117,15 @@ describe('useSort', () => {
           'Äpfel.txt',
           'b.png',
           'c.png',
+          'file1',
+          'file01',
+          'file001',
+          'file2',
+          'file02',
+          'file002',
+          'file3',
+          'file03',
+          'file003',
           'New file.txt',
           'New file (1).txt',
           'New file (2).txt',
@@ -120,6 +138,15 @@ describe('useSort', () => {
           'New file (2).txt',
           'New file (1).txt',
           'New file.txt',
+          'file3',
+          'file03',
+          'file003',
+          'file2',
+          'file02',
+          'file002',
+          'file1',
+          'file01',
+          'file001',
           'c.png',
           'b.png',
           'äpfel.txt',
@@ -140,6 +167,154 @@ describe('useSort', () => {
           'Dir1',
           'dir.with.dot'
         ])
+      })
+    })
+
+    const zeroPrefixBaseNames = [
+      '0_NODE_GAMMA',
+      '0000_BLOCK_OMEGA',
+      '00_SET_IOTA',
+      '00000_ITEM_OMEGA',
+      '00000_ITEM_ALPHA',
+      '00_SET_GAMMA',
+      '0_NODE_DELTA',
+      '0000_BLOCK_BETA',
+      '00000_ITEM_DUMMY',
+      '00_SET_BETA',
+      '0_NODE_ALPHA',
+      '00_SET_ZETA',
+      '0000_BLOCK_GAMMA',
+      '00_SET_KAPPA',
+      '0000_BLOCK_ALPHA',
+      '00_SET_DELTA',
+      '00_SET_EPSILON',
+      '0_NODE_OMEGA',
+      '00_SET_OMEGA',
+      '0_NODE_BETA',
+      '00000_ITEM_GAMMA',
+      '00_SET_LAMBDA',
+      '00_SET_ALPHA',
+      '00_SET_LAMBDA2',
+      '00000_ITEM_DELTA2026',
+      '000',
+      '00',
+      '0',
+      '0a'
+    ]
+    const zeroPrefixExpectedAsc = [
+      '00000_ITEM_ALPHA',
+      '00000_ITEM_DELTA2026',
+      '00000_ITEM_DUMMY',
+      '00000_ITEM_GAMMA',
+      '00000_ITEM_OMEGA',
+      '0000_BLOCK_ALPHA',
+      '0000_BLOCK_BETA',
+      '0000_BLOCK_GAMMA',
+      '0000_BLOCK_OMEGA',
+      '000',
+      '00',
+      '00_SET_ALPHA',
+      '00_SET_BETA',
+      '00_SET_DELTA',
+      '00_SET_EPSILON',
+      '00_SET_GAMMA',
+      '00_SET_IOTA',
+      '00_SET_KAPPA',
+      '00_SET_LAMBDA',
+      '00_SET_LAMBDA2',
+      '00_SET_OMEGA',
+      '00_SET_ZETA',
+      '0',
+      '0_NODE_ALPHA',
+      '0_NODE_BETA',
+      '0_NODE_DELTA',
+      '0_NODE_GAMMA',
+      '0_NODE_OMEGA',
+      '0a'
+    ]
+    const zeroPrefixExpectedDesc = [
+      '0a',
+      '0_NODE_OMEGA',
+      '0_NODE_GAMMA',
+      '0_NODE_DELTA',
+      '0_NODE_BETA',
+      '0_NODE_ALPHA',
+      '0',
+      '00_SET_ZETA',
+      '00_SET_OMEGA',
+      '00_SET_LAMBDA2',
+      '00_SET_LAMBDA',
+      '00_SET_KAPPA',
+      '00_SET_IOTA',
+      '00_SET_GAMMA',
+      '00_SET_EPSILON',
+      '00_SET_DELTA',
+      '00_SET_BETA',
+      '00_SET_ALPHA',
+      '00',
+      '000',
+      '0000_BLOCK_OMEGA',
+      '0000_BLOCK_GAMMA',
+      '0000_BLOCK_BETA',
+      '0000_BLOCK_ALPHA',
+      '00000_ITEM_OMEGA',
+      '00000_ITEM_GAMMA',
+      '00000_ITEM_DUMMY',
+      '00000_ITEM_DELTA2026',
+      '00000_ITEM_ALPHA'
+    ]
+
+    function withExtension(names: string[], extension: string): string[] {
+      if (!extension) {
+        return names
+      }
+      return names.map((name) => `${name}${extension}`)
+    }
+
+    function buildZeroPrefixItems(names: string[], asFolders: boolean): Resource[] {
+      return names.map((name, index) => ({
+        id: `${index}`,
+        name,
+        path: '',
+        webDavPath: '',
+        mdate: `${index}`,
+        ...(asFolders ? { type: 'folder' } : {})
+      }))
+    }
+
+    ;[
+      { title: 'folders', extension: '', asFolders: true },
+      { title: 'files', extension: '.txt', asFolders: false }
+    ].forEach(({ title, extension, asFolders }) => {
+      it(`sorts ${title} with pure leading zero prefixes like Windows Explorer`, () => {
+        getComposableWrapper(() => {
+          const sortDir = ref(SortDir.Asc)
+          const names = withExtension(zeroPrefixBaseNames, extension)
+
+          const input = {
+            items: ref<Resource[]>(buildZeroPrefixItems(names, asFolders)),
+            fields: [
+              {
+                name: 'name',
+                sortable: true
+              }
+            ],
+            sortBy: ref('name'),
+            sortDir
+          }
+
+          const { items } = useSort<Resource>(input)
+
+          expect(unref(items).map((i) => i.name)).toEqual(
+            withExtension(zeroPrefixExpectedAsc, extension)
+          )
+
+          sortDir.value = SortDir.Desc
+
+          expect(unref(items).map((i) => i.name)).toEqual(
+            withExtension(zeroPrefixExpectedDesc, extension)
+          )
+        })
       })
     })
   })


### PR DESCRIPTION
## Summary

Fixes sorting for files and folders with leading-zero prefixes (e.g., `00000_*`, `0000_*`, `00_*`, `0_*`) to match Windows Explorer behavior.

## Problem

The web client uses natural sorting with `Intl.Collator` and `numeric: true`, which treats different numbers of leading zeros as the same numeric value (0). This breaks intentional ordering schemes where users rely on distinct zero prefixes to organize their files.

**Example:** `00000_Important`, `0000_Archive`, `00_Projects`, `0_Other` were all treated as starting with `0` and sorted only by the text after the prefix.

## Solution

Added special handling in `useSort.ts` for names with leading-zero prefixes:

1. **Detection:** Regex `^(0+)(?!\d)(.*)$` identifies pure zero prefixes
2. **Comparison priority:**
   - Compare by prefix length (more zeros → higher priority)
   - Then compare suffixes using natural sorting
   - Use full name as tie-breaker
3. **Fallback:** Names without zero prefixes use existing natural sorting

## Examples

**With fix (ascending):**
- `00000_ITEM_ALPHA`
- `0000_BLOCK_ALPHA`
- `00_SET_ALPHA`
- `0_NODE_ALPHA`

**Regular names still work naturally:**
- `file1`, `file01`, `file001`, `file2`, `file02`, ...

## What Stays the Same

- Folder/file grouping unchanged
- Non-name sort fields unchanged
- Extension handling unchanged

## Testing

- Extended `useSort.spec.ts` with anonymized zero-prefix datasets
- Verified ascending/descending order for both files and folders
- Existing natural sorting tests still pass

Closes #2993