### PR TITLE
correct resource id in restore file version link

### DIFF
--- a/packages/web-client/src/webdav/restoreFileVersion.ts
+++ b/packages/web-client/src/webdav/restoreFileVersion.ts
@@ -8,7 +8,12 @@ export const RestoreFileVersionFactory = (dav: DAV, options: WebDavOptions) => {
   return {
     restoreFileVersion(
       space: SpaceResource,
-      { id, parentFolderId, name, path }: { id?: string; parentFolderId?: string; name?: string; path?: string },
+      {
+        id,
+        parentFolderId,
+        name,
+        path
+      }: { id?: string; parentFolderId?: string; name?: string; path?: string },
       versionId: string,
       opts: DAVRequestOptions = {}
     ) {

--- a/packages/web-client/src/webdav/restoreFileVersion.ts
+++ b/packages/web-client/src/webdav/restoreFileVersion.ts
@@ -8,12 +8,12 @@ export const RestoreFileVersionFactory = (dav: DAV, options: WebDavOptions) => {
   return {
     restoreFileVersion(
       space: SpaceResource,
-      { parentFolderId, name, path }: { parentFolderId?: string; name?: string; path?: string },
+      { id, parentFolderId, name, path }: { id?: string; parentFolderId?: string; name?: string; path?: string },
       versionId: string,
       opts: DAVRequestOptions = {}
     ) {
       const webDavPath = getWebDavPath(space, { path, fileId: parentFolderId, name })
-      const source = urlJoin('meta', parentFolderId, 'v', versionId, { leadingSlash: true })
+      const source = urlJoin('meta', id, 'v', versionId, { leadingSlash: true })
       const target = urlJoin('files', webDavPath, { leadingSlash: true })
       return dav.copy(source, target, opts)
     }


### PR DESCRIPTION
the restore link was not created correct resulting in 404 response for shared resources, the id was not pointing to the correct resource but to the parrentFolderId instead, for non shared resources it was working because backend was geting the file id from the key itself and ignoring this part.

`/ dav / meta / <id> / v / <version-key>`

for non shared resource the file id is from `version-key` for shared from `ìd`