### PR TITLE
fix: white flash on page relaod when dark theme is applied

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,31 @@
     <link rel="manifest" href="manifest.json" crossorigin="use-credentials" />
     <link rel="icon" href="img/favicon.svg" />
     <link rel="stylesheet" href="./packages/design-system/src/styles/tailwind.css" />
+    <script>
+      // Apply background color early to prevent a white flash on dark theme before theme loading finishes.
+      function applyInitialThemeBackground() {
+        var themeIsDarkStorageKey = 'oc_currentThemeIsDark'
+        var storedThemeIsDark = null
+
+        try {
+          storedThemeIsDark = localStorage.getItem(themeIsDarkStorageKey)
+        } catch (error) {
+          // Ignore storage access errors and fall back to system preference.
+        }
+
+        var isDark = storedThemeIsDark === 'true'
+        var prefersDark =
+          window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        var shouldUseDark = storedThemeIsDark !== null ? isDark : prefersDark
+        var themeName = shouldUseDark ? 'dark' : 'light'
+        var backgroundColor = shouldUseDark ? '#191c1d' : '#ffffff'
+
+        document.documentElement.style.colorScheme = themeName
+        document.documentElement.style.backgroundColor = backgroundColor
+      }
+
+      applyInitialThemeBackground()
+    </script>
     <script type="module" src="./packages/web-runtime/src/index.ts"></script>
     <script type="module">
       // Fix Buffer usage in production (!)

--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -64,6 +64,7 @@ export type WebThemeType = z.infer<typeof WebTheme>
 export type ThemeConfigType = z.infer<typeof ThemeConfig>
 
 const themeStorageKey = 'oc_currentThemeName'
+const themeIsDarkStorageKey = 'oc_currentThemeIsDark'
 
 const setFavicon = (url: string) => {
   let link = document.querySelector("link[rel~='icon']") as HTMLLinkElement
@@ -77,6 +78,7 @@ const setFavicon = (url: string) => {
 
 export const useThemeStore = defineStore('theme', () => {
   const currentLocalStorageThemeName = useLocalStorage(themeStorageKey, null)
+  const currentLocalStorageThemeIsDark = useLocalStorage(themeIsDarkStorageKey, false)
 
   const isDark = usePreferredDark()
 
@@ -121,6 +123,7 @@ export const useThemeStore = defineStore('theme', () => {
     currentTheme.value = theme
     if (updateStorage) {
       currentLocalStorageThemeName.value = unref(currentTheme).label
+      currentLocalStorageThemeIsDark.value = theme.isDark
     }
 
     document.documentElement.style.colorScheme = theme.isDark ? 'dark' : 'light'


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

Prevent a white flash during initial page paint when a dark theme is active but runtime theme loading has not finished yet.

The early inline bootstrap in `index.html` now:
- determines light/dark from `oc_currentThemeIsDark` with `prefers-color-scheme` fallback,
- sets `document.documentElement.style.colorScheme` early,
- sets `document.documentElement.style.backgroundColor` early.

## Related Issue

- Fixes #2632

## How Has This Been Tested?

- test environment: local development setup
- test case 1: load page with dark theme preference persisted in local storage and verify no white flash before app bootstraps
- test case 2: load page without persisted preference and verify system color scheme fallback is applied
- test case 3: verify runtime theme application still sets `data-theme` from configured theme label

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
