### PR TITLE
fix(web-pkg): keep sidebar panels mounted while loading

### DIFF
--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -88,9 +88,6 @@ const sidebarProps = computed(() => {
     'focus-visible:shadow-none',
     ...(unref(attrs)?.class ? [unref(attrs).class] : [])
   ]
-  if (loading) {
-    classes.push('flex', 'justify-center', 'items-center')
-  }
   return {
     ...unref(attrs),
     class: classes

--- a/packages/web-pkg/src/components/SideBar/SideBarPanels.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBarPanels.vue
@@ -1,6 +1,5 @@
 <template>
-  <oc-spinner v-if="loading" :aria-label="$gettext('Loading sidebar content')" />
-  <template v-else>
+  <div class="sidebar-panels relative size-full">
     <div
       v-for="panel in displayPanels"
       :id="`sidebar-panel-${panel.name}`"
@@ -95,7 +94,12 @@
         </div>
       </div>
     </div>
-  </template>
+    <oc-spinner
+      v-if="loading"
+      :aria-label="$gettext('Loading sidebar content')"
+      class="sidebar-panels-loading absolute inset-0 z-10 flex items-center justify-center"
+    />
+  </div>
 </template>
 <script setup lang="ts">
 import { computed, ref, unref } from 'vue'

--- a/packages/web-pkg/src/components/SideBar/SideBarPanels.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBarPanels.vue
@@ -7,7 +7,7 @@
       :data-testid="`sidebar-panel-${panel.name}`"
       :tabindex="activePanelName === panel.name ? -1 : null"
       class="sidebar-panel absolute top-0 grid grid-rows-[auto_1fr] bg-role-surface w-full size-full max-w-full max-h-full motion-reduce:transition-none"
-      :inert="activePanelName !== panel.name"
+      :inert="activePanelName !== panel.name || loading"
       :class="{
         'is-root-panel transition-[right] duration-[0.4s,0s]': panel.isRoot?.(panelContext),
         'is-active-sub-panel': hasActiveSubPanel && activeSubPanelName === panel.name, // only one specific sub panel can be active

--- a/packages/web-pkg/src/components/SideBar/SideBarPanels.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBarPanels.vue
@@ -94,11 +94,12 @@
         </div>
       </div>
     </div>
-    <oc-spinner
+    <div
       v-if="loading"
-      :aria-label="$gettext('Loading sidebar content')"
       class="sidebar-panels-loading absolute inset-0 z-10 flex items-center justify-center"
-    />
+    >
+      <oc-spinner :aria-label="$gettext('Loading sidebar content')" />
+    </div>
   </div>
 </template>
 <script setup lang="ts">


### PR DESCRIPTION
The sidebar loading state replaced all root panels with a spinner (`v-if`/`v-else` in `SideBarPanels`), so any stateful panel was unmounted and recreated on every resource change. For the maps location panel this destroyed the map, so switching between geotagged files re-created it instead of animating (no fly-to).

Render the panels always and show the spinner as an overlay instead, so panels keep their state while loading.

Regressed by #2676, which started toggling the sidebar loading state on every resource change.
