### PR TITLE
fix: reset shift selection anchor when deselecting all files

### DIFF
--- a/packages/web-app-files/src/composables/keyboardActions/useKeyboardFileMouseActions.ts
+++ b/packages/web-app-files/src/composables/keyboardActions/useKeyboardFileMouseActions.ts
@@ -11,7 +11,7 @@ export const useKeyboardFileMouseActions = (
   viewMode: Ref<string | QueryValue>
 ) => {
   const resourcesStore = useResourcesStore()
-  const { latestSelectedId } = storeToRefs(resourcesStore)
+  const { latestSelectedId, selectedIds } = storeToRefs(resourcesStore)
 
   let fileListClickedEvent: string
   let shiftAnchorResetEvent: string
@@ -23,6 +23,20 @@ export const useKeyboardFileMouseActions = (
     resourcesStore.toggleSelection(resource.id)
   }
 
+  const getShiftSelectionAnchorId = (resource: Resource) => {
+    if (shiftSelectionAnchorId) {
+      return shiftSelectionAnchorId
+    }
+
+    // only fall back to the latest selected resource if it's still selected. otherwise
+    // (e.g. after deselecting all) the clicked resource becomes the new anchor.
+    if (unref(selectedIds).includes(unref(latestSelectedId))) {
+      return unref(latestSelectedId)
+    }
+
+    return resource.id
+  }
+
   const handleShiftClickAction = ({
     resource,
     skipTargetSelection
@@ -30,9 +44,7 @@ export const useKeyboardFileMouseActions = (
     resource: Resource
     skipTargetSelection: boolean
   }) => {
-    if (!shiftSelectionAnchorId) {
-      shiftSelectionAnchorId = unref(latestSelectedId) || resource.id
-    }
+    shiftSelectionAnchorId = getShiftSelectionAnchorId(resource)
     resourcesStore.setSelection([])
 
     const parent = document.querySelectorAll(`[data-item-id='${resource.id}']`)[0]
@@ -68,9 +80,7 @@ export const useKeyboardFileMouseActions = (
     resource: Resource
     skipTargetSelection: boolean
   }) => {
-    if (!shiftSelectionAnchorId) {
-      shiftSelectionAnchorId = unref(latestSelectedId) || resource.id
-    }
+    shiftSelectionAnchorId = getShiftSelectionAnchorId(resource)
     resourcesStore.setSelection([])
 
     const tilesListCard = document.querySelectorAll('#tiles-view > ul > li > div')

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -5,6 +5,7 @@ import { getParentPaths } from '../../helpers'
 import { AncestorMetaData, AncestorMetaDataValue } from '../../types'
 import { DavProperty, WebDAV } from '@opencloud-eu/web-client/webdav'
 import { useSpacesStore } from './spaces'
+import { eventBus } from '../../services'
 
 export const useResourcesStore = defineStore('resources', () => {
   const spacesStore = useSpacesStore()
@@ -145,6 +146,7 @@ export const useResourcesStore = defineStore('resources', () => {
   }
 
   const resetSelection = () => {
+    eventBus.publish('app.files.shiftAnchor.reset')
     selectedIds.value = []
   }
 

--- a/packages/web-pkg/src/composables/resources/useResourceViewHelpers.ts
+++ b/packages/web-pkg/src/composables/resources/useResourceViewHelpers.ts
@@ -196,8 +196,13 @@ export const useResourceViewHelpers = ({
     event: MouseEvent | KeyboardEvent
   }) => {
     if (interceptModifierClick(event, resource)) {
+      const eventTarget = event.target as HTMLInputElement
+      if (eventTarget?.getAttribute('type') === 'checkbox') {
+        eventTarget.checked = isResourceSelected(resource)
+      }
       return
     }
+    eventBus.publish('app.files.shiftAnchor.reset')
     resourcesStore.toggleSelection(resource.id)
     eventBus.publish('app.files.list.clicked')
     emit('update:selectedIds', [...resourcesStore.selectedIds])

--- a/packages/web-pkg/src/composables/resources/useResourceViewSelection.ts
+++ b/packages/web-pkg/src/composables/resources/useResourceViewSelection.ts
@@ -47,6 +47,7 @@ export const useResourceViewSelection = ({
 
   const toggleSelectionAll = () => {
     if (unref(areAllResourcesSelected)) {
+      eventBus.publish('app.files.shiftAnchor.reset')
       return emitSelect([])
     }
     emitSelect(


### PR DESCRIPTION
## Summary

Fixes a bug where the shift selection anchor was not properly reset after deselecting all files, causing incorrect file selection on subsequent shift+click operations.

## Description

When users deselected all files (either via the checkbox or the "Clear selection" button), the visual state was correctly updated, but the internal `shiftSelectionAnchorId` was not reset. This caused the next shift+click selection to incorrectly select files starting from the old anchor point instead of from the newly clicked file.

## Changes

- Added `eventBus.publish('app.files.shiftAnchor.reset')` to `resetSelection()` in the resources store
- Added `eventBus.publish('app.files.shiftAnchor.reset')` to `toggleSelectionAll()` in useResourceViewSelection composable
- Added eventBus import to resources.ts

## Test Plan

1. Select multiple files in tiles or table view
2. Click "Deselect All" or use the clear selection button
3. Verify all files are visually deselected
4. Click on a file, then shift+click on another file
5. Verify only the files between the two clicks are selected (not including files from the previous selection)
