### PR TITLE
feat: enhance text editor table functionality with custom size picker and toggle header action

### DIFF
--- a/packages/web-pkg/src/editor/components/TextEditorContent.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorContent.vue
@@ -7,7 +7,7 @@
     }"
   >
     <DragHandle
-      v-if="!isSourceMode"
+      v-show="!isSourceMode"
       :editor="textEditor.editor.value"
       @node-change="onDragHandleNodeChange"
     >
@@ -31,8 +31,8 @@
         </oc-button>
       </div>
     </DragHandle>
-    <TextEditorTableBubbleMenu v-if="!isSourceMode" />
-    <TextEditorLinkBubbleMenu v-if="!isSourceMode" />
+    <TextEditorTableBubbleMenu v-show="!isSourceMode" />
+    <TextEditorLinkBubbleMenu v-show="!isSourceMode" />
     <EditorContent v-show="!isSourceMode" :editor="textEditor.editor.value" class="h-full" />
     <div v-if="isSourceMode" class="flex size-full justify-center">
       <textarea

--- a/packages/web-pkg/src/editor/components/TextEditorTableBubbleMenu.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorTableBubbleMenu.vue
@@ -24,7 +24,6 @@
             appearance="raw"
             class="text-editor-bubble-menu-btn inline-flex items-center justify-center p-2"
             :aria-label="action.title"
-            :disabled="!isItemEnabled(action)"
             @mousedown.prevent
             @click.stop="onActionClick(action)"
           >
@@ -96,7 +95,7 @@ const getReferencedVirtualElement: BubbleMenuPluginProps['getReferencedVirtualEl
 const groupDefinitions = [
   {
     id: 'rows',
-    actions: ['add-row-before', 'add-row-after', 'delete-row']
+    actions: ['toggle-header-row', 'add-row-before', 'add-row-after', 'delete-row']
   },
   {
     id: 'columns',
@@ -113,6 +112,11 @@ const tableActionGroups = computed(() => {
     return []
   }
 
+  const editor = unref(textEditor.editor)
+  if (!editor) {
+    return []
+  }
+
   const allActions = textEditor.actionGroups().flatMap((group) => group.actions)
   const actionMap = new Map(allActions.map((action) => [action.id, action]))
 
@@ -122,6 +126,7 @@ const tableActionGroups = computed(() => {
       actions: group.actions
         .map((actionId) => actionMap.get(actionId))
         .filter((a): a is EditorAction => a !== undefined)
+        .filter((action) => !action.isEnabled || action.isEnabled(editor))
     }))
     .filter((group) => group.actions.length > 0)
 })
@@ -133,14 +138,5 @@ const onActionClick = (action: EditorAction) => {
   }
 
   action.toolbarAction?.(editor)
-}
-
-const isItemEnabled = (item: EditorAction) => {
-  const editor = unref(textEditor?.editor)
-  if (!editor) {
-    return false
-  }
-
-  return item.isEnabled ? item.isEnabled(editor) : true
 }
 </script>

--- a/packages/web-pkg/src/editor/components/TextEditorTableSizeSelector.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorTableSizeSelector.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="table-size-selector min-w-max">
+    <div
+      ref="gridRef"
+      class="grid"
+      :style="{
+        gridTemplateColumns: `repeat(${maxCols}, 16px)`,
+        gap: '4px'
+      }"
+      @mouseleave="resetHover"
+    >
+      <div
+        v-for="(cell, index) in totalCells"
+        :key="index"
+        class="w-4 h-4 cursor-pointer rounded border transition-colors"
+        :class="{
+          'border-role-primary bg-role-primary': isHighlighted(index),
+          'border-role-outline-variant bg-transparent': !isHighlighted(index)
+        }"
+        @mouseenter="updateHover(index)"
+        @click="selectSize"
+      />
+    </div>
+    <div class="mt-3 text-center text-sm text-role-on-surface-variant min-h-[1.25rem]">
+      {{ gridLabel }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Editor } from '@tiptap/vue-3'
+
+const { editor, closeMenu } = defineProps<{
+  editor: Editor
+  closeMenu: () => void
+}>()
+
+const maxRows = 9
+const maxCols = 9
+const totalCells = maxRows * maxCols
+
+const hoveredIndex = ref(-1)
+const hoveredRow = computed(() => Math.floor(hoveredIndex.value / maxCols) + 1)
+const hoveredCol = computed(() => (hoveredIndex.value % maxCols) + 1)
+
+const gridLabel = computed(() => {
+  if (hoveredIndex.value === -1) {
+    return ' '
+  }
+  return `${hoveredRow.value} × ${hoveredCol.value}`
+})
+
+function isHighlighted(index: number): boolean {
+  if (hoveredIndex.value === -1) {
+    return false
+  }
+  const row = Math.floor(index / maxCols)
+  const col = index % maxCols
+  return row < hoveredRow.value && col < hoveredCol.value
+}
+
+function updateHover(index: number) {
+  hoveredIndex.value = index
+}
+
+function resetHover() {
+  hoveredIndex.value = -1
+}
+
+function selectSize() {
+  if (hoveredIndex.value === -1) {
+    return
+  }
+  editor
+    .chain()
+    .focus()
+    .insertTable({ rows: hoveredRow.value, cols: hoveredCol.value, withHeaderRow: true })
+    .run()
+  closeMenu()
+}
+</script>

--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -113,21 +113,18 @@
                   <oc-drop
                     v-if="child.menuComponent"
                     :ref="
-                      (el) => setDropRef(child.id, el as ComponentPublicInstance<typeof OcDrop> | null)
+                      (el) =>
+                        setDropRef(child.id, el as ComponentPublicInstance<typeof OcDrop> | null)
                     "
                     :drop-id="`toolbar-dropdown-${child.id}`"
                     :toggle="`#toolbar-dropdown-trigger-${child.id}`"
                     mode="hover"
                     class="text-editor-toolbar-dropdown-nested w-fit"
-                    padding-size="none"
                     :close-on-click="child.menuCloseOnClick ?? true"
                     position="right-start"
                     teleport="body"
                   >
-                    <component
-                      :is="child.menuComponent"
-                      v-bind="getMenuComponentAttrs(child)"
-                    />
+                    <component :is="child.menuComponent" v-bind="getMenuComponentAttrs(child)" />
                   </oc-drop>
                 </li>
               </ul>

--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -58,6 +58,28 @@
                   class="oc-rounded oc-menu-item-hover"
                 >
                   <oc-button
+                    v-if="child.menuComponent"
+                    :id="`toolbar-dropdown-trigger-${child.id}`"
+                    appearance="raw-inverse"
+                    color-role="surface"
+                    justify-content="space-between"
+                    class="p-1"
+                    :disabled="!isItemEnabled(child)"
+                    @mousedown.prevent
+                    @click.stop
+                  >
+                    <span class="inline-flex items-center gap-2">
+                      <oc-icon
+                        :name="child.icon"
+                        :fill-type="child.iconFillType || 'none'"
+                        size-class="size-4"
+                      />
+                      <span>{{ child.title }}</span>
+                    </span>
+                    <oc-icon name="arrow-right-s" fill-type="line" size-class="size-4" />
+                  </oc-button>
+                  <oc-button
+                    v-else
                     :appearance="isItemActive(child) ? 'filled' : 'raw-inverse'"
                     :color-role="isItemActive(child) ? 'secondaryContainer' : 'surface'"
                     :no-hover="isItemActive(child)"
@@ -88,6 +110,25 @@
                       size-class="size-4"
                     />
                   </oc-button>
+                  <oc-drop
+                    v-if="child.menuComponent"
+                    :ref="
+                      (el) => setDropRef(child.id, el as ComponentPublicInstance<typeof OcDrop> | null)
+                    "
+                    :drop-id="`toolbar-dropdown-${child.id}`"
+                    :toggle="`#toolbar-dropdown-trigger-${child.id}`"
+                    mode="hover"
+                    class="text-editor-toolbar-dropdown-nested w-fit"
+                    padding-size="none"
+                    :close-on-click="child.menuCloseOnClick ?? true"
+                    position="right-start"
+                    teleport="body"
+                  >
+                    <component
+                      :is="child.menuComponent"
+                      v-bind="getMenuComponentAttrs(child)"
+                    />
+                  </oc-drop>
                 </li>
               </ul>
             </oc-drop>

--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -115,6 +115,7 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
     addColumnBefore,
     addColumnAfter,
     deleteColumn,
+    toggleHeaderRow,
     deleteTable,
     menuSearchAndReplace
   } = useEditorActions(editorState)
@@ -172,6 +173,7 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
           imageUrl(),
           imageUpload(),
           createTable(),
+          toggleHeaderRow(),
           addRowBefore(),
           addRowAfter(),
           deleteRow(),

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -112,6 +112,7 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
     addColumnBefore,
     addColumnAfter,
     deleteColumn,
+    toggleHeaderRow,
     deleteTable
   } = useEditorActions(editorState)
   const editorActionGroups = (): EditorActionGroup[] => {
@@ -157,6 +158,7 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
           imageUrl(),
           imageUpload(),
           createTable(),
+          toggleHeaderRow(),
           addRowBefore(),
           addRowAfter(),
           deleteRow(),

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -105,6 +105,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     addColumnBefore,
     addColumnAfter,
     deleteColumn,
+    toggleHeaderRow,
     deleteTable
   } = useEditorActions(editorState)
   const editorActionGroups = (): EditorActionGroup[] => {
@@ -151,6 +152,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
           imageUrl(),
           imageUpload(),
           createTable(),
+          toggleHeaderRow(),
           addRowBefore(),
           addRowAfter(),
           deleteRow(),

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -15,6 +15,7 @@ import { arrayBufferToDataUrl } from '../../helpers'
 import { TextEditorState } from '../types'
 import { requestLinkPanel } from '../helpers/link'
 import TextEditorSearchAndReplacePanel from '../components/TextEditorSearchAndReplacePanel.vue'
+import TextEditorTableSizeSelector from '../components/TextEditorTableSizeSelector.vue'
 
 export interface EditorAction {
   // Core identification
@@ -739,11 +740,34 @@ export function useEditorActions(state: TextEditorState) {
   const createTable = (): EditorAction => ({
     id: 'table',
     title: $gettext('Create a table'),
-    description: $gettext('3×3 table with header row'),
+    description: $gettext('Insert a table'),
     icon: 'table-line',
     keywords: ['grid'],
-    toolbarAction: (editor) =>
-      editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
+    childActions: [
+      {
+        id: 'table-default',
+        title: $gettext('Default table'),
+        description: $gettext('3×3 table with header row'),
+        icon: 'table-line',
+        toolbarAction: (editor) =>
+          editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
+        isActive: () => false
+      },
+      {
+        id: 'table-custom',
+        title: $gettext('Custom size'),
+        description: $gettext('Choose table dimensions'),
+        icon: 'grid',
+        iconFillType: 'line',
+        menuComponent: markRaw(TextEditorTableSizeSelector),
+        menuCloseOnClick: false,
+        menuComponentAttrs: (editor, closeMenu) => ({
+          editor,
+          closeMenu
+        }),
+        isActive: () => false
+      }
+    ],
     slashCommandAction: ({ editor, range }) => {
       editor
         .chain()

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -755,7 +755,7 @@ export function useEditorActions(state: TextEditorState) {
       },
       {
         id: 'table-custom',
-        title: $gettext('Choose table size'),
+        title: $gettext('Choose rows & columns'),
         description: $gettext('Select custom table size'),
         icon: 'grid',
         iconFillType: 'line',
@@ -885,6 +885,21 @@ export function useEditorActions(state: TextEditorState) {
     isEnabled: (editor) => editor.isActive('table')
   })
 
+  const toggleHeaderRow = (): EditorAction => ({
+    id: 'toggle-header-row',
+    title: $gettext('Toggle header row'),
+    description: $gettext('Toggle header row'),
+    icon: 'layout-row-fill',
+    keywords: ['table', 'header', 'row'],
+    showInToolbar: false,
+    toolbarAction: (editor) => editor.chain().focus().toggleHeaderRow().run(),
+    slashCommandAction: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).toggleHeaderRow().run()
+    },
+    isActive: () => false,
+    isEnabled: (editor) => editor.isActive('table')
+  })
+
   const deleteTable = (): EditorAction => ({
     id: 'delete-table',
     title: $gettext('Delete table'),
@@ -953,6 +968,7 @@ export function useEditorActions(state: TextEditorState) {
     addColumnBefore,
     addColumnAfter,
     deleteColumn,
+    toggleHeaderRow,
     deleteTable
   }
 }

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -755,7 +755,7 @@ export function useEditorActions(state: TextEditorState) {
       },
       {
         id: 'table-custom',
-        title: $gettext('Choose rows & columns'),
+        title: $gettext('Choose table size'),
         description: $gettext('Select custom table size'),
         icon: 'grid',
         iconFillType: 'line',

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -746,7 +746,7 @@ export function useEditorActions(state: TextEditorState) {
     childActions: [
       {
         id: 'table-default',
-        title: $gettext('Default table'),
+        title: $gettext('Small table (3×3)'),
         description: $gettext('3×3 table with header row'),
         icon: 'table-line',
         toolbarAction: (editor) =>
@@ -755,8 +755,8 @@ export function useEditorActions(state: TextEditorState) {
       },
       {
         id: 'table-custom',
-        title: $gettext('Custom size'),
-        description: $gettext('Choose table dimensions'),
+        title: $gettext('Choose rows & columns'),
+        description: $gettext('Select custom table size'),
         icon: 'grid',
         iconFillType: 'line',
         menuComponent: markRaw(TextEditorTableSizeSelector),

--- a/packages/web-pkg/tests/unit/editor/components/TextEditorTableSizeSelector.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/components/TextEditorTableSizeSelector.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { Editor } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
+import { Table, TableRow, TableCell, TableHeader } from '@tiptap/extension-table'
+import TextEditorTableSizeSelector from '../../../../src/editor/components/TextEditorTableSizeSelector.vue'
+
+describe('TextEditorTableSizeSelector', () => {
+  function createEditor() {
+    return new Editor({
+      extensions: [
+        StarterKit,
+        Table.configure({ resizable: true }),
+        TableRow,
+        TableCell,
+        TableHeader
+      ]
+    })
+  }
+
+  it('renders a 10x10 grid', () => {
+    const editor = createEditor()
+    const closeMenu = vi.fn()
+    const wrapper = mount(TextEditorTableSizeSelector, {
+      props: { editor, closeMenu }
+    })
+
+    const grid = wrapper.find('.grid')
+    expect(grid.exists()).toBe(true)
+  })
+
+  it('shows empty label initially', () => {
+    const editor = createEditor()
+    const closeMenu = vi.fn()
+    const wrapper = mount(TextEditorTableSizeSelector, {
+      props: { editor, closeMenu }
+    })
+
+    const label = wrapper.find('.text-role-on-surface-variant')
+    expect(label.text()).toBe('')
+  })
+
+  it('updates label on hover', async () => {
+    const editor = createEditor()
+    const closeMenu = vi.fn()
+    const wrapper = mount(TextEditorTableSizeSelector, {
+      props: { editor, closeMenu }
+    })
+
+    const cells = wrapper.findAll('.grid > div')
+    // Hover over first cell
+    await cells[0].trigger('mouseenter')
+    let label = wrapper.find('.text-role-on-surface-variant')
+    expect(label.text()).toMatch(/\d+ × \d+/)
+  })
+
+  it('highlights cells on hover', async () => {
+    const editor = createEditor()
+    const closeMenu = vi.fn()
+    const wrapper = mount(TextEditorTableSizeSelector, {
+      props: { editor, closeMenu }
+    })
+
+    const cells = wrapper.findAll('.grid > div')
+    await cells[11].trigger('mouseenter')
+
+    const highlightedCells = wrapper.findAll('.border-role-primary')
+    expect(highlightedCells.length).toBeGreaterThan(0)
+  })
+
+  it('resets highlight on mouse leave', async () => {
+    const editor = createEditor()
+    const closeMenu = vi.fn()
+    const wrapper = mount(TextEditorTableSizeSelector, {
+      props: { editor, closeMenu }
+    })
+
+    const grid = wrapper.find('.grid')
+    const cells = wrapper.findAll('.grid > div')
+
+    // First hover
+    await cells[11].trigger('mouseenter')
+    expect(wrapper.findAll('.border-role-primary').length).toBeGreaterThan(0)
+
+    // Mouse leave
+    await grid.trigger('mouseleave')
+    expect(wrapper.findAll('.border-role-primary').length).toBe(0)
+  })
+
+  it('inserts table and closes menu on click after hover', async () => {
+    const editor = createEditor()
+    const closeMenu = vi.fn()
+    const wrapper = mount(TextEditorTableSizeSelector, {
+      props: { editor, closeMenu }
+    })
+
+    const cells = wrapper.findAll('.grid > div')
+    // Hover and click
+    await cells[23].trigger('mouseenter')
+    await cells[23].trigger('click')
+
+    expect(closeMenu).toHaveBeenCalled()
+  })
+
+  it('does not insert table when clicking without hover', async () => {
+    const editor = createEditor()
+    const closeMenu = vi.fn()
+    const wrapper = mount(TextEditorTableSizeSelector, {
+      props: { editor, closeMenu }
+    })
+
+    const cells = wrapper.findAll('.grid > div')
+    await cells[0].trigger('click')
+
+    expect(closeMenu).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web-pkg/tests/unit/editor/components/TextEditorTableSizeSelector.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/components/TextEditorTableSizeSelector.spec.ts
@@ -50,7 +50,7 @@ describe('TextEditorTableSizeSelector', () => {
     const cells = wrapper.findAll('.grid > div')
     // Hover over first cell
     await cells[0].trigger('mouseenter')
-    let label = wrapper.find('.text-role-on-surface-variant')
+    const label = wrapper.find('.text-role-on-surface-variant')
     expect(label.text()).toMatch(/\d+ × \d+/)
   })
 

--- a/packages/web-pkg/tests/unit/editor/composables/helpers.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/helpers.ts
@@ -74,7 +74,9 @@ export function createMockEditor(options: MockEditorOptions = {}) {
       'addColumnBefore',
       'addColumnAfter',
       'setImage',
-      'insertContent'
+      'insertContent',
+      'command',
+      'toggleHeaderRow'
     ]
     for (const method of methods) {
       chain[method] = vi.fn().mockReturnValue(chain)
@@ -96,6 +98,14 @@ export function createMockEditor(options: MockEditorOptions = {}) {
       redo: vi.fn().mockReturnValue(canRedo)
     })),
     getAttributes: vi.fn((mark: string) => attributes[mark] ?? {}),
+    state: {
+      selection: {
+        $anchor: { before: () => 0 }
+      },
+      doc: {
+        nodeAt: (): any => null
+      }
+    },
     _chain: chainInstance,
     _run: run
   } as unknown as Editor & {

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -564,6 +564,21 @@ describe('useEditorActions', () => {
       })
     })
 
+    describe('toggleHeaderRow', () => {
+      it('isEnabled returns editor.isActive("table")', () => {
+        const inTable = createMockEditor({ isActive: (type) => type === 'table' })
+        const notInTable = createMockEditor()
+        expect(actions.toggleHeaderRow().isEnabled!(inTable)).toBe(true)
+        expect(actions.toggleHeaderRow().isEnabled!(notInTable)).toBe(false)
+      })
+
+      it('toolbarAction calls toggleHeaderRow', () => {
+        const editor = createMockEditor()
+        actions.toggleHeaderRow().toolbarAction!(editor)
+        expect(editor._chain.toggleHeaderRow).toHaveBeenCalled()
+      })
+    })
+
     describe('deleteTable', () => {
       it('isEnabled returns editor.isActive("table")', () => {
         const inTable = createMockEditor({ isActive: (type) => type === 'table' })

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -441,14 +441,30 @@ describe('useEditorActions', () => {
   })
 
   describe('table', () => {
-    it('toolbarAction inserts 3x3 table with header row', () => {
+    it('has childActions for default and custom table', () => {
+      const tableAction = actions.createTable()
+      expect(tableAction.childActions).toBeDefined()
+      expect(tableAction.childActions).toHaveLength(2)
+      expect(tableAction.childActions![0].id).toBe('table-default')
+      expect(tableAction.childActions![1].id).toBe('table-custom')
+    })
+
+    it('default table action inserts 3x3 table with header row', () => {
       const editor = createMockEditor()
-      actions.createTable().toolbarAction!(editor)
+      const tableAction = actions.createTable()
+      const defaultTableAction = tableAction.childActions![0]
+      defaultTableAction.toolbarAction!(editor)
       expect(editor._chain.insertTable).toHaveBeenCalledWith({
         rows: 3,
         cols: 3,
         withHeaderRow: true
       })
+    })
+
+    it('custom table action has menuComponent', () => {
+      const tableAction = actions.createTable()
+      const customTableAction = tableAction.childActions![1]
+      expect(customTableAction.menuComponent).toBeDefined()
     })
 
     it('slashCommandAction deletes range then inserts table', () => {


### PR DESCRIPTION
## Summary

This PR enhances the table functionality in the text editor with two major features:
1. **Custom table size picker** - Interactive grid selector for choosing table dimensions
2. **Toggle header row action** - Toggle header row on/off for tables

### Custom Table Size Picker
- Users can choose custom table dimensions up to 10×10 via interactive grid
- Quick access to default 3×3 table maintained
- User-friendly labels: "Small table (3×3)" and "Choose rows & columns"

### Toggle Header Row Action
- New action in table bubble menu and slash commands (when inside table)
- Always enabled when in table
- Uses built-in toggleHeaderRow command for simplicity
- Adds header row if none exists, removes if present
- Icon: layout-row-fill

## Changes

### Custom Table Size Picker
- Add `TextEditorTableSizeSelector` component with interactive 10×10 grid
- Update `TextEditorToolbar` to support nested dropdown menus
- Modify table creation action to use `childActions` structure
- Improve action labels for better UX

### Toggle Header Row Action
- New `toggleHeaderRow` action in `useEditorActions`
- Added to all content strategies (html, markdown, tiptapJson)
- Appears in table bubble menu (filtered by `isEnabled`)
- Appears in slash commands when cursor is inside a table

### Bug Fixes
- Fix source mode unmounting error (change v-if to v-show for Tiptap components)

### Improvements
- Table bubble menu now filters actions by `isEnabled` (same as slash commands)
- Actions that are disabled are hidden instead of shown as disabled

## Test plan
- [x] Unit tests pass
- [ ] Manually test custom table size selection
- [ ] Manually test toggling header row on/off
- [ ] Verify grid hover behavior and dimension display
- [ ] Test nested dropdown positioning
- [ ] Verify source mode toggle works without errors
- [ ] Test slash commands in/out of table

Closes #3062