### PR TITLE
feat: add subscript and superscript support to text editor

### DIFF
--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -66,6 +66,8 @@
     "@tiptap/extension-node-range": "^3.28.0",
     "@tiptap/extension-paragraph": "^3.28.0",
     "@tiptap/extension-placeholder": "^3.28.0",
+    "@tiptap/extension-subscript": "^3.29.2",
+    "@tiptap/extension-superscript": "^3.29.2",
     "@tiptap/extension-table": "^3.28.0",
     "@tiptap/extension-task-item": "^3.28.0",
     "@tiptap/extension-task-list": "^3.28.0",

--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -4,6 +4,8 @@ import type { Editor } from '@tiptap/vue-3'
 import type { Extension } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
+import Subscript from '@tiptap/extension-subscript'
+import Superscript from '@tiptap/extension-superscript'
 import Image from '@tiptap/extension-image'
 import FindAndReplace from '@tiptap/extension-find-and-replace'
 import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table'
@@ -66,6 +68,8 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
       FontFamily,
       TextStyle,
       Underline,
+      Subscript,
+      Superscript,
       Color,
       BackgroundColor,
       FontSize,
@@ -87,6 +91,8 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
     italic,
     underline,
     strikethrough,
+    subscript,
+    superscript,
     heading,
     paragraph,
     heading1,
@@ -151,7 +157,9 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
           bold(),
           italic(),
           underline(),
-          strikethrough()
+          strikethrough(),
+          subscript(),
+          superscript()
         ]
       },
       {

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -4,6 +4,8 @@ import type { Editor } from '@tiptap/vue-3'
 import type { Extension } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
+import Subscript from '@tiptap/extension-subscript'
+import Superscript from '@tiptap/extension-superscript'
 import Image from '@tiptap/extension-image'
 import FindAndReplace from '@tiptap/extension-find-and-replace'
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
@@ -61,6 +63,8 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
       FontFamily,
       TextStyle,
       Underline,
+      Subscript,
+      Superscript,
       Color,
       BackgroundColor,
       FontSize,
@@ -81,6 +85,8 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     italic,
     underline,
     strikethrough,
+    subscript,
+    superscript,
     heading,
     heading1,
     heading2,
@@ -130,7 +136,9 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
           bold(),
           italic(),
           underline(),
-          strikethrough()
+          strikethrough(),
+          subscript(),
+          superscript()
         ]
       },
       {

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -313,6 +313,26 @@ export function useEditorActions(state: TextEditorState) {
     isActive: (editor) => editor.isActive('strike')
   })
 
+  const subscript = (): EditorAction => ({
+    id: 'subscript',
+    title: $gettext('Subscript'),
+    icon: 'subscript',
+    toolbarAction: (editor) => editor.chain().focus().toggleSubscript().run(),
+    slashCommandAction: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleSubscript().run(),
+    isActive: (editor) => editor.isActive('subscript')
+  })
+
+  const superscript = (): EditorAction => ({
+    id: 'superscript',
+    title: $gettext('Superscript'),
+    icon: 'superscript',
+    toolbarAction: (editor) => editor.chain().focus().toggleSuperscript().run(),
+    slashCommandAction: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleSuperscript().run(),
+    isActive: (editor) => editor.isActive('superscript')
+  })
+
   const codeInline = (): EditorAction => ({
     id: 'code-inline',
     title: $gettext('Inline code'),
@@ -943,6 +963,8 @@ export function useEditorActions(state: TextEditorState) {
     italic,
     underline,
     strikethrough,
+    subscript,
+    superscript,
     codeInline,
     // Blocks
     lineHeight,

--- a/packages/web-pkg/tests/unit/editor/composables/helpers.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/helpers.ts
@@ -47,6 +47,8 @@ export function createMockEditor(options: MockEditorOptions = {}) {
       'toggleItalic',
       'toggleUnderline',
       'toggleStrike',
+      'toggleSubscript',
+      'toggleSuperscript',
       'toggleCode',
       'setParagraph',
       'setNode',

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -154,6 +154,8 @@ describe('useEditorActions', () => {
       { name: 'italic', toggleMethod: 'toggleItalic', markName: 'italic' },
       { name: 'underline', toggleMethod: 'toggleUnderline', markName: 'underline' },
       { name: 'strikethrough', toggleMethod: 'toggleStrike', markName: 'strike' },
+      { name: 'subscript', toggleMethod: 'toggleSubscript', markName: 'subscript' },
+      { name: 'superscript', toggleMethod: 'toggleSuperscript', markName: 'superscript' },
       { name: 'codeInline', toggleMethod: 'toggleCode', markName: 'code' }
     ] as const
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,6 +894,12 @@ importers:
       '@tiptap/extension-placeholder':
         specifier: ^3.28.0
         version: 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-subscript':
+        specifier: ^3.29.2
+        version: 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-superscript':
+        specifier: ^3.29.2
+        version: 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
       '@tiptap/extension-table':
         specifier: ^3.28.0
         version: 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
@@ -1986,6 +1992,18 @@ packages:
     resolution: {integrity: sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==}
     peerDependencies:
       '@tiptap/core': 3.29.2
+
+  '@tiptap/extension-subscript@3.29.2':
+    resolution: {integrity: sha512-3fpp1B2kZWBfmVYZ1ak3yFWiKR3eV9GR/vYGPDMrkZoTdG9LKylRAJs3Fk2gDgTtOPmbrtilGQjl2o55RuoGxw==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-superscript@3.29.2':
+    resolution: {integrity: sha512-/bPgdY7zUHtvToHizvzR6Yf4uIWO35cKj9EZsl/vyFb2mXyJ3a2mysCZgZq+5uvhZS/16eNNKOcezlkayhhkMA==}
+    peerDependencies:
+      '@tiptap/core': 3.29.2
+      '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-table@3.29.2':
     resolution: {integrity: sha512-HY3JWD8i/F8W1oWw56DMqEMqxScIAZFRrhL3rUwiuowHG8LLDqDdQjBV3w1DY8lUZOtNY9grpuMtGlPUFrOVAA==}
@@ -5914,6 +5932,16 @@ snapshots:
   '@tiptap/extension-strike@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))':
     dependencies:
       '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+
+  '@tiptap/extension-subscript@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
+
+  '@tiptap/extension-superscript@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+    dependencies:
+      '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
+      '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-table@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:


### PR DESCRIPTION
## Description

<img width="1577" height="737" alt="image" src="https://github.com/user-attachments/assets/dea6483f-be3f-433e-867f-26cf21d5e76e" />

Adds subscript (x₂) and superscript (x²) formatting to the text editor for scientific notation, mathematical expressions, and footnotes.

**Availability:** HTML and TiptapJson modes. Not available in Markdown (no native support).

## Related Issue

Closes #3070

## Changes

- Added `@tiptap/extension-subscript` and `@tiptap/extension-superscript` to web-pkg
- Implemented toggle actions in `useEditorActions.ts`
- Integrated into HTML and TiptapJson editor strategies
- Added unit tests (131 tests passing)

## Testing

- ✅ All tests pass
- ✅ Type checking passes  
- ✅ Linting passes
- ✅ Build succeeds

## Type

- [x] Enhancement
- [x] Tests