### PR TITLE
[stable-7.1] fix: encode hash character in app route URLs to prevent truncation (#3075)

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -174,8 +174,8 @@ export const useFileActions = () => {
     if (!routeName || !router.hasRoute(routeName)) {
       return null
     }
-    const routeOpts = getEditorRouteOpts(routeName, space, resource, remoteItemId)
-    return router.resolve(routeOpts)
+
+    return getEditorRouteOpts(routeName, space, resource, remoteItemId)
   }
   const getEditorRouteOpts = (
     routeName: RouteRecordName,

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
@@ -94,11 +94,50 @@ describe('fileActions', () => {
         }
       })
       mocks.$router.hasRoute.mockReturnValue(true)
+
+      const mockSpace = mock<SpaceResource>({
+        getDriveAliasAndItem: () => 'personal/admin/test.txt'
+      })
+
       const result = editorAction.route({
-        space: mock<SpaceResource>(),
+        space: mockSpace,
         resources: actionOptions.resources
       })
       expect(result).not.toBeNull()
+    })
+
+    it('returns unresolved route options so the router encodes the path', () => {
+      let editorAction: FileAction
+      const { mocks } = getWrapper({
+        setup: ({ getAllOpenWithActions }) => {
+          const actions = getAllOpenWithActions(actionOptions)
+          editorAction = actions.find((a) => a.name === 'editor-text-editor')
+        }
+      })
+      mocks.$router.hasRoute.mockReturnValue(true)
+
+      const mockSpace = mock<SpaceResource>({
+        getDriveAliasAndItem: () => 'personal/admin/ticket#1234/logs.txt'
+      })
+      const mockResource = mock<Resource>({
+        path: '/ticket#1234/logs.txt',
+        fileId: 'test-file-id'
+      })
+
+      const route = editorAction.route({
+        space: mockSpace,
+        resources: [mockResource]
+      })
+
+      // Resolving is left to the router. Handing it an already resolved location
+      // or a pre-encoded path both break the encoding of characters like `#`.
+      expect(route).toEqual(
+        expect.objectContaining({
+          name: 'text-editor',
+          params: { driveAliasAndItem: 'personal/admin/ticket#1234/logs.txt' }
+        })
+      )
+      expect(route).not.toHaveProperty('href')
     })
   })
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-7.1`:
 - [fix: encode hash character in app route URLs to prevent truncation (#3075)](https://github.com/opencloud-eu/web/pull/3075)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)