### PR TITLE
fix(text-editor): update editor content when loaded via recovery

### DIFF
--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRef, unref } from 'vue'
+import { computed, toRef, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import {
   ContentType,
@@ -64,4 +64,15 @@ const textEditor = useTextEditor({
   placeholder: unref(placeholder),
   onUpdate: (content) => emit('update:currentContent', content)
 })
+
+// Update editor when content is loaded after initial mount (e.g., via recovery mechanism).
+// Only triggers when transitioning from undefined to avoid interfering with normal edits.
+watch(
+  () => currentContent,
+  (newContent, oldContent) => {
+    if (oldContent === undefined && newContent && textEditor.editor.value) {
+      textEditor.setContent(newContent)
+    }
+  }
+)
 </script>

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -153,6 +153,7 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
     readonly,
     actionGroups: strategy.editorActionGroups,
     getContent,
+    setContent,
     isEmpty,
     isFocused,
     focus,

--- a/packages/web-pkg/src/editor/types.ts
+++ b/packages/web-pkg/src/editor/types.ts
@@ -26,6 +26,7 @@ export interface TextEditorInstance {
   readonly: Ref<boolean>
   actionGroups(): EditorActionGroup[]
   getContent(): string
+  setContent(value: string): void
   isEmpty: ComputedRef<boolean>
   isFocused: ComputedRef<boolean>
   focus(): void


### PR DESCRIPTION
## Summary
The text editor now properly updates when file content is loaded after initial mount, e.g., through the AppWrapper recovery mechanism. This ensures the editor displays content even when it's loaded asynchronously after the editor component has already been initialized.

## Changes
- Added a watcher in `packages/web-app-text-editor/src/App.vue` that detects when `currentContent` transitions from `undefined` to a value
- Only triggers during recovery scenarios to avoid interfering with normal editing or file switches

## Test plan
- [ ] Open a file in the text editor
- [ ] Verify content loads correctly in normal scenarios
- [ ] Test with files that trigger the recovery mechanism
- [ ] Verify editor updates properly when content loads after mount
- [ ] Ensure typing/editing is not affected by the watcher

Works towards #3074