### PR TITLE
fix: make ESC app close behave like top-bar close

### DIFF
--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <main :id="applicationId" class="app-wrapper h-full rounded-xl" @keydown.esc="closeApp">
+  <main :id="applicationId" class="app-wrapper h-full rounded-xl" @keydown.esc.stop="closeApp">
     <h1 class="sr-only" v-text="pageTitle" />
     <loading-screen v-if="isLoading" />
     <error-screen v-else-if="loadingError" :message="loadingError.message" />

--- a/packages/web-pkg/tests/unit/components/AppTemplates/AppWrapper.spec.ts
+++ b/packages/web-pkg/tests/unit/components/AppTemplates/AppWrapper.spec.ts
@@ -90,9 +90,16 @@ function setup({
   const getFileContents = vi
     .fn()
     .mockImplementation(() => new Promise((r) => (resolveContents = r)))
+  const closeApp = vi.fn()
 
   useAppDefaultsSpy.mockReturnValue(
-    useAppDefaultsMock({ currentFileContext, getFileInfo, getFileContents, putFileContents })
+    useAppDefaultsMock({
+      currentFileContext,
+      getFileInfo,
+      getFileContents,
+      putFileContents,
+      closeApp
+    })
   )
 
   let sessionOptions: any
@@ -155,6 +162,7 @@ function setup({
     isEnabled: () => sessionOptions?.enabled(),
     isLockedForReload,
     putFileContents,
+    closeApp,
     getFileContents,
     wasWrittenByRoom,
     beginSave,
@@ -181,6 +189,22 @@ function setup({
     }
   }
 }
+
+describe('AppWrapper — ESC close behavior', () => {
+  it('stops Escape propagation while closing the app', async () => {
+    const s = setup({ yjsEnabled: false })
+    const documentKeydownSpy = vi.fn()
+    document.addEventListener('keydown', documentKeydownSpy)
+    try {
+      await s.wrapper.find('main').trigger('keydown', { key: 'Escape' })
+
+      expect(s.closeApp).toHaveBeenCalledTimes(1)
+      expect(documentKeydownSpy).not.toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('keydown', documentKeydownSpy)
+    }
+  })
+})
 
 describe('AppWrapper — Yjs session gate', () => {
   it('stays disabled until the body for the current resource has arrived', async () => {


### PR DESCRIPTION
## Description

Fixes inconsistent app-close behavior for `Escape` vs. top-bar close button.

`Escape` in `AppWrapper` now stops keydown propagation before closing the app, so global file-list keyboard handlers cannot clear `scrollTo` selection state during the route transition.

Added a regression test that verifies:
- `Escape` triggers `closeApp`
- `Escape` does not propagate to `document`

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3093

## How Has This Been Tested?

- test environment: local dev (macOS), unit tests
- test case 1: `pnpm test:unit --run packages/web-pkg/tests/unit/components/AppTemplates/AppWrapper.spec.ts`
- test case 2: verify new regression test `AppWrapper — ESC close behavior` passes

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
