### PR TITLE
fix(files): guard FileDetails against transient null resource

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="oc-file-details-sidebar" class="p-2">
-    <div v-if="hasContent">
+    <div v-if="resource && hasContent">
       <div
         class="relative flex items-center justify-center bg-role-surface-container rounded-xl p-4 mb-4"
       >
@@ -331,7 +331,7 @@ const stickyShowVersions = ref(false)
 watch(
   versionsLoading,
   (loading) => {
-    if (!loading) {
+    if (unref(resource) && !loading) {
       stickyShowVersions.value = !!unref(showVersions)
     }
   },
@@ -352,7 +352,7 @@ const capitalizedTimestamp = computed(() => {
 })
 
 watch(
-  () => unref(resource).mdate,
+  () => unref(resource)?.mdate,
   async () => {
     if (unref(resource)) {
       preview.value = await loadPreview({


### PR DESCRIPTION
## Description

Fixes a crash in `FileDetails` when opening the sidebar for shared resources as share receiver.

The issue was caused by transient access to `resource.mdate` while `resource` could be temporarily unavailable during sidebar/resource updates. This change hardens the component with minimal surface change:

- render details content only when `resource` is present (`v-if="resource && hasContent"`)
- guard version placeholder state updates behind resource availability
- make preview watch source null-safe (`unref(resource)?.mdate`)

This prevents `TypeError: Cannot read properties of null (reading 'mdate')` in the sidebar flow.

## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local dev instance, shared-with-me route
- test case 1: open sidebar as share receiver on shared file -> no `mdate` null crash
- test case 2: switch sidebar panels / reload details while versions are loading -> no crash
- test case 3: open regular (non-shared) file details -> unchanged behavior

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
