### PR TITLE
test(e2e): add coverage for opening files with special characters

### DIFF
--- a/tests/e2e/features/file-action/openWithAppSpecialCharacters.feature
+++ b/tests/e2e/features/file-action/openWithAppSpecialCharacters.feature
@@ -1,0 +1,43 @@
+Feature: open files with special characters in apps
+  As a user
+  I want to open files whose name or parent folder contains special characters
+  So that I can work with resources regardless of the characters in their path
+        
+
+  Scenario: open a file inside a folder containing a hash character in the text-editor
+    Given "Admin" creates following user using API
+      | id    |
+      | Alice |
+    And "Alice" creates the following folder in personal space using API
+      | name        |
+      | ticket#3074 |
+    And "Alice" creates the following file into personal space using API
+      | pathToFile               | content      |
+      | ticket#3074/example?.txt | example text |
+      | ticket#3074/test%20.txt  | some content |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile      | to                       |
+      | testavatar.png | ticket#3074/image%20.png |
+    And "Alice" logs in
+    When "Alice" opens the "files" app
+    And "Alice" opens folder "ticket#3074"
+    When "Alice" opens the following file in texteditor
+      | resource     | verifyPropfindPath |
+      | example?.txt | true               |
+    Then "Alice" is in a text-editor
+    And "Alice" should see the content "example text" in editor "TextEditor"
+    And "Alice" closes the file viewer
+    When "Alice" opens the following file in texteditor
+      | resource    | verifyPropfindPath |
+      | test%20.txt | true               |
+    Then "Alice" should see the content "some content" in editor "TextEditor"
+    And "Alice" closes the file viewer
+    When "Alice" opens the following file in mediaviewer
+      | resource     | verifyPropfindPath |
+      | image%20.png | true               |
+    Then "Alice" is in a media-viewer
+    And "Alice" downloads the following resource using the preview topbar
+      | resource     | type |
+      | image%20.png | file |
+    And "Alice" closes the file viewer
+    And "Alice" logs out

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -639,7 +639,8 @@ When(
       await resourceObject.openFileInViewer({
         name: info.resource,
         actionType: actionType as
-          'mediaviewer' | 'pdfviewer' | 'texteditor' | 'Collabora' | 'Euro-Office'
+          'mediaviewer' | 'pdfviewer' | 'texteditor' | 'Collabora' | 'Euro-Office',
+        verifyPropfindPath: info.verifyPropfindPath === 'true'
       })
     }
   }

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -1,6 +1,6 @@
 import { checkResponseStatus, request } from '../http'
 import { User } from '../../types'
-import { urlJoin } from '../../utils/urlJoin'
+import { urlJoin, encodeWebDavPath } from '../../utils/urlJoin'
 import { XMLParser } from 'fast-xml-parser'
 import { getSpaceIdBySpaceName } from '../graph'
 import _ from 'lodash-es/object.js'
@@ -35,7 +35,8 @@ const createFolder = async ({
 
   let parentFolder = ''
   for (const resource of paths) {
-    const path = urlJoin('remote.php', 'dav', webDavEndPathToRoot, parentFolder, resource)
+    const encodedResource = encodeWebDavPath(resource)
+    const path = urlJoin('remote.php', 'dav', webDavEndPathToRoot, parentFolder, encodedResource)
     // check if the folder exists already or not
     const folderExist = await folderExists({ user, path })
     if (folderExist === false) {
@@ -46,7 +47,7 @@ const createFolder = async ({
       })
       checkResponseStatus(response, 'Failed while creating folder')
     }
-    parentFolder = urlJoin(parentFolder, resource)
+    parentFolder = urlJoin(parentFolder, encodedResource)
   }
 }
 const createFile = async ({
@@ -65,7 +66,7 @@ const createFile = async ({
   const today = new Date()
   const response = await request({
     method: 'PUT',
-    path: urlJoin('remote.php', 'dav', webDavEndPathToRoot, pathToFile),
+    path: urlJoin('remote.php', 'dav', webDavEndPathToRoot, encodeWebDavPath(pathToFile)),
     body: content,
     user: user,
     header: mtimeDeltaDays
@@ -87,7 +88,7 @@ const deleteFile = async ({
 }): Promise<void> => {
   const response = await request({
     method: 'DELETE',
-    path: urlJoin('remote.php', 'dav', webDavEndPathToRoot, pathToFile),
+    path: urlJoin('remote.php', 'dav', webDavEndPathToRoot, encodeWebDavPath(pathToFile)),
     user: user,
     header: {}
   })
@@ -195,7 +196,7 @@ export const getDataOfFileInsideSpace = async ({
       'dav',
       'spaces',
       await getSpaceIdBySpaceName({ user, spaceType, spaceName }),
-      pathToFileName
+      encodeWebDavPath(pathToFileName)
     ),
     body: body,
     user: user

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -9,6 +9,7 @@ import { File, Space } from '../../../types'
 import { waitProcessingToFinish } from '../fileEvents'
 import { state } from '../../../../environment/shared'
 import { lstatSync, readFileSync } from 'fs'
+import { encodeWebDavPath } from '../../../utils'
 
 const appLoadingSpinner = '#app-loading-spinner'
 const topbarFilenameSelector = '#app-top-bar-resource .oc-resource-name'
@@ -2006,10 +2007,11 @@ export interface openFileInViewerArgs {
   name: string
   actionType:
     'mediaviewer' | 'audioviewer' | 'pdfviewer' | 'texteditor' | 'Collabora' | 'Euro-Office'
+  verifyPropfindPath?: boolean
 }
 
 export const openFileInViewer = async (args: openFileInViewerArgs): Promise<void> => {
-  const { page, name, actionType } = args
+  const { page, name, actionType, verifyPropfindPath = false } = args
   await waitProcessingToFinish(page, name)
 
   switch (actionType) {
@@ -2057,7 +2059,21 @@ export const openFileInViewer = async (args: openFileInViewerArgs): Promise<void
       ])
       break
     case 'mediaviewer': {
-      await page.locator(util.format(resourceNameSelector, name)).click()
+      if (verifyPropfindPath) {
+        // shared files opened via "shared with me" don't trigger a PROPFIND at all,
+        // so only wait for (and assert) it when explicitly requested
+        await Promise.all([
+          page.waitForResponse(
+            (resp) =>
+              resp.status() === 207 &&
+              resp.request().method() === 'PROPFIND' &&
+              resp.url().includes(encodeWebDavPath(name))
+          ),
+          page.locator(util.format(resourceNameSelector, name)).click()
+        ])
+      } else {
+        await page.locator(util.format(resourceNameSelector, name)).click()
+      }
       const extension = name.split('.').pop()
       switch (extension) {
         case 'mp3':
@@ -2087,7 +2103,10 @@ export const openFileInViewer = async (args: openFileInViewerArgs): Promise<void
     case 'texteditor': {
       await Promise.all([
         page.waitForResponse(
-          (resp) => resp.status() === 207 && resp.request().method() === 'PROPFIND'
+          (resp) =>
+            resp.status() === 207 &&
+            resp.request().method() === 'PROPFIND' &&
+            (!verifyPropfindPath || resp.url().includes(encodeWebDavPath(name)))
         ),
         page.locator(util.format(resourceNameSelector, name)).click()
       ])

--- a/tests/e2e/support/utils/urlJoin.ts
+++ b/tests/e2e/support/utils/urlJoin.ts
@@ -66,6 +66,15 @@ const buildUrl = (parsedParts: ReturnType<typeof parseParts>, options: UrlJoinOp
   return url
 }
 
+/**
+ * Encode a WebDAV resource path
+ */
+export const encodeWebDavPath = (path: string) =>
+  path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+
 export const urlJoin = (...parts: Array<string | UrlJoinOptions>) => {
   const lastArg = parts[parts.length - 1]
   let options: UrlJoinOptions


### PR DESCRIPTION
tests for https://github.com/opencloud-eu/web/issues/3074

- openning txt/png file what contains special characters. 
- openning files from parent folder what contains special characters.
- check that propfind request url contains encrypted resource name