### PR TITLE
test(e2e): extend e2e coverage for rclone-crypt vault

### DIFF
--- a/tests/e2e/features/rclone-crypt/vault.feature
+++ b/tests/e2e/features/rclone-crypt/vault.feature
@@ -21,12 +21,13 @@ Feature: Work with an rclone-crypt encrypted vault
     And "Alice" uploads the following resource
       | resource          | to           | password |
       | PARENT/parent.txt | my.vault/sub | foobar   |
+      | testavatar.png    | my.vault/sub | foobar   |
     And "Alice" enters the vault "my.vault" with passphrase "foobar"
-    And following resources should be displayed in the files list for user "Alice"
+    Then following resources should be displayed in the files list for user "Alice"
       | resource  |
       | hello.txt |
       | sub       |
-    And "Alice" opens folder "sub"
+    When "Alice" opens folder "sub"
     And following resources should be displayed in the files list for user "Alice"
       | resource   |
       | nested.txt |
@@ -34,15 +35,18 @@ Feature: Work with an rclone-crypt encrypted vault
     And "Alice" opens the following file in texteditor
       | resource   |
       | nested.txt |
-    And "Alice" should see the content "nested file content" in editor "TextEditor"
+    Then "Alice" should see the content "nested file content" in editor "TextEditor"
     And "Alice" closes the file viewer
-    And "Alice" opens the following file in texteditor
+    When "Alice" opens the following file in texteditor
       | resource   |
       | parent.txt |
-    And "Alice" should see the content "OpenCloud test text file parent" in editor "TextEditor"
+    Then "Alice" should see the content "OpenCloud test text file parent" in editor "TextEditor"
     And "Alice" closes the file viewer
+    When "Alice" opens the following file in mediaviewer
+      | resource       |
+      | testavatar.png |
+    Then "Alice" is in a media-viewer
     And "Alice" logs out
-
 
   
   @rclone-crypt

--- a/tests/e2e/features/rclone-crypt/vault.feature
+++ b/tests/e2e/features/rclone-crypt/vault.feature
@@ -126,6 +126,22 @@ Feature: Work with an rclone-crypt encrypted vault
     And "Alice" logs out
 
   @rclone-crypt
+  Scenario: Create normal folder with .vault suffix which will be treated as a vault
+    When "Alice" logs in
+    And "Alice" creates the following resources
+      | resource | type   |
+      | my.vault | folder |
+    And "Alice" opens folder "my.vault"
+    And "Alice" sets the vault password "foobar"
+    And "Alice" navigates to the personal space page
+    And "Alice" locks the vault "my.vault"
+    And "Alice" enters the vault "my.vault" with passphrase "foobar"
+    And "Alice" creates the following resources
+      | resource | type   |
+      | lorem    | folder |
+    And "Alice" logs out
+
+  @rclone-crypt
   Scenario: Create a vault inside a project space
     Given "Admin" creates following user using API
       | id    |

--- a/tests/e2e/features/rclone-crypt/vault.feature
+++ b/tests/e2e/features/rclone-crypt/vault.feature
@@ -182,10 +182,10 @@ Feature: Work with an rclone-crypt encrypted vault
     And "Admin" assigns following role to the users using API
       | id    | role        |
       | Alice | Space Admin |
-    When "Alice" logs in
     And "Alice" creates the following project spaces using API
       | name     |
       | ourspace |
+    When "Alice" logs in
     And "Alice" navigates to the project space "ourspace"
     And "Alice" creates the following resources
       | resource                | type    | content             | password |

--- a/tests/e2e/features/rclone-crypt/vault.feature
+++ b/tests/e2e/features/rclone-crypt/vault.feature
@@ -114,7 +114,7 @@ Feature: Work with an rclone-crypt encrypted vault
       | my.vault/hello.txt | txtFile | hello world | foobar   |
     And "Alice" navigates to the personal space page
     When "Alice" renames the following resource
-      | resource | as                 |
+      | resource | as            |
       | my.vault | renamed.vault |
     And "Alice" enters the vault "renamed.vault" with passphrase "foobar"
     Then following resource should be displayed in the files list for user "Alice"
@@ -139,6 +139,39 @@ Feature: Work with an rclone-crypt encrypted vault
     And "Alice" creates the following resources
       | resource | type   |
       | lorem    | folder |
+    And "Alice" logs out
+
+  @rclone-crypt
+  Scenario: Vault with content but no integrity token
+    When "Alice" logs in
+    And "Alice" creates the following resources
+      | resource       | type   | password |
+      | vaultOne.vault | vault  | foobar   |
+      | vaultTwo       | folder |          |
+    And "Alice" enters the vault "vaultOne.vault" with passphrase "foobar"
+    And "Alice" creates the following resources
+      | resource  | type    | content       |
+      | lorem.txt | txtFile | hello content |
+    And "Alice" opens the "files" app
+    And "Alice" renames the following resource
+      | resource       | as       |
+      | vaultOne.vault | vaultOne |
+    And "Alice" copies all resource from folder "vaultOne" to folder "Personal/vaultTwo"
+    And "Alice" navigates to the personal space page
+    And "Alice" opens folder "vaultTwo"
+    Then following resource should not be displayed in the files list for user "Alice"
+      | resource  |
+      | lorem.txt |
+    When "Alice" navigates to the personal space page
+    And "Alice" renames the following resource
+      | resource | as             |
+      | vaultTwo | vaultTwo.vault |
+    And "Alice" enters the vault "vaultTwo.vault" with passphrase "foobar"
+    And "Alice" opens the following file in texteditor
+      | resource  |
+      | lorem.txt |
+    Then "Alice" should see the content "hello content" in editor "TextEditor"
+    And "Alice" closes the file viewer
     And "Alice" logs out
 
   @rclone-crypt

--- a/tests/e2e/features/rclone-crypt/vault.feature
+++ b/tests/e2e/features/rclone-crypt/vault.feature
@@ -46,6 +46,7 @@ Feature: Work with an rclone-crypt encrypted vault
       | resource       |
       | testavatar.png |
     Then "Alice" is in a media-viewer
+    And "Alice" closes the file viewer
     And "Alice" logs out
 
   
@@ -123,3 +124,79 @@ Feature: Work with an rclone-crypt encrypted vault
       | resource  | type |
       | hello.txt | file |
     And "Alice" logs out
+
+  @rclone-crypt
+  Scenario: Create a vault inside a project space
+    Given "Admin" creates following user using API
+      | id    |
+      | Brian |
+    And "Admin" assigns following role to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    When "Alice" logs in
+    And "Alice" creates the following project spaces using API
+      | name     |
+      | ourspace |
+    And "Alice" navigates to the project space "ourspace"
+    And "Alice" creates the following resources
+      | resource                | type    | content             | password |
+      | my.vault                | vault   |                     | foobar   |
+      | my.vault/sub            | folder  |                     | foobar   |
+      | my.vault/hello.txt      | txtFile | hello world         | foobar   |
+    And "Alice" uploads the following resource
+      | resource          | to           | password |
+      | PARENT/parent.txt | my.vault/sub | foobar   |
+      | testavatar.png    | my.vault/sub | foobar   |
+    And "Alice" enters the vault "my.vault" with passphrase "foobar"
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource  |
+      | hello.txt |
+      | sub       |
+    When "Alice" opens the following file in texteditor
+      | resource  |
+      | hello.txt |
+    Then "Alice" should see the content "hello world" in editor "TextEditor"
+    And "Alice" closes the file viewer
+    When "Alice" opens folder "sub"
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource       |
+      | testavatar.png |
+      | parent.txt     |
+    When "Alice" opens the following file in texteditor
+      | resource   |
+      | parent.txt |
+    Then "Alice" should see the content "OpenCloud test text file parent" in editor "TextEditor"
+    And "Alice" closes the file viewer
+    When "Alice" opens the following file in mediaviewer
+      | resource       |
+      | testavatar.png |
+    Then "Alice" is in a media-viewer
+    And "Alice" closes the file viewer
+    When "Alice" navigates to the project space "ourspace"
+    And "Alice" adds following user to the project space
+      | user     | role     | kind  |
+      | Brian    | Can edit | user  |
+    Then "Alice" logs out
+
+    # check vault by space member
+    When "Brian" logs in
+    And "Brian" navigates to the project space "ourspace"
+    And "Brian" enters the vault "my.vault" with passphrase "foobar"
+    And "Brian" opens the following file in texteditor
+      | resource  |
+      | hello.txt |
+    Then "Brian" should see the content "hello world" in editor "TextEditor"
+    And "Brian" closes the file viewer
+    When "Brian" opens folder "sub"
+    And "Brian" opens the following file in texteditor
+      | resource   |
+      | parent.txt |
+    Then "Brian" should see the content "OpenCloud test text file parent" in editor "TextEditor"
+    And "Brian" closes the file viewer
+    When "Brian" opens the following file in mediaviewer
+      | resource       |
+      | testavatar.png |
+    Then "Brian" is in a media-viewer
+    And "Brian" closes the file viewer
+    And "Brian" logs out
+

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -1332,3 +1332,23 @@ When(
     expect(page.url()).toContain('/rclone-crypt/unlock')
   }
 )
+
+When(
+  '{string} sets the vault password {string}',
+  async ({ world }: { world: World }, stepUser: string, password: string): Promise<void> => {
+    const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+
+    await resourceObject.setupVaultPassword(password)
+  }
+)
+
+When(
+  '{string} locks the vault {string}',
+  async ({ world }: { world: World }, stepUser: string, vault: string): Promise<void> => {
+    const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+
+    await resourceObject.lockVault(vault)
+  }
+)

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -1352,3 +1352,18 @@ When(
     await resourceObject.lockVault(vault)
   }
 )
+
+When(
+  '{string} copies all resource from folder {string} to folder {string}',
+  async (
+    { world }: { world: World },
+    stepUser: string,
+    source: string,
+    destination: string
+  ): Promise<void> => {
+    const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+
+    await resourceObject.copyAllTo(source, destination)
+  }
+)

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -2086,7 +2086,7 @@ export const openFileInViewer = async (args: openFileInViewerArgs): Promise<void
           break
         default:
           // in case of error <img> doesn't contain src="blob:https://url"
-          expect(await page.locator(previewImage).getAttribute('src')).toContain('blob')
+          expect(await page.locator(previewImage).getAttribute('src')).toContain('blob:https://')
       }
       break
     }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1072,7 +1072,9 @@ export interface moveOrCopyMultipleResourceArgs extends Omit<moveOrCopyResourceA
   resources: string[]
 }
 
-export const pasteResource = async (args: moveOrCopyResourceArgs): Promise<void> => {
+export const pasteResource = async (
+  args: Omit<moveOrCopyResourceArgs, 'method'>
+): Promise<void> => {
   const { page, resource, newLocation, action, option } = args
   const newLocationPath = newLocation.split('/')
   const frame = page.frameLocator('iframe[title="OpenCloud"]')
@@ -2763,4 +2765,25 @@ const unlockVault = async ({
 export const lockVault = async ({ page, vault }: { page: Page; vault: string }): Promise<void> => {
   await page.locator(util.format(resourceNameSelector, vault)).click({ button: 'right' })
   await page.locator(filesContextLockVaultAction).click()
+}
+
+export const copyAllTo = async ({
+  page,
+  source,
+  destination
+}: {
+  page: Page
+  source: string
+  destination: string
+}): Promise<void> => {
+  await page.locator(util.format(resourceNameSelector, source)).click()
+  await selectAll({ page })
+  await selectBatchAction(page, 'copy')
+
+  await pasteResource({
+    page,
+    resource: source,
+    newLocation: destination,
+    action: 'copy'
+  })
 }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1268,13 +1268,13 @@ export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<
     case 'dropdown-menu': {
       await page.locator(util.format(resourceNameSelector, resourceBase)).click({ button: 'right' })
       await page.locator(util.format(filesContextMenuAction, action)).click()
-      await pasteResource({ page, resource: resourceBase, newLocation, action, method, option })
+      await pasteResource({ page, resource: resourceBase, newLocation, action, option })
       break
     }
     case 'batch-action': {
       await page.locator(util.format(checkBox, resourceBase)).click()
       await selectBatchAction(page, action)
-      await pasteResource({ page, resource: resourceBase, newLocation, action, method, option })
+      await pasteResource({ page, resource: resourceBase, newLocation, action, option })
       break
     }
     case 'sidebar-panel': {
@@ -1283,7 +1283,7 @@ export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<
 
       const actionButtonType = action === 'copy' ? 'Copy to' : 'Move to'
       await page.locator(util.format(sideBarActionButton, actionButtonType)).click()
-      await pasteResource({ page, resource: resourceBase, newLocation, action, method, option })
+      await pasteResource({ page, resource: resourceBase, newLocation, action, option })
       break
     }
     case 'keyboard': {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -109,6 +109,8 @@ const pauseUploadButton = '#pause-upload-info-btn[aria-label="Pause upload"]'
 const resumeUploadButton = '#pause-upload-info-btn[aria-label="Resume upload"]'
 const cancelUploadButton = '#cancel-upload-info-btn'
 const filesContextMenuAction = 'div[id^="context-menu-drop"] button.oc-files-actions-%s-trigger'
+const filesContextLockVaultAction =
+  'div[id^="context-menu-drop"] button.oc-files-actions-lock-vault'
 const highlightedTileCardSelector = '.oc-tile-card-selected'
 const emptyTrashbinButtonSelector = '.oc-files-actions-empty-trash-bin-trigger'
 const resourceLockIcon =
@@ -502,6 +504,14 @@ export const createNewFileOrFolder = async (args: createResourceArgs): Promise<v
       break
     }
   }
+}
+
+export const setupVaultPassword = async ({ page, password }: { page: Page; password: string }) => {
+  await page.locator(vaultSetupPassphraseInput).fill(password)
+  // Committing the passphrase writes the integrity token onto the new folder.
+  const proppatchPromise = page.waitForResponse((resp) => resp.request().method() === 'PROPPATCH')
+  await page.locator(unlockVaultBtn).click()
+  await proppatchPromise
 }
 
 const createDocumentFile = async (
@@ -2748,4 +2758,9 @@ const unlockVault = async ({
   await expect(unlockButton).toBeDisabled()
   await page.locator('#vault-passphrase').fill(passphrase)
   await unlockButton.click()
+}
+
+export const lockVault = async ({ page, vault }: { page: Page; vault: string }): Promise<void> => {
+  await page.locator(util.format(resourceNameSelector, vault)).click({ button: 'right' })
+  await page.locator(filesContextLockVaultAction).click()
 }

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -479,4 +479,12 @@ export class Resource {
   async enterVault({ vault, passphrase }: { vault: string; passphrase: string }): Promise<void> {
     await po.enterVault({ page: this.#page, vault, passphrase })
   }
+
+  async setupVaultPassword(password: string): Promise<void> {
+    await po.setupVaultPassword({ page: this.#page, password })
+  }
+
+  async lockVault(vault: string): Promise<void> {
+    await po.lockVault({ page: this.#page, vault })
+  }
 }

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -487,4 +487,8 @@ export class Resource {
   async lockVault(vault: string): Promise<void> {
     await po.lockVault({ page: this.#page, vault })
   }
+
+  async copyAllTo(source: string, destination: string): Promise<void> {
+    await po.copyAllTo({ page: this.#page, source, destination })
+  }
 }


### PR DESCRIPTION
## Description
Added test scenarios to extend rclone-crypt vault coverage:

- Check image in a vault
- Vault in a project space
- Vault with no content and no integrity token
- Vault with content but no integrity token


## Related Issue
- Closes #3045

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
