### PR TITLE
feat: pulsierende Logo-Animation in der Top Bar

### DIFF
--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -13,7 +13,7 @@
           <oc-image
             :src="logoWithVersion"
             :alt="sidebarLogoAlt"
-            class="oc-logo-image align-middle ml-1 h-[28px] md:h-[36px] w-auto select-none"
+            class="oc-logo-image oc-logo-pulsate align-middle ml-1 h-[28px] md:h-[36px] w-auto select-none"
           />
         </picture>
       </router-link>
@@ -155,6 +155,22 @@ const logoMobileWithVersion = computed(() => {
     image-rendering: crisp-edges;
     image-rendering: pixelated;
     image-rendering: -webkit-optimize-contrast;
+  }
+
+  .oc-logo-pulsate {
+    animation: pulsate 2s infinite ease-in-out;
+  }
+
+  @keyframes pulsate {
+    0% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.05);
+    }
+    100% {
+      transform: scale(1);
+    }
   }
 }
 </style>

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -7,7 +7,7 @@
     <div class="flex items-center flex-start gap-2.5 sm:gap-5 col-1 oc-logo-wrapper">
       <custom-component-target :extension-point="topBarLeftExtensionPoint" />
       <sidebar-nav-mobile class="flex" />
-      <router-link v-if="!hideLogo" :to="homeLink">
+      <router-link v-if="!hideLogo" :to="homeLink" class="flex">
         <picture>
           <source :srcset="logoMobileWithVersion" media="(max-width: 959px)" />
           <oc-image

--- a/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
@@ -72,6 +72,10 @@ describe('Top Bar component', () => {
       expect(wrapper.find(`${componentName}-stub`).exists()).toBeTruthy()
     }
   )
+  it('has a pulsating logo', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.find('.oc-logo-wrapper').html()).toContain('oc-logo-pulsate')
+  })
 })
 
 const getWrapper = ({


### PR DESCRIPTION
Dieses PR fügt eine pulsierende Animation zum Logo in der Top Bar hinzu, um es pregnanter zu machen. Schließt #3128.