### PR TITLE
feat: add pulsating animation to logo in top bar

### DIFF
--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -13,7 +13,7 @@
           <oc-image
             :src="logoWithVersion"
             :alt="sidebarLogoAlt"
-            class="oc-logo-image align-middle ml-1 h-[28px] md:h-[36px] w-auto select-none"
+            class="oc-logo-image oc-logo-pulsate align-middle ml-1 h-[28px] md:h-[36px] w-auto select-none"
           />
         </picture>
       </router-link>
@@ -155,6 +155,22 @@ const logoMobileWithVersion = computed(() => {
     image-rendering: crisp-edges;
     image-rendering: pixelated;
     image-rendering: -webkit-optimize-contrast;
+  }
+
+  .oc-logo-pulsate {
+    animation: pulsate 2s infinite ease-in-out;
+  }
+
+  @keyframes pulsate {
+    0% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.05);
+    }
+    100% {
+      transform: scale(1);
+    }
   }
 }
 </style>

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -7,7 +7,7 @@
     <div class="flex items-center flex-start gap-2.5 sm:gap-5 col-1 oc-logo-wrapper">
       <custom-component-target :extension-point="topBarLeftExtensionPoint" />
       <sidebar-nav-mobile class="flex" />
-      <router-link v-if="!hideLogo" :to="homeLink">
+      <router-link v-if="!hideLogo" :to="homeLink" class="flex">
         <picture>
           <source :srcset="logoMobileWithVersion" media="(max-width: 959px)" />
           <oc-image

--- a/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
@@ -72,6 +72,10 @@ describe('Top Bar component', () => {
       expect(wrapper.find(`${componentName}-stub`).exists()).toBeTruthy()
     }
   )
+  it('has a pulsating logo', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.find('.oc-logo-wrapper').html()).toContain('oc-logo-pulsate')
+  })
 })
 
 const getWrapper = ({


### PR DESCRIPTION
## Summary
Adds a subtle pulsating animation to the OpenCloud logo in the top bar to make it more prominent and eye-catching. The logo now scales from 100% to 105% and back in a smooth 2-second cycle.

## Related Issue
Fixes #3130

## Changes Made
- Added `oc-logo-pulsate` CSS class to the logo image element in `TopBar.vue`
- Implemented CSS keyframe animation that scales the logo using `transform: scale()`
- Added `flex` class to router-link wrapper for proper animation rendering
- Added unit test to verify the pulsating class is applied

## How Has This Been Tested
- [x] Visual inspection in browser - animation runs smoothly
- [x] Unit tests pass
- [x] Animation works on both desktop and mobile viewports
- [x] Logo remains clickable during animation

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (improvement to an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical debt (code improvements, cleanups)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (adding or updating documentation)
- [ ] Maintenance (repository maintenance, dependencies updates)

## Screenshots
The logo now smoothly pulsates with a scale animation from 1.0 to 1.05 and back, making it more noticeable while maintaining a professional appearance.