### PR TITLE
feat(web-pkg): optional unload warning for loading tasks

### DIFF
--- a/packages/web-pkg/src/services/loadingService.ts
+++ b/packages/web-pkg/src/services/loadingService.ts
@@ -17,6 +17,7 @@ export interface LoadingTask {
   id: string
   active: boolean
   state?: LoadingTaskState
+  warnBeforeUnload?: boolean
 }
 
 export interface LoadingTaskCallbackArguments {
@@ -59,17 +60,18 @@ export class LoadingService {
     callback: ({ setProgress }: LoadingTaskCallbackArguments) => Promise<T>,
     {
       debounceTime = DEFAULT_DEBOUNCE_TIME,
-      indeterminate = true
-    }: { debounceTime?: number; indeterminate?: boolean } = {}
+      indeterminate = true,
+      warnBeforeUnload = true
+    }: { debounceTime?: number; indeterminate?: boolean; warnBeforeUnload?: boolean } = {}
   ): Promise<T> {
     const task = {
       id: uuidV4(),
       active: false,
+      warnBeforeUnload,
       ...(!indeterminate && { state: { total: 0, current: 0 } })
     }
 
-    // If no tasks are in progress, attach an event listener for 'beforeunload'.
-    if (!this.tasks.length) {
+    if (warnBeforeUnload && !this.tasks.some((e) => e.warnBeforeUnload)) {
       window.addEventListener('beforeunload', this.onBeforeUnload)
     }
 
@@ -95,7 +97,7 @@ export class LoadingService {
   private removeTask(id: string): void {
     this.tasks = this.tasks.filter((e) => e.id !== id)
 
-    if (!this.tasks.length) {
+    if (!this.tasks.some((e) => e.warnBeforeUnload)) {
       window.removeEventListener('beforeunload', this.onBeforeUnload)
     }
 

--- a/packages/web-pkg/tests/unit/services/loadingService.spec.ts
+++ b/packages/web-pkg/tests/unit/services/loadingService.spec.ts
@@ -38,6 +38,41 @@ describe('LoadingService', () => {
     vi.runAllTimers()
     expect(service.isLoading).toBeFalsy()
   })
+  it('warns before unload while a task is running', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const service = new LoadingService()
+
+    const task = service.addTask(() => Promise.resolve(true))
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+    await task
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+  it('does not warn before unload when a task opts out', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const service = new LoadingService()
+
+    await service.addTask(() => Promise.resolve(true), { warnBeforeUnload: false })
+    expect(addSpy).not.toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+  it('keeps warning while a warning task remains after an opted-out task finished', async () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const service = new LoadingService()
+
+    let finishWarning: (value: boolean) => void
+    const warning = service.addTask(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishWarning = resolve
+        })
+    )
+    await service.addTask(() => Promise.resolve(true), { warnBeforeUnload: false })
+    expect(removeSpy).not.toHaveBeenCalledWith('beforeunload', expect.any(Function))
+
+    finishWarning(true)
+    await warning
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
   it('returns the current progress of a running task', () => {
     const service = new LoadingService()
     const expectedResult = {


### PR DESCRIPTION
`LoadingService.addTask` gains a `warnBeforeUnload` option (default `true`, no behavior change for existing callers). Tasks that opt out never arm the browser's beforeunload confirmation dialog; the listener follows warning tasks instead of any tasks, so an opted-out task cannot detach it while a warning task is still running.

Motivation: long-running tasks that only drive the global progress bar (e.g. a photo slideshow) are not unsaved operations and should not make the browser ask "changes you made may not be saved" on reload.