### PR TITLE
fix(extension-sdk): ignore module federation temp files in the dev watcher

### DIFF
--- a/packages/extension-sdk/src/index.ts
+++ b/packages/extension-sdk/src/index.ts
@@ -147,6 +147,11 @@ export function defineConfig(overrides: ExtensionConfigOverrides = {}) {
           host: 'host.docker.internal',
           port,
           cors: true,
+          // the module federation plugin keeps rewriting .__mf__temp/* during
+          // dev; watching it turns every rewrite into a full page reload
+          watch: {
+            ignored: ['**/.__mf__temp/**']
+          },
           ...(customHttps && { https: customHttps })
         },
         test: {


### PR DESCRIPTION
The federation plugin rewrites `.__mf__temp/*` while the dev server runs; with the default watcher every rewrite triggers a full page reload (with two dev servers of the same app it even reload-loops). Extensions currently have to carry this ignore in their own vite config; ship it as a default.