### PR TITLE
add sanitized SVG rendering in preview app

### DIFF
--- a/packages/web-app-preview/package.json
+++ b/packages/web-app-preview/package.json
@@ -5,7 +5,9 @@
   "description": "OpenCloud Web Preview",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@panzoom/panzoom": "^4.6.1"
+    "@panzoom/panzoom": "^4.6.1",
+    "dompurify": "^3.3.3",
+    "vue-inline-svg": "^4.0.1"
   },
   "devDependencies": {
     "@opencloud-eu/web-test-helpers": "workspace:*"

--- a/packages/web-app-preview/package.json
+++ b/packages/web-app-preview/package.json
@@ -6,7 +6,6 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@panzoom/panzoom": "^4.6.1",
-    "dompurify": "^3.3.3",
     "vue-inline-svg": "^4.0.1"
   },
   "devDependencies": {
@@ -17,6 +16,7 @@
     "@opencloud-eu/web-client": "workspace:*",
     "@opencloud-eu/web-pkg": "workspace:*",
     "@vueuse/core": "^14.0.0",
+    "dompurify": "^3.3.3",
     "lodash-es": "^4.17.21",
     "vue-router": "5.2.0",
     "vue3-gettext": "^4.0.0-beta.1"

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -275,7 +275,9 @@ const loadPreviewImage = async (mediaFile: MediaFile) => {
     // no-thumbnail behaviour (do NOT key this off hasPreview(), or plain
     // images the server has no thumbnail for would download the full
     // original on every open).
-    const useFullImage = mediaFile.isImage && mediaFile.resource.isInVault
+    const useFullImage =
+      mediaFile.isImage &&
+      (mediaFile.resource.isInVault || mediaFile.mimeType.toLowerCase() === 'image/svg+xml')
 
     if (mediaFile.isImage && !useFullImage) {
       mediaFile.url = await previewService.loadPreview(

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -277,7 +277,7 @@ const loadPreviewImage = async (mediaFile: MediaFile) => {
     // original on every open).
     const useFullImage =
       mediaFile.isImage &&
-      (mediaFile.resource.isInVault || mediaFile.mimeType.toLowerCase() === 'image/svg+xml')
+      (mediaFile.resource.isInVault || mediaFile.mimeType === 'image/svg+xml')
 
     if (mediaFile.isImage && !useFullImage) {
       mediaFile.url = await previewService.loadPreview(

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -276,8 +276,7 @@ const loadPreviewImage = async (mediaFile: MediaFile) => {
     // images the server has no thumbnail for would download the full
     // original on every open).
     const useFullImage =
-      mediaFile.isImage &&
-      (mediaFile.resource.isInVault || mediaFile.mimeType === 'image/svg+xml')
+      mediaFile.isImage && (mediaFile.resource.isInVault || mediaFile.mimeType === 'image/svg+xml')
 
     if (mediaFile.isImage && !useFullImage) {
       mediaFile.url = await previewService.loadPreview(

--- a/packages/web-app-preview/src/components/Sources/MediaImage.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isSvgImage" ref="imageContainer" :data-id="file.id">
+  <div v-if="isSvgImage" ref="img" :data-id="file.id">
     <inline-svg
       :key="`media-svg-${file.id}`"
       :src="file.url"
@@ -12,7 +12,7 @@
   </div>
   <img
     v-else
-    ref="imageContainer"
+    ref="img"
     :key="`media-image-${file.id}`"
     :src="file.url"
     :alt="file.name"
@@ -47,7 +47,7 @@ const { file, currentImageRotation } = defineProps<{
 
 const eventBus = useEventBus()
 
-const imageContainer = useTemplateRef<HTMLElement>('imageContainer')
+const img = useTemplateRef<HTMLElement>('img')
 const panzoom = ref<PanzoomObject>()
 const isSvgImage = computed(() => file.mimeType.toLowerCase() === 'image/svg+xml')
 
@@ -105,7 +105,7 @@ const setTransform = ({ scale, x, y }: { scale: number; x: number; y: number }) 
 }
 
 const destroyPanzoom = () => {
-  unref(imageContainer)?.removeEventListener('wheel', onWheelEvent)
+  unref(img)?.removeEventListener('wheel', onWheelEvent)
   unref(panzoom)?.destroy()
   panzoom.value = undefined
 }
@@ -116,7 +116,7 @@ const initPanzoom = async () => {
   // wait for next tick until image is rendered
   await nextTick()
 
-  panzoom.value = Panzoom(unref(imageContainer), {
+  panzoom.value = Panzoom(unref(img), {
     animate: false,
     duration: 300,
     overflow: 'auto',
@@ -124,7 +124,7 @@ const initPanzoom = async () => {
     maxScale: 10,
     setTransform: (_, { scale, x, y }) => setTransform({ scale, x, y })
   } as PanzoomOptions)
-  unref(imageContainer).addEventListener('wheel', onWheelEvent, { passive: false })
+  unref(img).addEventListener('wheel', onWheelEvent, { passive: false })
 }
 
 watch(() => file, initPanzoom, { immediate: true, deep: true })

--- a/packages/web-app-preview/src/components/Sources/MediaImage.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaImage.vue
@@ -1,7 +1,6 @@
 <template>
-  <div ref="imageContainer" :data-id="file.id" class="max-w-full max-h-full pt-4 [&_svg]:size-full">
+  <div v-if="isSvgImage" ref="imageContainer" :data-id="file.id">
     <inline-svg
-      v-if="isSvgImage"
       :key="`media-svg-${file.id}`"
       :src="file.url"
       :transform-source="sanitizeSvgElement"
@@ -10,18 +9,29 @@
       class="max-w-full max-h-full"
       @loaded="initPanzoom"
     />
-    <img
-      v-else
-      :key="`media-image-${file.id}`"
-      :src="file.url"
-      :alt="file.name"
-      class="max-w-full max-h-full"
-    />
   </div>
+  <img
+    v-else
+    ref="imageContainer"
+    :key="`media-image-${file.id}`"
+    :src="file.url"
+    :alt="file.name"
+    :data-id="file.id"
+    class="max-w-full max-h-full pt-4"
+  />
 </template>
 <script setup lang="ts">
 import { MediaFile } from '../../helpers/types'
-import { computed, ref, watch, unref, nextTick, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import {
+  computed,
+  ref,
+  watch,
+  unref,
+  nextTick,
+  onMounted,
+  onBeforeUnmount,
+  useTemplateRef
+} from 'vue'
 import type { PanzoomObject, PanzoomOptions } from '@panzoom/panzoom'
 import Panzoom from '@panzoom/panzoom'
 import DOMPurify from 'dompurify'
@@ -42,7 +52,15 @@ const panzoom = ref<PanzoomObject>()
 const isSvgImage = computed(() => file.mimeType.toLowerCase() === 'image/svg+xml')
 
 function getMediaElement() {
-  return unref(imageContainer)?.querySelector('img,svg') as HTMLElement | null
+  const container = unref(imageContainer)
+  if (!container) {
+    return null
+  }
+  // For SVG, container is a div wrapping the inline-svg component, so we query for the svg element
+  // For regular images, container is the img element itself
+  return container.tagName === 'DIV'
+    ? (container.querySelector('svg') as HTMLElement | null)
+    : container
 }
 
 function sanitizeSvgElement(svg: SVGElement) {

--- a/packages/web-app-preview/src/components/Sources/MediaImage.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaImage.vue
@@ -49,7 +49,7 @@ const eventBus = useEventBus()
 
 const img = useTemplateRef<HTMLElement>('img')
 const panzoom = ref<PanzoomObject>()
-const isSvgImage = computed(() => file.mimeType.toLowerCase() === 'image/svg+xml')
+const isSvgImage = computed(() => file.mimeType === 'image/svg+xml')
 
 function sanitizeSvgElement(svg: SVGElement) {
   DOMPurify.sanitize(svg, {

--- a/packages/web-app-preview/src/components/Sources/MediaImage.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaImage.vue
@@ -51,18 +51,6 @@ const imageContainer = useTemplateRef<HTMLElement>('imageContainer')
 const panzoom = ref<PanzoomObject>()
 const isSvgImage = computed(() => file.mimeType.toLowerCase() === 'image/svg+xml')
 
-function getMediaElement() {
-  const container = unref(imageContainer)
-  if (!container) {
-    return null
-  }
-  // For SVG, container is a div wrapping the inline-svg component, so we query for the svg element
-  // For regular images, container is the img element itself
-  return container.tagName === 'DIV'
-    ? (container.querySelector('svg') as HTMLElement | null)
-    : container
-}
-
 function sanitizeSvgElement(svg: SVGElement) {
   DOMPurify.sanitize(svg, {
     IN_PLACE: true,
@@ -117,7 +105,7 @@ const setTransform = ({ scale, x, y }: { scale: number; x: number; y: number }) 
 }
 
 const destroyPanzoom = () => {
-  getMediaElement()?.removeEventListener('wheel', onWheelEvent)
+  unref(imageContainer)?.removeEventListener('wheel', onWheelEvent)
   unref(panzoom)?.destroy()
   panzoom.value = undefined
 }
@@ -128,12 +116,12 @@ const initPanzoom = async () => {
   // wait for next tick until image is rendered
   await nextTick()
 
-  const mediaElement = getMediaElement()
-  if (!mediaElement) {
+  const container = unref(imageContainer)
+  if (!container) {
     return
   }
 
-  panzoom.value = Panzoom(mediaElement, {
+  panzoom.value = Panzoom(container, {
     animate: false,
     duration: 300,
     overflow: 'auto',
@@ -141,7 +129,7 @@ const initPanzoom = async () => {
     maxScale: 10,
     setTransform: (_, { scale, x, y }) => setTransform({ scale, x, y })
   } as PanzoomOptions)
-  mediaElement.addEventListener('wheel', onWheelEvent, { passive: false })
+  container.addEventListener('wheel', onWheelEvent, { passive: false })
 }
 
 watch(() => file, initPanzoom, { immediate: true, deep: true })

--- a/packages/web-app-preview/src/components/Sources/MediaImage.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaImage.vue
@@ -1,19 +1,34 @@
 <template>
-  <img
-    ref="img"
-    :key="`media-image-${file.id}`"
-    :src="file.url"
-    :alt="file.name"
-    :data-id="file.id"
-    class="max-w-full max-h-full pt-4"
-  />
+  <div ref="imageContainer" :data-id="file.id" class="max-w-full max-h-full pt-4 [&_svg]:size-full">
+    <inline-svg
+      v-if="isSvgImage"
+      :key="`media-svg-${file.id}`"
+      :src="file.url"
+      :transform-source="sanitizeSvgElement"
+      role="img"
+      :aria-label="file.name"
+      class="max-w-full max-h-full"
+      @loaded="initPanzoom"
+    />
+    <img
+      v-else
+      :key="`media-image-${file.id}`"
+      :src="file.url"
+      :alt="file.name"
+      class="max-w-full max-h-full"
+    />
+  </div>
 </template>
 <script setup lang="ts">
 import { MediaFile } from '../../helpers/types'
-import { ref, watch, unref, nextTick, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import { computed, ref, watch, unref, nextTick, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
 import type { PanzoomObject, PanzoomOptions } from '@panzoom/panzoom'
 import Panzoom from '@panzoom/panzoom'
+import DOMPurify from 'dompurify'
 import { useEventBus } from '@opencloud-eu/web-pkg'
+import InlineSvg from 'vue-inline-svg'
+
+InlineSvg.name = 'inline-svg'
 
 const { file, currentImageRotation } = defineProps<{
   file: MediaFile
@@ -22,8 +37,22 @@ const { file, currentImageRotation } = defineProps<{
 
 const eventBus = useEventBus()
 
-const img = useTemplateRef('img')
+const imageContainer = useTemplateRef<HTMLElement>('imageContainer')
 const panzoom = ref<PanzoomObject>()
+const isSvgImage = computed(() => file.mimeType.toLowerCase() === 'image/svg+xml')
+
+function getMediaElement() {
+  return unref(imageContainer)?.querySelector('img,svg') as HTMLElement | null
+}
+
+function sanitizeSvgElement(svg: SVGElement) {
+  DOMPurify.sanitize(svg, {
+    IN_PLACE: true,
+    USE_PROFILES: { svg: true, svgFilters: true }
+  })
+
+  return svg
+}
 
 const onWheelEvent = (e: WheelEvent) => {
   e.preventDefault()
@@ -70,7 +99,7 @@ const setTransform = ({ scale, x, y }: { scale: number; x: number; y: number }) 
 }
 
 const destroyPanzoom = () => {
-  unref(img)?.removeEventListener('wheel', onWheelEvent)
+  getMediaElement()?.removeEventListener('wheel', onWheelEvent)
   unref(panzoom)?.destroy()
   panzoom.value = undefined
 }
@@ -81,7 +110,12 @@ const initPanzoom = async () => {
   // wait for next tick until image is rendered
   await nextTick()
 
-  panzoom.value = Panzoom(unref(img), {
+  const mediaElement = getMediaElement()
+  if (!mediaElement) {
+    return
+  }
+
+  panzoom.value = Panzoom(mediaElement, {
     animate: false,
     duration: 300,
     overflow: 'auto',
@@ -89,7 +123,7 @@ const initPanzoom = async () => {
     maxScale: 10,
     setTransform: (_, { scale, x, y }) => setTransform({ scale, x, y })
   } as PanzoomOptions)
-  unref(img).addEventListener('wheel', onWheelEvent, { passive: false })
+  mediaElement.addEventListener('wheel', onWheelEvent, { passive: false })
 }
 
 watch(() => file, initPanzoom, { immediate: true, deep: true })

--- a/packages/web-app-preview/src/components/Sources/MediaImage.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaImage.vue
@@ -116,12 +116,7 @@ const initPanzoom = async () => {
   // wait for next tick until image is rendered
   await nextTick()
 
-  const container = unref(imageContainer)
-  if (!container) {
-    return
-  }
-
-  panzoom.value = Panzoom(container, {
+  panzoom.value = Panzoom(unref(imageContainer), {
     animate: false,
     duration: 300,
     overflow: 'auto',
@@ -129,7 +124,7 @@ const initPanzoom = async () => {
     maxScale: 10,
     setTransform: (_, { scale, x, y }) => setTransform({ scale, x, y })
   } as PanzoomOptions)
-  container.addEventListener('wheel', onWheelEvent, { passive: false })
+  unref(imageContainer).addEventListener('wheel', onWheelEvent, { passive: false })
 }
 
 watch(() => file, initPanzoom, { immediate: true, deep: true })

--- a/packages/web-app-preview/src/mimeTypes.ts
+++ b/packages/web-app-preview/src/mimeTypes.ts
@@ -8,6 +8,7 @@ export const mimeTypes = [
   'image/gif',
   'image/jpeg',
   'image/png',
+  'image/svg+xml',
   'image/tiff',
   'image/bmp',
   'image/webp',

--- a/packages/web-app-preview/tests/unit/app.spec.ts
+++ b/packages/web-app-preview/tests/unit/app.spec.ts
@@ -126,6 +126,7 @@ describe('Preview app', () => {
 
       const mediaFile = {
         isImage: true,
+        mimeType: 'image/png',
         resource: mock<Resource>({ isInVault: false, hasPreview: () => false })
       }
       await (wrapper.vm as any).loadPreviewImage(mediaFile)
@@ -143,6 +144,7 @@ describe('Preview app', () => {
 
       const mediaFile = {
         isImage: true,
+        mimeType: 'image/png',
         resource: mock<Resource>({ isInVault: true, hasPreview: () => false })
       }
       await (wrapper.vm as any).loadPreviewImage(mediaFile)

--- a/packages/web-app-preview/tests/unit/app.spec.ts
+++ b/packages/web-app-preview/tests/unit/app.spec.ts
@@ -150,6 +150,23 @@ describe('Preview app', () => {
       expect(getUrlForResource).toHaveBeenCalled()
       expect(mocks.$previewService.loadPreview).not.toHaveBeenCalled()
     })
+
+    it('fetches SVG files via getUrlForResource instead of the preview service', async () => {
+      const { wrapper, mocks, getUrlForResource } = createShallowMountWrapper()
+      await nextTick()
+      mocks.$previewService.loadPreview.mockClear()
+      getUrlForResource.mockClear()
+
+      const mediaFile = {
+        isImage: true,
+        mimeType: 'image/svg+xml',
+        resource: mock<Resource>({ isInVault: false, hasPreview: () => true })
+      }
+      await (wrapper.vm as any).loadPreviewImage(mediaFile)
+
+      expect(getUrlForResource).toHaveBeenCalled()
+      expect(mocks.$previewService.loadPreview).not.toHaveBeenCalled()
+    })
   })
 
   describe('Generated "mediaFiles"', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,9 +684,15 @@ importers:
       '@vueuse/core':
         specifier: ^14.0.0
         version: 14.4.0(vue@3.5.41(typescript@6.0.3))
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.4.13
       lodash-es:
         specifier: ^4.17.21
         version: 4.18.1
+      vue-inline-svg:
+        specifier: ^4.0.1
+        version: 4.0.1(patch_hash=29bc386a6e932912ee46485a87911f6ff5409dca9ed70ba0ff32c52d6f56986b)(vue@3.5.41(typescript@6.0.3))
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@vue/compiler-sfc@3.5.41)(pinia@4.0.3(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(vite@8.2.1(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))


### PR DESCRIPTION
## Description

- introduces SVG support in the preview app
- routes SVG files through getUrlForResource instead of the preview service
- renders SVGs inline and sanitizes the SVG DOM with DOMPurify before insertion
- keeps pan/zoom behavior for both inline SVG and raster images
- fixes a raster-image regression where non-SVG images could appear partially zoomed due to shared container behavior
- extends preview unit tests with an SVG loading path assertion
- adds preview app dependencies and lockfile entries for vue-inline-svg and dompurify

## Related Issue

- Fixes n/a

## How Has This Been Tested?

- test environment: local development workspace on macOS
- test case 1: reviewed app preview loading logic and MIME allowlist changes
- test case 2: reviewed inline SVG sanitization hook in MediaImage.vue
- test case 3: reviewed raster-image rendering path after container split for SVG vs non-SVG
- test case 4: automated unit test execution could not be completed in this sandbox due npm registry DNS/network resolution failures (ENOTFOUND)

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that does not break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
