### PR TITLE
fix: improve media controls layout stability

### DIFF
--- a/packages/web-app-preview/src/components/MediaControls.vue
+++ b/packages/web-app-preview/src/components/MediaControls.vue
@@ -4,9 +4,7 @@
     class="preview-details"
     :class="[{ 'lightbox opacity-90 z-1000': isFullScreenModeActivated }]"
   >
-    <oc-bubble-menu
-      class="w-lg max-w-[80vw] flex flex-wrap items-center justify-center gap-x-1 gap-y-1"
-    >
+    <oc-bubble-menu class="max-w-[80vw] flex flex-wrap items-center justify-center gap-x-1 gap-y-1">
       <div class="preview-controls-navigation flex w-full items-center justify-center sm:w-auto">
         <oc-button
           v-oc-tooltip="previousDescription"
@@ -18,7 +16,7 @@
           <oc-icon name="arrow-left-s" fill-type="line" />
         </oc-button>
         <p v-if="!isFolderLoading" class="preview-controls-action-count m-0 px-2 text-center">
-          <span aria-hidden="true" v-text="ariaHiddenFileCount" />
+          <span class="min-w-[60px] block" aria-hidden="true" v-text="ariaHiddenFileCount" />
           <span class="sr-only" v-text="screenreaderFileCount" />
         </p>
         <oc-button


### PR DESCRIPTION
## Summary

Fixes layout stability issues in preview media controls:
- Adds minimum width (60px) to file counter to prevent prev/next buttons from jumping when navigating between files
- Removes `w-lg` class from bubble menu to prevent line breaks when displaying 10+ files

## Related Issue

N/A (bug fix for existing media controls)

## How Has This Been Tested

- **Test environment**: Local development
- **Test cases**:
  - [ ] Navigate between files with single-digit counts (1 of 5)
  - [ ] Navigate between files with double-digit counts (10 of 25)
  - [ ] Verify buttons don't shift position during navigation
  - [ ] Verify no line breaks occur with 10+ files
  - [ ] Test on mobile and desktop viewports

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (improving an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical debt (reducing tech debt, not directly a bug fix or adding a feature)
- [ ] Tests (fix or improvement of tests)
- [ ] Documentation
- [ ] Maintenance