### PR TITLE
fix: render action buttons in move/copy dialogs

### DIFF
--- a/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
+++ b/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
@@ -11,14 +11,7 @@
     />
 
     <div class="flex items-center ml-auto">
-      <oc-button
-        class="mr-4"
-        data-testid="button-cancel"
-        color-role="chrome"
-        appearance="raw-inverse"
-        no-hover
-        @click="emitCancel"
-      >
+      <oc-button class="mr-4" data-testid="button-cancel" appearance="outline" @click="emitCancel">
         {{ $gettext('Cancel') }}
       </oc-button>
       <oc-button
@@ -26,7 +19,6 @@
         key="btn-share"
         class="mr-4"
         data-testid="button-share"
-        color-role="chrome"
         appearance="filled"
         :disabled="isShareLinksButtonDisabled"
         @click="createLinkAction.handler({ resources: selectedFiles, space })"
@@ -38,7 +30,6 @@
           v-if="isLocationPicker"
           data-testid="button-select"
           appearance="filled"
-          color-role="chrome"
           :disabled="isChooseButtonDisabled"
           @click="emitSelect"
         >
@@ -48,7 +39,6 @@
           v-else
           data-testid="button-select"
           appearance="filled"
-          color-role="chrome"
           :disabled="isAttachAsCopyButtonDisabled"
           @click="emitSelect"
         >

--- a/packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts
@@ -160,6 +160,34 @@ describe('EmbedActions', () => {
       expect(mocks.createLinkHandlerMock).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('button appearance', () => {
+    // the actions are rendered on top of the chrome colored area, hence the buttons must not use
+    // the chrome color role themselves. Otherwise they'd be invisible on their own background.
+    it('should render the cancel action as outlined button', () => {
+      const { wrapper } = getWrapper({ isLocationPicker: true })
+      const classes = wrapper.find(selectors.btnCancel).classes()
+
+      expect(classes).toContain('oc-button-secondary-outline')
+      expect(classes).not.toContain('oc-button-chrome')
+    })
+
+    it('should render the select action as filled button', () => {
+      const { wrapper } = getWrapper({ isLocationPicker: true })
+      const classes = wrapper.find(selectors.btnSelect).classes()
+
+      expect(classes).toContain('oc-button-secondary-filled')
+      expect(classes).not.toContain('oc-button-chrome')
+    })
+
+    it('should render the share action as filled button', () => {
+      const { wrapper } = getWrapper({ selectedIds: ['1'] })
+      const classes = wrapper.find(selectors.btnShare).classes()
+
+      expect(classes).toContain('oc-button-secondary-filled')
+      expect(classes).not.toContain('oc-button-chrome')
+    })
+  })
 })
 
 function getWrapper(


### PR DESCRIPTION
## Description

The "Move to" and "Copy to" dialogs open the file list in embed mode. Their action buttons come from `EmbedActions.vue`, which is teleported into `#app-runtime-footer`. That footer sits on the chrome colored area of the application layout (`bg-role-chrome` in `Application.vue`).

The buttons used `color-role="chrome"` themselves:

- the confirming button (`Move here` / `Copy here` / `Choose` / `Save` / `Attach as copy` / `Share link(s)`) was `appearance="filled"` with the chrome role, so it was filled with exactly the color of the area it is placed on and became invisible,
- the cancel button was `appearance="raw-inverse"` with `no-hover`, so it was rendered as plain text without any hover feedback.

Both therefore looked unrendered, as reported.

This changes the actions to the color role and appearances that the other dialogs use (see `UnsavedChangesModal.vue`, `UnlockVault.vue`, `OcModal.vue`): the default `secondary` color role, `outline` for cancel and `filled` for the confirming action. The buttons now render like the ones in the "Rename" dialog in both the light and the dark theme.

Note that the default themes shipped by OpenCloud do not define a `chrome` role, so it falls back to `surfaceContainer` / `onSurface` in the theme store, which is why the filled button was painted in the same color as the surrounding area.

## Related Issue

- Fixes #2975

## How Has This Been Tested?

- test environment: local monorepo checkout, Node 24, pnpm 11
- test case 1: extended `packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts` with a `button appearance` block asserting that the cancel action renders as an outlined button, that the select and share actions render as filled buttons, and that none of them carries the chrome color role class. The three new assertions fail on `main` and pass with this change.
- test case 2: `pnpm test:unit --run packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts` passes (19 tests)
- test case 3: `pnpm check:types` and `pnpm lint` pass without errors, `prettier --check` is clean for the touched files. The full unit test run has 6 pre-existing failures in unrelated files (conflict handling, `ResourcePreview`, `CreateFolderModal`) which also fail on an unmodified `main`.

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
