### PR TITLE
fix: only mark shares nav item active on shares routes

### DIFF
--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -22,7 +22,7 @@ import { buildRoutes } from '@opencloud-eu/web-pkg'
 
 // dirty: importing view from other extension within project
 import SearchResults from '../../web-app-search/src/views/List.vue'
-import { isPersonalSpaceResource, isShareSpaceResource } from '@opencloud-eu/web-client'
+import { isPersonalSpaceResource } from '@opencloud-eu/web-client'
 import { unref } from 'vue'
 import { extensionPoints } from './extensionPoints'
 import { useGettext } from 'vue3-gettext'
@@ -81,14 +81,9 @@ export const navItems: ClassicApplicationScript['navItems'] = ({ $ability, $gett
       route: {
         path: `/${appInfo.id}/shares`
       },
-      isActive: () => {
-        const space = spacesStores.currentSpace
-        return !space || isShareSpaceResource(space)
-      },
       activeFor: [
         { path: `/${appInfo.id}/spaces/share` },
-        { path: `/${appInfo.id}/spaces/ocm-share` },
-        { path: `/${appInfo.id}/spaces/personal` }
+        { path: `/${appInfo.id}/spaces/ocm-share` }
       ],
       isVisible() {
         return capabilityStore.sharingApiEnabled !== false

--- a/packages/web-app-files/tests/unit/index.spec.ts
+++ b/packages/web-app-files/tests/unit/index.spec.ts
@@ -1,10 +1,41 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { navItems } from '../../src/index'
-import { AppNavigationItem, GlobalProperties, useSpacesStore } from '@opencloud-eu/web-pkg'
-import { SpaceResource } from '@opencloud-eu/web-client'
+import {
+  AppNavigationItem,
+  GlobalProperties,
+  NavItem,
+  SidebarNavExtension,
+  useExtensionRegistry,
+  useNavItems,
+  useSpacesStore
+} from '@opencloud-eu/web-pkg'
+import { Ability, SpaceResource } from '@opencloud-eu/web-client'
+import { Capabilities } from '@opencloud-eu/web-client/ocs'
 import { mock } from 'vitest-mock-extended'
+import { computed, ComputedRef, defineComponent, unref } from 'vue'
+import { createRouter, defaultPlugins, mount } from '@opencloud-eu/web-test-helpers'
+import { RouteRecordRaw } from 'vue-router'
 
 const callableNavItems = navItems as (args: GlobalProperties) => AppNavigationItem[]
+
+const personalSpace = mock<SpaceResource>({
+  id: '1',
+  driveType: 'personal',
+  driveAlias: 'personal/admin',
+  isOwner: () => true
+})
+
+const routes: RouteRecordRaw[] = [
+  'files/favorites',
+  'files/shares',
+  'files/spaces/projects',
+  'files/spaces/:driveAliasAndItem(.*)?',
+  'files/trash/overview'
+].map((path) => ({
+  path: `/${path}`,
+  name: path,
+  component: defineComponent({ template: '<div />' })
+}))
 
 describe('Web app files', () => {
   beforeEach(() => {
@@ -32,5 +63,92 @@ describe('Web app files', () => {
         expect(items[0].isVisible()).toBeFalsy()
       })
     })
+
+    describe('active state', () => {
+      it('marks "Spaces" as active on the project spaces overview', async () => {
+        const { getActiveNames } = await getNavItemsWrapper({ path: '/files/spaces/projects' })
+        expect(getActiveNames()).toEqual(['Spaces'])
+      })
+      it.each(['/files/shares', '/files/spaces/share/some-share'])(
+        'marks "Shares" as active on the shares route %s',
+        async (path) => {
+          const { getActiveNames } = await getNavItemsWrapper({ path })
+          expect(getActiveNames()).toEqual(['Shares'])
+        }
+      )
+      it('marks only "Personal" as active when navigating from the project spaces overview to the personal space', async () => {
+        const { router, getActiveNames } = await getNavItemsWrapper({
+          path: '/files/spaces/projects'
+        })
+
+        // no space has been resolved yet, which is the case right after a page reload
+        await router.push('/files/spaces/personal')
+
+        expect(getActiveNames()).toEqual(['Personal'])
+      })
+    })
   })
 })
+
+async function getNavItemsWrapper({ path }: { path: string }) {
+  const plugins = defaultPlugins({
+    piniaOptions: {
+      stubActions: false,
+      authState: { userContextReady: true },
+      capabilityState: {
+        capabilities: { spaces: mock<Capabilities['capabilities']['spaces']>({ projects: true }) }
+      }
+    }
+  })
+
+  const spacesStore = useSpacesStore()
+  spacesStore.spacesInitialized = true
+  spacesStore.spaces = [personalSpace]
+
+  const items = callableNavItems(
+    mock<GlobalProperties>({
+      $ability: mock<Ability>({ can: () => true }),
+      $gettext: (msg: string) => msg
+    })
+  )
+  useExtensionRegistry().registerExtensions(
+    computed<SidebarNavExtension[]>(() =>
+      items.map((navItem, index) => ({
+        id: `app.files.navItem-${index}`,
+        type: 'sidebarNav',
+        navItem,
+        extensionPointIds: ['app.files.navItems']
+      }))
+    )
+  )
+
+  const router = createRouter({ routes })
+  await router.push(path)
+  await router.isReady()
+
+  let resolvedNavItems: ComputedRef<NavItem[]>
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        resolvedNavItems = useNavItems().navItems
+      },
+      template: '<div />'
+    }),
+    {
+      global: {
+        plugins: [...plugins, router],
+        provide: { $router: router },
+        mocks: { $router: router }
+      }
+    }
+  )
+
+  return {
+    wrapper,
+    router,
+    getActiveNames: () =>
+      unref(resolvedNavItems)
+        .filter(({ active }) => active)
+        .map(({ name }) => name)
+  }
+}


### PR DESCRIPTION
## Description

The "Shares" sidebar nav item stayed filled (active) while browsing the personal space.

The item listed `/${appInfo.id}/spaces/personal` among its `activeFor` paths. That entry is a leftover from the "full share owner paths" feature (#9721 in the old repository), where a received share could be opened below the owner's personal path, and where the matching `isActive` check still had a `!space?.isOwner(user)` branch to go with it. That branch is long gone, but the path stayed.

What was left was an `isActive` check of `!space || isShareSpaceResource(space)`. The `!space` part is true whenever no current space is set in the spaces store, which is exactly the situation while a space is still being resolved, for example directly after a page reload on a route that does not resolve a space (like the project spaces overview). Combined with the `activeFor` entry above, the personal space route then matched the "Shares" item as well, so both "Personal" and "Shares" were rendered as active.

The nav item now derives its active state from its own routes only (`/files/shares`, `/files/spaces/share`, `/files/spaces/ocm-share`), which are the only locations it should ever be active for. The now obsolete `isActive` check has been removed, which also makes the active state independent of asynchronously resolved store state.

## Related Issue

- Fixes #2989

## How Has This Been Tested?

- test environment: local dev machine, `pnpm check:types`, `pnpm lint`, `pnpm format:check` and the unit test suite
- test case 1: navigate to "Spaces", reload the page, then go to "Personal": only "Personal" is active, the "Shares" icon is no longer filled (covered by a new unit test that drives `useNavItems` through a real router from `/files/spaces/projects` to `/files/spaces/personal`)
- test case 2: "Shares" is still active on `/files/shares` and on a received share below `/files/spaces/share/...` (new unit test)
- test case 3: "Spaces" is still active on the project spaces overview (new unit test)
- test case 4: full unit test suite passes, apart from four spec files that already fail on `main` on this machine for unrelated reasons (Windows path separators in `conflictDialog`, `resourcesTransfer`, `ResourcePreview` and `CreateFolderModal`)

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
