### PR TITLE
Fix empty right sidebar when opening space context menu

### DIFF
--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -329,6 +329,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
       panel: {
         name: 'space-share',
         icon: 'group',
+        iconFillType: 'line',
         title: () => $gettext('Members'),
         component: markRaw(SharesPanel),
         componentAttrs: () => ({

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="oc-space-details-sidebar" class="p-2">
+  <div v-if="resource" id="oc-space-details-sidebar" class="p-2">
     <oc-spinner
       v-if="imagesLoading.includes(resource.id)"
       :aria-label="$gettext('Space image is loading')"
@@ -141,8 +141,12 @@ const size = computed(() => {
 })
 
 watch(
-  () => unref(resource).spaceImageData,
+  () => unref(resource)?.spaceImageData,
   async () => {
+    if (!unref(resource)) {
+      return
+    }
+
     spaceImage.value = await loadPreview({
       space: unref(resource),
       resource: unref(resource).spaceImageData


### PR DESCRIPTION
## Description

This fixes a regression in the Spaces right sidebar where opening the 3-dot context menu could render an empty sidebar and empty menu state.

Changes included in this PR:
- guard SpaceDetails rendering when resource is not available yet
- guard the space image watcher when resource is missing
- make the watcher source optional with resource?.spaceImageData
- set iconFillType to line for the Members panel selector (sidebar-panel-space-share-select)

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3150

## How Has This Been Tested?

- test environment: local workspace
- test case 1: enable right sidebar, navigate to Spaces, open the 3-dot menu for a space
- test case 2: verify sidebar content and menu content render correctly
- test case 3: open Members panel selector and verify group icon uses line style
- automated tests: executed locally by author and passing

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that does not break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)