### PR TITLE
e2e-test: cover favorite SSE events across tabs

### DIFF
--- a/tests/e2e/features/smoke/sse.feature
+++ b/tests/e2e/features/smoke/sse.feature
@@ -10,7 +10,10 @@ Feature: server sent events
       | item-trashed            | x |
       | item-restored           | x |
       | item-moved              | x |
+      | item-favorite-added     | x |
+      | item-favorite-removed   | x |
       | folder-created          | x |
+      | space-created           | x |
       | space-member-added      | x |
       | space-member-removed    | x |
       | space-share-updated     | x |
@@ -44,6 +47,9 @@ Feature: server sent events
     And "Alice" creates the following project space using API
       | name      | id        |
       | Marketing | marketing |
+
+    # space-created
+    Then "Alice" should get "space-created" SSE event
 
     # space-member-added
     When "Alice" adds the following member to the space "Marketing" using API
@@ -284,4 +290,45 @@ Feature: server sent events
       | simple-renamed.pdf |
 
     And "Brian" logs out
+    And "Alice" logs out
+
+  @webkit-skip
+  Scenario: favorite sse events update the favorites view across tabs
+    Given "Alice" creates the following file into personal space using API
+      | pathToFile  | content     |
+      | example.txt | lorem ipsum |
+    And "Alice" logs in
+
+    # tab 2. open the favorites page in the second tab
+    And "Alice" opens a new tab
+    And "Alice" navigates to the favorites page
+    And following resource should not be displayed in the files list for user "Alice"
+      | resource    |
+      | example.txt |
+
+    # tab 1. item-favorite-added - mark as favorite
+    When "Alice" switches to tab 1
+    And "Alice" marks the following resource as favorite using "context menu"
+      | resource    |
+      | example.txt |
+    Then "Alice" should get "item-favorite-added" SSE event
+    
+    # tab 2 check that the resource is displayed without a reload
+    When "Alice" switches to tab 2
+    Then following resource should be displayed in the files list for user "Alice"
+      | resource    |
+      | example.txt |
+
+    # tab 1. item-favorite-removed - unmark as favorite
+    When "Alice" switches to tab 1
+    And "Alice" removes the following resource from favorites using "context menu"
+      | resource    |
+      | example.txt |
+    Then "Alice" should get "item-favorite-removed" SSE event
+
+    # tab 2 check that the resource is not displayed without a reload
+    When "Alice" switches to tab 2
+    Then following resource should not be displayed in the files list for user "Alice"
+      | resource    |
+      | example.txt |
     And "Alice" logs out

--- a/tests/e2e/steps/ui/session.ts
+++ b/tests/e2e/steps/ui/session.ts
@@ -98,6 +98,24 @@ When(
 )
 
 When(
+  '{string} opens a new tab',
+  async function ({ world }: { world: World }, stepUser: string): Promise<void> {
+    const actor = world.actorsEnvironment.getActor({ key: stepUser })
+    await actor.newTab()
+    await actor.page.goto(appConfig.baseUrl)
+    await actor.page.locator('#web-content').waitFor()
+  }
+)
+
+When(
+  '{string} switches to tab {int}',
+  async function ({ world }: { world: World }, stepUser: string, tab: number): Promise<void> {
+    const actor = world.actorsEnvironment.getActor({ key: stepUser })
+    await actor.switchTab(tab - 1)
+  }
+)
+
+When(
   '{string} closes the current tab',
   async function ({ world }: { world: World }, stepUser: string): Promise<void> {
     const actor = world.actorsEnvironment.getActor({ key: stepUser })

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -58,6 +58,16 @@ export class ActorEnvironment extends EventEmitter implements Actor {
     return page
   }
 
+  public async switchTab(index: number): Promise<Page> {
+    const page = this.tabs[index]
+    if (!page) {
+      throw new Error(`No tab found at index ${index}. Open tabs: ${this.tabs.length}`)
+    }
+    this.page = page
+    await page.bringToFront()
+    return page
+  }
+
   public async closeCurrentTab(): Promise<void> {
     await this.page.close()
     this.tabs.pop()

--- a/tests/e2e/support/types.ts
+++ b/tests/e2e/support/types.ts
@@ -18,6 +18,7 @@ export interface Actor {
   close(): Promise<void>
   savePage(page: Page): void
   newTab(): Promise<Page>
+  switchTab(index: number): Promise<Page>
   closeCurrentTab(): Promise<void>
 }
 


### PR DESCRIPTION
related https://github.com/opencloud-eu/qa/issues/103
It checks the SSE events `item-favorite-added` and `item-favorite-removed`.  

 - user opens 2 tabs
 - opens the favorites page on the 2 tab
 - adds/removes a resource from favorites on the 1 tab

Result: user receives SSE events. Favorites appear/disappear on the favorites page without the page being reloaded
<img width="1691" height="795" alt="Screenshot 2026-08-18 at 13 05 03" src="https://github.com/user-attachments/assets/b79a5389-df5b-46ac-9885-1346e523a359" />

