### PR TITLE
test(e2e): add test for saving file as different

### DIFF
--- a/tests/e2e/features/file-action/saveAs.feature
+++ b/tests/e2e/features/file-action/saveAs.feature
@@ -1,0 +1,116 @@
+Feature: rename
+  As a user
+  I want to save current resource as a new resource
+  So I can have a copy of the resource
+
+  Scenario: save as resources in personal space
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+    And "Admin" assigns following role to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following project spaces using API
+      | name       |
+      | cool-space |
+    And "Alice" creates the following folders in personal space using API
+      | name       |
+      | top-folder |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile   | content     |
+      | textfile.txt | lorem ipsum |
+    When "Alice" logs in
+    And "Alice" opens the following file in texteditor
+      | resource     |
+      | textfile.txt |
+    Then "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    When "Alice" saves the current file as "textfile.txt"
+    Then file "textfile (1).txt" should be opened in texteditor for user "Alice"
+    And "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    When "Alice" switches to tab 1
+    And "Alice" closes the file viewer
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource         |
+      | textfile.txt     |
+      | textfile (1).txt |
+    And "Alice" closes the current tab
+    And "Alice" closes the file viewer
+    And "Alice" opens the following file in texteditor
+      | resource     |
+      | textfile.txt |
+    When "Alice" saves the current file as "top-folder/newfile.txt"
+    Then file "newfile.txt" should be opened in texteditor for user "Alice"
+    And "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    When "Alice" closes the file viewer
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource    |
+      | newfile.txt |
+    When "Alice" opens the following file in texteditor
+      | resource    |
+      | newfile.txt |
+    And "Alice" saves the current file as "Project/cool-space/newfile.txt"
+    Then file "newfile.txt" should be opened in texteditor for user "Alice"
+    And "Alice" closes the current tab
+    And "Alice" closes the file viewer
+    When "Alice" navigates to the project space "cool-space"
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource    |
+      | newfile.txt |
+    And "Alice" logs out
+
+
+  Scenario: save as resources in project space
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+    And "Admin" assigns following role to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following project spaces using API
+      | name       |
+      | cool-space |
+    And "Alice" creates the following folders in space "cool-space" using API
+      | name       |
+      | top-folder |
+    And "Alice" creates the following files in space "cool-space" using API
+      | name         | content     |
+      | textfile.txt | lorem ipsum |
+    When "Alice" logs in
+    And "Alice" navigates to the project space "cool-space"
+    And "Alice" opens the following file in texteditor
+      | resource     |
+      | textfile.txt |
+    Then "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    When "Alice" saves the current file as "textfile.txt"
+    Then file "textfile (1).txt" should be opened in texteditor for user "Alice"
+    And "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    When "Alice" switches to tab 1
+    And "Alice" closes the file viewer
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource         |
+      | textfile.txt     |
+      | textfile (1).txt |
+    And "Alice" closes the current tab
+    And "Alice" closes the file viewer
+    And "Alice" opens the following file in texteditor
+      | resource     |
+      | textfile.txt |
+    When "Alice" saves the current file as "top-folder/newfile.txt"
+    Then file "newfile.txt" should be opened in texteditor for user "Alice"
+    And "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    When "Alice" closes the file viewer
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource    |
+      | newfile.txt |
+    When "Alice" opens the following file in texteditor
+      | resource    |
+      | newfile.txt |
+    And "Alice" saves the current file as "Personal/fromspacefile.txt"
+    Then file "fromspacefile.txt" should be opened in texteditor for user "Alice"
+    And "Alice" closes the current tab
+    And "Alice" closes the file viewer
+    When "Alice" navigates to the personal space page
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource          |
+      | fromspacefile.txt |
+    And "Alice" logs out

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -1384,3 +1384,25 @@ Then(
     await expect(page.locator('.tiptap.ProseMirror')).toContainText(text)
   }
 )
+
+When(
+  '{string} saves the current file as {string}',
+  async ({ world }: { world: World }, stepUser: string, newPath: string): Promise<void> => {
+    const actor = world.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page: actor.page })
+
+    const newPage = await resourceObject.saveAs(newPath)
+    // change current active page
+    actor.savePage(newPage)
+  }
+)
+
+Then(
+  'file {string} should be opened in texteditor for user {string}',
+  async ({ world }: { world: World }, filename: string, stepUser: string): Promise<void> => {
+    const actor = world.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page: actor.page })
+    const actualFilename = await resourceObject.getTopBarFilename()
+    expect(actualFilename).toBe(filename)
+  }
+)

--- a/tests/e2e/steps/ui/session.ts
+++ b/tests/e2e/steps/ui/session.ts
@@ -111,7 +111,7 @@ When(
   '{string} switches to tab {int}',
   async function ({ world }: { world: World }, stepUser: string, tab: number): Promise<void> {
     const actor = world.actorsEnvironment.getActor({ key: stepUser })
-    await actor.switchTab(tab - 1)
+    await actor.switchTab(tab)
   }
 )
 

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -5,6 +5,7 @@ import { ActorOptions } from './shared'
 
 export class ActorEnvironment extends EventEmitter implements Actor {
   private readonly options: ActorOptions
+  private currentTabIndex: number
   public context: BrowserContext
   public page: Page
   public tabs: Page[] = []
@@ -12,6 +13,7 @@ export class ActorEnvironment extends EventEmitter implements Actor {
   constructor(options: ActorOptions) {
     super()
     this.options = options
+    this.currentTabIndex = 0
   }
 
   async setup(): Promise<void> {
@@ -46,36 +48,41 @@ export class ActorEnvironment extends EventEmitter implements Actor {
   }
 
   public savePage(newPage: Page) {
-    this.tabs.push(newPage)
+    const tabsLength = this.tabs.push(newPage)
     // set the new page
     this.page = newPage
+    this.currentTabIndex = tabsLength - 1
   }
 
   public async newTab(): Promise<Page> {
     const page: Page = await this.context.newPage()
-    this.tabs.push(page)
+    const tabsLength = this.tabs.push(page)
     this.page = page
+    this.currentTabIndex = tabsLength - 1
     return page
   }
 
   public async switchTab(index: number): Promise<Page> {
+    index = index - 1
     const page = this.tabs[index]
     if (!page) {
       throw new Error(`No tab found at index ${index}. Open tabs: ${this.tabs.length}`)
     }
     this.page = page
     await page.bringToFront()
+    this.currentTabIndex = index
     return page
   }
 
   public async closeCurrentTab(): Promise<void> {
     await this.page.close()
-    this.tabs.pop()
+    this.tabs.splice(this.currentTabIndex, 1)
+
     if (this.tabs.length === 0) {
       this.page = null
       return
     }
-    this.page = this.tabs[this.tabs.length - 1]
+    this.page = this.tabs.at(-1)
   }
 
   async close(): Promise<void> {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -23,6 +23,7 @@ const downloadFolderButtonSideBar =
 const downloadButtonBatchAction = '.oc-files-actions-download-archive-trigger'
 const appBarContextMenu = '#oc-openfile-contextmenu-trigger'
 const appBarDownloadFileButton = '#oc-openfile-contextmenu .oc-files-actions-download-file-trigger'
+const appBarSaveAsButton = '#oc-openfile-contextmenu .oc-files-actions-save-as-trigger'
 const deleteButtonBatchAction = '.oc-files-actions-delete-trigger'
 const createSpaceFromResourceAction =
   '[role="menuitem"].oc-files-actions-create-space-from-resource-trigger'
@@ -136,6 +137,9 @@ const mobileViewmodeSwitchDropdown = '#viewmode-switch-drop'
 const pdfViewerContainer = '#pdf-viewer .pdf-viewer'
 const textEditorContainer = '.text-editor-provider .ProseMirror'
 
+// OpenCloud iframe
+const opencloudFrame = 'iframe[title="OpenCloud"]'
+
 // online office locators
 // Collabora
 const collaboraDocPermissionModeSelector = '#permissionmode-container'
@@ -196,7 +200,7 @@ export const clickResourceInFrame = async ({
   path: string
 }): Promise<void> => {
   const paths = path.split('/')
-  const frame = page.frameLocator('iframe[title="OpenCloud"]')
+  const frame = page.frameLocator(opencloudFrame)
   await expect(frame.locator('body')).toBeVisible()
 
   for (const name of paths) {
@@ -1079,7 +1083,7 @@ export const pasteResource = async (
 ): Promise<void> => {
   const { page, resource, newLocation, action, option } = args
   const newLocationPath = newLocation.split('/')
-  const frame = page.frameLocator('iframe[title="OpenCloud"]')
+  const frame = page.frameLocator(opencloudFrame)
 
   for (const path of newLocationPath) {
     switch (path) {
@@ -1172,7 +1176,7 @@ export const moveOrCopyMultipleResources = async (
       // after selecting multiple resources, resources can be copied or moved by clicking on any of the selected resources
       await page.locator(highlightedTileCardSelector).first().click({ button: 'right' })
       await page.locator(util.format(filesContextMenuAction, action)).click()
-      const frame = page.frameLocator('iframe[title="OpenCloud"]')
+      const frame = page.frameLocator(opencloudFrame)
 
       const newLocationPath = newLocation.split('/')
       for (const path of newLocationPath) {
@@ -1197,7 +1201,7 @@ export const moveOrCopyMultipleResources = async (
     case 'batch-action': {
       await selectBatchAction(page, action)
 
-      const frame = page.frameLocator('iframe[title="OpenCloud"]')
+      const frame = page.frameLocator(opencloudFrame)
 
       const newLocationPath = newLocation.split('/')
       for (const path of newLocationPath) {
@@ -2794,4 +2798,66 @@ export const copyAllTo = async ({
     newLocation: destination,
     action: 'copy'
   })
+}
+
+export const saveAs = async ({ page, newPath }: { page: Page; newPath: string }): Promise<Page> => {
+  await page.locator(appBarContextMenu).click()
+  await page.locator(appBarSaveAsButton).click()
+
+  const frame = page.frameLocator(opencloudFrame)
+  const parentPath = path.dirname(newPath)
+  let filename = path.basename(newPath)
+  if (parentPath !== '.') {
+    for (const path of parentPath.split('/')) {
+      switch (path) {
+        case 'Personal': {
+          await frame.locator('a[data-nav-name="files-spaces-generic"]').click()
+          break
+        }
+
+        case 'Project': {
+          await frame.locator('a[data-nav-name="files-spaces-projects"]').click()
+          break
+        }
+
+        case 'Shares': {
+          await frame.locator('a[data-nav-name="files-shares"]').click()
+          break
+        }
+
+        default: {
+          await clickResourceInFrame({ page, path })
+        }
+      }
+    }
+  }
+
+  const newFilenameInput = frame.locator('#app-runtime-footer input.oc-text-input')
+  await newFilenameInput.clear()
+  await newFilenameInput.fill(filename)
+
+  const currentFilename = await getTopBarFilename(page)
+  if (currentFilename === newPath) {
+    const filenameExt = path.extname(newPath)
+    const newFilename = path.basename(newPath, filenameExt)
+    // new file will be: <filename> (1).<ext>
+    filename = `${newFilename} (1)${filenameExt}`
+  }
+
+  const [newPage] = await Promise.all([
+    page.context().waitForEvent('page'),
+    page.waitForResponse(
+      (resp) =>
+        resp.url().endsWith(encodeURIComponent(filename)) &&
+        resp.status() === 201 &&
+        resp.request().method() === 'PUT'
+    ),
+    frame.getByTestId('button-select').click()
+  ])
+
+  return newPage
+}
+
+export const getTopBarFilename = (page: Page): Promise<string> => {
+  return page.locator(topbarFilenameSelector).getAttribute('data-test-resource-name')
 }

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -495,4 +495,12 @@ export class Resource {
   async copyAllTo(source: string, destination: string): Promise<void> {
     await po.copyAllTo({ page: this.#page, source, destination })
   }
+
+  saveAs(newPath: string): Promise<Page> {
+    return po.saveAs({ page: this.#page, newPath })
+  }
+
+  getTopBarFilename(): Promise<string> {
+    return po.getTopBarFilename(this.#page)
+  }
 }


### PR DESCRIPTION
## Description
Added test scenarios for `Save as` file action. Scenarios covered for personal and project spaces.

## Related Issue
- Fixes https://github.com/opencloud-eu/qa/issues/100

## How Has This Been Tested?
- test environment: :computer: 

## Types of changes
- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
