### PR TITLE
Rename extensions to apps in admin and account settings

### DIFF
--- a/packages/web-app-admin-settings/src/components/Extensions/ExtensionsList.vue
+++ b/packages/web-app-admin-settings/src/components/Extensions/ExtensionsList.vue
@@ -5,7 +5,7 @@
     img-src="images/empty-states/empty-extensions.svg"
   >
     <template #message>
-      <span v-text="$gettext('No extensions found')" />
+      <span v-text="$gettext('No apps found')" />
     </template>
     <template #callToAction>
       <span v-text="$gettext('Try refining the search term or filters to get results')" />
@@ -25,7 +25,7 @@
   >
     <template #name="{ item }">
       <div class="flex items-center gap-2">
-        <oc-icon :name="item.icon || 'puzzle'" size-class="size-5" fill-type="line" />
+        <oc-icon :name="item.icon || 'store'" size-class="size-5" fill-type="line" />
         <span v-text="item.name" />
       </div>
     </template>

--- a/packages/web-app-admin-settings/src/index.ts
+++ b/packages/web-app-admin-settings/src/index.ts
@@ -108,7 +108,7 @@ export const routes: ClassicApplicationScript['routes'] = ({ $ability, $gettext 
     }
   },
   {
-    path: '/extensions',
+    path: '/apps',
     name: 'admin-settings-extensions',
     component: Extensions,
     beforeEnter: (to, from, next) => {
@@ -119,7 +119,7 @@ export const routes: ClassicApplicationScript['routes'] = ({ $ability, $gettext 
     },
     meta: {
       authContext: 'user',
-      title: $gettext('Extensions')
+      title: $gettext('Apps')
     }
   }
 ]
@@ -170,11 +170,11 @@ export const navItems: ClassicApplicationScript['navItems'] = ({ $ability, $gett
     priority: 40
   },
   {
-    name: $gettext('Extensions'),
-    icon: 'puzzle',
+    name: $gettext('Apps'),
+    icon: 'store',
     fillType: 'line',
     route: {
-      path: `/${APPID}/extensions?`
+      path: `/${APPID}/apps?`
     },
     isVisible: () => {
       return $ability.can('read-all', 'Setting')

--- a/packages/web-app-admin-settings/src/views/Extensions.vue
+++ b/packages/web-app-admin-settings/src/views/Extensions.vue
@@ -12,7 +12,7 @@
           v-model="filterTerm"
           class="w-3xs"
           :label="$gettext('Search')"
-          :placeholder="$gettext('Search for extensions')"
+          :placeholder="$gettext('Search for apps')"
           button-hidden
           :is-rounded="false"
         />
@@ -27,10 +27,10 @@
         img-src="images/empty-states/empty-extensions.svg"
       >
         <template #message>
-          <span v-text="$gettext('No extensions found')" />
+          <span v-text="$gettext('No apps found')" />
         </template>
         <template #callToAction>
-          <span v-text="$gettext('Install an extension and it will show up here')" />
+          <span v-text="$gettext('Install an app and it will show up here')" />
         </template>
       </no-content-message>
       <extensions-list v-else :extensions="extensions" :filter-term="filterTerm" />
@@ -82,8 +82,8 @@ const extensions = computed<ExtensionInfo[]>(() => {
 
 const breadcrumbs = computed(() => [
   {
-    text: $gettext('Extensions'),
-    to: { path: '/admin-settings/extensions' }
+    text: $gettext('Apps'),
+    to: { path: '/admin-settings/apps' }
   }
 ])
 </script>

--- a/packages/web-runtime/src/pages/account/accountExtensionLayout.vue
+++ b/packages/web-runtime/src/pages/account/accountExtensionLayout.vue
@@ -2,7 +2,7 @@
   <div id="account-extension">
     <no-content-message v-if="!extension" id="account-extensions-empty" icon="emotion-unhappy">
       <template #message>
-        <span v-text="$gettext('Extension not found')" />
+        <span v-text="$gettext('App not found')" />
       </template>
     </no-content-message>
     <component :is="extension.content" v-else />

--- a/packages/web-runtime/src/pages/account/accountExtensions.vue
+++ b/packages/web-runtime/src/pages/account/accountExtensions.vue
@@ -1,22 +1,18 @@
 <template>
   <div id="account-extensions">
-    <h1 class="text-lg mt-2" v-text="$gettext('Extensions')" />
+    <h1 class="text-lg mt-2" v-text="$gettext('Apps')" />
     <no-content-message
       v-if="!extensionPointsWithUserPreferences.length"
       id="account-extensions-empty"
-      icon="puzzle-2"
+      icon="store"
     >
       <template #message>
-        <span v-text="$gettext('No extensions available')" />
+        <span v-text="$gettext('No apps available')" />
       </template>
     </no-content-message>
     <account-table
       v-else
-      :fields="[
-        $gettext('Extension name'),
-        $gettext('Extension description'),
-        $gettext('Extension value')
-      ]"
+      :fields="[$gettext('App name'), $gettext('App description'), $gettext('App value')]"
       class="account-page-extensions"
     >
       <oc-table-tr

--- a/packages/web-runtime/src/pages/account/accountLayout.vue
+++ b/packages/web-runtime/src/pages/account/accountLayout.vue
@@ -53,9 +53,9 @@ const navItems = computed(() => {
       priority: 20
     },
     {
-      name: $gettext('Extensions'),
+      name: $gettext('Apps'),
       route: { name: 'account-extensions' },
-      icon: 'puzzle-2',
+      icon: 'store',
       active: unref(isAccountExtensionsActive),
       priority: 30
     },

--- a/packages/web-runtime/src/router/index.ts
+++ b/packages/web-runtime/src/router/index.ts
@@ -122,7 +122,7 @@ const routes: readonly RouteRecordRaw[] = [
         meta: { authContext: 'hybrid' }
       },
       {
-        path: 'extensions',
+        path: 'apps',
         name: locationAccountExtensions.name,
         component: AccountExtensions,
         meta: { authContext: 'user' }


### PR DESCRIPTION
## Description

This pull request renames user-facing "Extensions" wording to "Apps" in admin settings and personal account settings, updates the related icons to `store`, and updates the settings routes accordingly.

Changes included:
- Admin settings: label and texts changed from extension(s) to app(s)
- Admin settings route changed from `/admin-settings/extensions` to `/admin-settings/apps`
- Personal account route changed from `/account/extensions` to `/account/apps`
- Icons for the related entries changed to `store`
- Internal extension APIs/types and route names remain unchanged to keep the change scoped to user-facing behavior

## Related Issue

- Fixes #3188

## How Has This Been Tested?

- test environment: local development environment (macOS), Vitest unit tests
- test case 1: `pnpm test:unit --run packages/web-app-admin-settings/tests/unit/index.spec.ts packages/web-app-admin-settings/tests/unit/views/Extensions.spec.ts packages/web-app-admin-settings/tests/unit/components/Extensions/ExtensionsList.spec.ts`
- test case 2: `pnpm test:unit --run packages/web-runtime/tests/unit/pages/account/accountExtensions.spec.ts packages/web-runtime/tests/unit/pages/account/accountPreferences.spec.ts packages/web-runtime/tests/unit/pages/account/accountInformation.spec.ts`

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
