### PR TITLE
feat(web-runtime): add sponsor emoji transition on hover

### DIFF
--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -52,9 +52,11 @@
           href="https://github.com/sponsors/opencloud-eu"
           target="_blank"
           rel="noopener noreferrer"
-          class="oc-sidebar-nav-sponsor-link mb-2"
+          class="oc-sidebar-nav-sponsor-link group mb-2 inline-flex self-start items-center gap-1"
         >
-          {{ $gettext('Sponsor us ❤️') }}
+          <span v-text="$gettext('Sponsor us')" />
+          <span aria-hidden="true" class="group-hover:hidden">💜</span>
+          <span aria-hidden="true" class="hidden group-hover:inline">🤗</span>
         </a>
         <span v-text="backendVersion" />
         <version-check />

--- a/packages/web-runtime/tests/unit/components/SidebarNav/__snapshots__/SidebarNav.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/components/SidebarNav/__snapshots__/SidebarNav.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`OcSidebarNav > renders navItems into a list 1`] = `
     </nav>
   </div>
   <div class="flex flex-col gap-2">
-    <div class="flex flex-col pb-4 px-4 text-xs text-role-on-surface-variant"><a href="https://github.com/sponsors/opencloud-eu" target="_blank" rel="noopener noreferrer" class="oc-sidebar-nav-sponsor-link mb-2">Sponsor us ❤️</a> <span></span>
+    <div class="flex flex-col pb-4 px-4 text-xs text-role-on-surface-variant"><a href="https://github.com/sponsors/opencloud-eu" target="_blank" rel="noopener noreferrer" class="oc-sidebar-nav-sponsor-link group mb-2 inline-flex self-start items-center gap-1"><span>Sponsor us</span> <span aria-hidden="true" class="group-hover:hidden">💜</span> <span aria-hidden="true" class="hidden group-hover:inline">🤗</span></a> <span></span>
       <!--v-if-->
     </div>
   </div>


### PR DESCRIPTION
## Description

This enhancement updates the sidebar sponsor link to better match the OpenCloud design and adds a subtle hover transition.

Changes made:
- Updated sponsor link text rendering to structured markup (`Sponsor us` + emoji)
- Uses a purple heart (`💜`) in the default state
- Switches to a hugging face (`🤗`) on hover
- Keeps the sponsor link hit area limited to its visible content
- Updated the corresponding unit test snapshot for `SidebarNav`

## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local development environment (macOS), pnpm + Vitest
- test case 1: render `SidebarNav` with default config and verify sponsor link output
- test case 2: verify hover state switches `💜` to `🤗` without animation classes
- test case 3: run unit test for sidebar navigation component and confirm snapshot and assertions pass
- `pnpm test:unit --run packages/web-runtime/tests/unit/components/SidebarNav/SidebarNav.spec.ts`

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
