### PR TITLE
perf: dynamic tile preview dimensions

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -358,7 +358,7 @@ watch(
       preview.value = await loadPreview({
         space: unref(space),
         resource: unref(resource),
-        dimensions: ImageDimension.Preview,
+        dimensions: ImageDimension.Medium,
         cancelRunning: true,
         updateStore: false
       })

--- a/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
@@ -284,7 +284,7 @@ watch(
     imageContent.value = await loadPreview({
       space,
       resource: space.spaceImageData ? buildSpaceImageResource(space) : space,
-      dimensions: ImageDimension.Tile,
+      dimensions: ImageDimension.Preview, // request full preview because image can be expanded
       processor: ProcessorType.enum.fit,
       cancelRunning: true,
       updateStore: false

--- a/packages/web-app-preview/src/components/PhotoRoll.vue
+++ b/packages/web-app-preview/src/components/PhotoRoll.vue
@@ -38,7 +38,7 @@ const onItemVisible = (item: MediaFile) => {
     resource: item.resource,
     space: getMatchingSpace(item.resource),
     processor: ProcessorType.enum.fit,
-    dimensions: ImageDimension.Tile
+    dimensions: ImageDimension.Small
   })
 }
 

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -294,7 +294,7 @@ const updateViewWidth = () => {
 const gapSizePixels = computed(() => {
   return parseFloat(getComputedStyle(document.documentElement).fontSize)
 })
-const { calculateTileSizePixels } = useTileSize()
+const { calculateTileSizePixels, setRenderedTileSize } = useTileSize()
 const maxTilesAll = computed<number[]>(() => {
   const viewSizes = [...Array(FolderViewModeConstants.tilesSizeMax).keys()].map((i) => i + 1)
   return [
@@ -328,6 +328,7 @@ watch(
   tileSizePixels,
   (px: number | undefined) => {
     if (px && !isNaN(px)) {
+      setRenderedTileSize(px)
       document.documentElement.style.setProperty(`--oc-size-tiles-actual`, `${px}px`)
     }
   },

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
@@ -157,7 +157,7 @@ watch(
       resource: unref(resource).spaceImageData
         ? buildSpaceImageResource(unref(resource))
         : unref(resource),
-      dimensions: ImageDimension.Tile,
+      dimensions: ImageDimension.Medium,
       processor: ProcessorType.enum.fit,
       cancelRunning: true,
       updateStore: false

--- a/packages/web-pkg/src/composables/resources/useLoadPreview.ts
+++ b/packages/web-pkg/src/composables/resources/useLoadPreview.ts
@@ -7,7 +7,7 @@ import {
   Resource,
   SpaceResource
 } from '@opencloud-eu/web-client'
-import { FolderViewModeConstants } from '../viewMode'
+import { FolderViewModeConstants, useTileSize } from '../viewMode'
 import { usePreviewService } from '../previewService'
 import { ProcessorType } from '../../services'
 import { useResourcesStore, useSpacesStore } from '../piniaStores'
@@ -44,8 +44,9 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
   const defaultProcessor = computed(() =>
     unref(isTilesView) ? ProcessorType.enum.fit : ProcessorType.enum.thumbnail
   )
-  const defaultDimensions = computed(() =>
-    unref(isTilesView) ? ImageDimension.Tile : ImageDimension.Thumbnail
+  const { previewDimensions } = useTileSize()
+  const defaultDimensions = computed<[number, number]>(() =>
+    unref(isTilesView) ? unref(previewDimensions) : ImageDimension.Thumbnail
   )
 
   const loadPreviewTask = useTask<string, LoadPreviewOptions[]>(function* (

--- a/packages/web-pkg/src/composables/viewMode/useTileSize.ts
+++ b/packages/web-pkg/src/composables/viewMode/useTileSize.ts
@@ -1,8 +1,17 @@
-import { ref, unref } from 'vue'
+import { computed, readonly, ref, unref } from 'vue'
 
 // sizes in pixels
 const BASE_SIZE = 140
 const STEP_SIZE = 84
+
+// tile previews are snapped up to this step to keep the amount of distinct
+// requests (and hence cache misses) low while resizing
+const PREVIEW_SIZE_STEP = 64
+const PREVIEW_PIXEL_RATIO_MAX = 1.5
+const PREVIEW_SIZE_MAX = 768
+const PREVIEW_SIZE_MIN = 320
+
+const renderedTileSizePixels = ref<number>(0)
 
 export const useTileSize = () => {
   const baseSizePixels = ref(BASE_SIZE)
@@ -16,8 +25,36 @@ export const useTileSize = () => {
     return calculateTileSizePixels(viewSize) / fontSize
   }
 
+  const setRenderedTileSize = (pixels: number) => {
+    renderedTileSizePixels.value = pixels
+  }
+
+  /**
+   * Preview dimensions for tiles, derived from the rendered tile size and the device pixel ratio.
+   * Falls back to the maximum as long as no tile has been rendered.
+   */
+  const previewDimensions = computed<[number, number]>(() => {
+    const cssPixels = unref(renderedTileSizePixels)
+    if (!cssPixels) {
+      return [PREVIEW_SIZE_MAX, PREVIEW_SIZE_MAX]
+    }
+
+    // capped because serving the full ratio on high density displays costs a lot of
+    // bandwidth for a barely visible gain
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, PREVIEW_PIXEL_RATIO_MAX)
+    const devicePixels = cssPixels * pixelRatio
+    const size = Math.min(
+      Math.max(Math.ceil(devicePixels / PREVIEW_SIZE_STEP) * PREVIEW_SIZE_STEP, PREVIEW_SIZE_MIN),
+      PREVIEW_SIZE_MAX
+    )
+    return [size, size]
+  })
+
   return {
     calculateTileSizePixels,
-    calculateTileSizeRem
+    calculateTileSizeRem,
+    renderedTileSizePixels: readonly(renderedTileSizePixels),
+    setRenderedTileSize,
+    previewDimensions
   }
 }

--- a/packages/web-pkg/src/constants.ts
+++ b/packages/web-pkg/src/constants.ts
@@ -1,5 +1,5 @@
 export abstract class ImageDimension {
-  static readonly Thumbnail: [number, number] = [36, 36]
+  static readonly Thumbnail: [number, number] = [32, 32]
   static readonly Small: [number, number] = [320, 320]
   static readonly Medium: [number, number] = [448, 448]
   /** @deprecated use `previewDimensions` of `useTileSize` instead */

--- a/packages/web-pkg/src/constants.ts
+++ b/packages/web-pkg/src/constants.ts
@@ -1,6 +1,9 @@
 export abstract class ImageDimension {
   static readonly Thumbnail: [number, number] = [36, 36]
-  static readonly Tile: [number, number] = [1000, 1000]
+  static readonly Small: [number, number] = [320, 320]
+  static readonly Medium: [number, number] = [448, 448]
+  /** @deprecated use `previewDimensions` of `useTileSize` instead */
+  static readonly Tile: [number, number] = [512, 512]
   static readonly Preview: [number, number] = [1200, 1200]
   static readonly Avatar: number = 64
 }

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -11,12 +11,16 @@ import { OcFilterChip } from '@opencloud-eu/design-system/components'
 import { useResourcesStore } from '../../../../src'
 
 vi.mock('../../../../src/helpers/contextMenuDropdown')
-vi.mock('../../../../src/composables/viewMode', async (importOriginal) => ({
-  ...(await importOriginal<any>()),
-  useTileSize: vi.fn().mockReturnValue({
-    calculateTileSizePixels: vi.fn().mockImplementation((viewSize: number) => 100 * viewSize)
-  })
-}))
+vi.mock('../../../../src/composables/viewMode', async (importOriginal) => {
+  const original = await importOriginal<any>()
+  return {
+    ...original,
+    useTileSize: vi.fn().mockImplementation(() => ({
+      ...original.useTileSize(),
+      calculateTileSizePixels: vi.fn().mockImplementation((viewSize: number) => 100 * viewSize)
+    }))
+  }
+})
 
 const mockUseEmbedMode = vi.fn().mockReturnValue({ isEnabled: computed(() => false) })
 vi.mock('../../../../src/composables/embedMode', () => ({

--- a/packages/web-pkg/tests/unit/composables/resources/useLoadPreview.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useLoadPreview.spec.ts
@@ -5,7 +5,7 @@ import { buildSpaceImageResource, Resource, SpaceResource } from '@opencloud-eu/
 import { useLoadPreview } from '../../../../src/composables/resources'
 import { usePreviewService } from '../../../../src/composables/previewService'
 import { PreviewService, ProcessorType } from '../../../../src/services'
-import { FolderViewModeConstants, ImageDimension } from '../../../../src'
+import { FolderViewModeConstants, ImageDimension, useTileSize } from '../../../../src'
 import { useSpacesStore } from '../../../../src/composables/piniaStores'
 
 vi.mock('../../../../src/composables/previewService/usePreviewService')
@@ -15,6 +15,11 @@ vi.mock('@opencloud-eu/web-client', async (importOriginal) => ({
 }))
 
 describe('useLoadPreview', () => {
+  afterEach(() => {
+    window.devicePixelRatio = 1
+    useTileSize().setRenderedTileSize(0)
+  })
+
   describe('loadPreview', () => {
     it('returns a loaded preview for a given file', () => {
       const loadedPreview = 'blob:image'
@@ -107,14 +112,86 @@ describe('useLoadPreview', () => {
           }
         })
       })
-      it('uses tile default dimensions in tiles view', () => {
+      it('uses the maximum tile dimensions in tiles view while no tile has been rendered', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
             const resource = mock<Resource>({ isInVault: false })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
-              expect.objectContaining({ dimensions: ImageDimension.Tile }),
+              expect.objectContaining({ dimensions: [768, 768] }),
+              expect.anything(),
+              expect.anything(),
+              expect.anything()
+            )
+          },
+          viewMode: FolderViewModeConstants.name.tiles
+        })
+      })
+      it('derives the tile dimensions from the rendered tile size', () => {
+        window.devicePixelRatio = 1
+        useTileSize().setRenderedTileSize(400)
+        getWrapper({
+          setup: async ({ loadPreview }, { previewService }) => {
+            const space = mock<SpaceResource>()
+            const resource = mock<Resource>({ isInVault: false })
+            await loadPreview({ space, resource })
+            expect(previewService.loadPreview).toHaveBeenCalledWith(
+              expect.objectContaining({ dimensions: [448, 448] }),
+              expect.anything(),
+              expect.anything(),
+              expect.anything()
+            )
+          },
+          viewMode: FolderViewModeConstants.name.tiles
+        })
+      })
+      it('does not go below the minimum tile dimensions', () => {
+        window.devicePixelRatio = 1
+        useTileSize().setRenderedTileSize(150)
+        getWrapper({
+          setup: async ({ loadPreview }, { previewService }) => {
+            const space = mock<SpaceResource>()
+            const resource = mock<Resource>({ isInVault: false })
+            await loadPreview({ space, resource })
+            expect(previewService.loadPreview).toHaveBeenCalledWith(
+              expect.objectContaining({ dimensions: [320, 320] }),
+              expect.anything(),
+              expect.anything(),
+              expect.anything()
+            )
+          },
+          viewMode: FolderViewModeConstants.name.tiles
+        })
+      })
+      it('caps the device pixel ratio the tile dimensions are scaled with', () => {
+        window.devicePixelRatio = 3
+        useTileSize().setRenderedTileSize(300)
+        getWrapper({
+          setup: async ({ loadPreview }, { previewService }) => {
+            const space = mock<SpaceResource>()
+            const resource = mock<Resource>({ isInVault: false })
+            await loadPreview({ space, resource })
+            expect(previewService.loadPreview).toHaveBeenCalledWith(
+              expect.objectContaining({ dimensions: [512, 512] }),
+              expect.anything(),
+              expect.anything(),
+              expect.anything()
+            )
+          },
+          viewMode: FolderViewModeConstants.name.tiles
+        })
+      })
+      it('caps the tile dimensions for large tiles', () => {
+        window.devicePixelRatio = 2
+        useTileSize().setRenderedTileSize(600)
+        getWrapper({
+          setup: async ({ loadPreview }, { previewService }) => {
+            const space = mock<SpaceResource>()
+            const resource = mock<Resource>({ isInVault: false })
+            await loadPreview({ space, resource })
+            expect(previewService.loadPreview).toHaveBeenCalledWith(
+              expect.objectContaining({ dimensions: [768, 768] }),
               expect.anything(),
               expect.anything(),
               expect.anything()


### PR DESCRIPTION
Derive the requested tile preview dimensions from the current tile size setting and the device pixel ratio. This way we avoid fetching large previews for small tile sizes.

Also reduce the max tile dimension from 1000 to 768 px because this feels sufficient, even on the largest tile size setting, and optimize the requested preview sizes in the right sidebar and the photo roll.

refs https://github.com/opencloud-eu/web/issues/3167