### PR TITLE
test(e2e): fix e2ee space tests by creating ocnote instead of txt

### DIFF
--- a/tests/e2e/features/rclone-crypt/spaceVault.feature
+++ b/tests/e2e/features/rclone-crypt/spaceVault.feature
@@ -22,22 +22,22 @@ Feature: Work with an rclone-crypt encrypted vault space
       | vaultspace | foobar   |
     And "Alice" enters the vault space "vaultspace" with passphrase "foobar"
     And "Alice" creates the following resources
-      | resource  | type    | content     | password |
-      | hello.txt | txtFile | hello world | foobar   |
+      | resource     | type     | content     | password |
+      | hello.ocnote | noteFile | hello world | foobar   |
     And "Alice" uploads the following resource
       | resource       | password |
       | testavatar.png | foobar   |
     Then following resources should be displayed in the files list for user "Alice"
       | resource       |
-      | hello.txt      |
+      | hello.ocnote   |
       | testavatar.png |
     And "Alice" should not be able to share following resources from the space "vaultspace"
       | resource       |
-      | hello.txt      |
+      | hello.ocnote   |
       | testavatar.png |
     When "Alice" opens the following file in texteditor
-      | resource  |
-      | hello.txt |
+      | resource     |
+      | hello.ocnote |
     Then "Alice" should see the content "hello world" in editor "TextEditor"
     And "Alice" closes the file viewer
     When "Alice" opens the following file in mediaviewer
@@ -55,15 +55,15 @@ Feature: Work with an rclone-crypt encrypted vault space
     And "Brian" enters the vault space "vaultspace" with passphrase "foobar"
     Then following resources should be displayed in the files list for user "Brian"
       | resource       |
-      | hello.txt      |
+      | hello.ocnote   |
       | testavatar.png |
     And "Brian" should not be able to share following resources from the space "vaultspace"
       | resource       |
-      | hello.txt      |
+      | hello.ocnote   |
       | testavatar.png |
     When "Brian" opens the following file in texteditor
-      | resource  |
-      | hello.txt |
+      | resource     |
+      | hello.ocnote |
     Then "Brian" should see the content "hello world" in editor "TextEditor"
     And "Brian" closes the file viewer
     When "Brian" opens the following file in mediaviewer
@@ -82,12 +82,12 @@ Feature: Work with an rclone-crypt encrypted vault space
       | vaultspace | foobar   |
     And "Alice" enters the vault space "vaultspace" with passphrase "foobar"
     And "Alice" creates the following resources
-      | resource  | type    | content     | password |
-      | hello.txt | txtFile | hello world | foobar   |
+      | resource     | type     | content     | password |
+      | hello.ocnote | noteFile | hello world | foobar   |
     And "Alice" reloads the page
     Then "Alice" should see the unlock page of the vault space "vaultspace"
     When "Alice" unlocks the vault space with passphrase "foobar"
     Then following resource should be displayed in the files list for user "Alice"
-      | resource  |
-      | hello.txt |
+      | resource     |
+      | hello.ocnote |
     And "Alice" logs out

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -516,6 +516,8 @@ export const createNewFileOrFolder = async (args: createResourceArgs): Promise<v
       await createNewFolder({ page, resource: '.empty' })
       break
     }
+    default:
+      throw new Error(`Unknown resource type: ${type}`)
   }
 }
 


### PR DESCRIPTION
Needs to be adjusted after https://github.com/opencloud-eu/web/pull/3175 got merged.