### PR TITLE
perf: preview cache optimizations

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -49,15 +49,8 @@ export const useResourcesStore = defineStore('resources', () => {
     resources.value = file
   }
 
-  /** Drops cached previews of resources that are gone, so their object URLs get revoked. */
-  const releasePreviews = (values: Resource[]) => {
-    for (const resource of values) {
-      releaseFilePreviews(resource.id)
-    }
-  }
-
   const removeResources = (values: Resource[]) => {
-    releasePreviews(values)
+    releaseFilePreviews(values.map(({ id }) => id))
     resources.value = unref(resources).filter((file) => !values.find(({ id }) => id === file.id))
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -5,7 +5,7 @@ import { getParentPaths } from '../../helpers'
 import { AncestorMetaData, AncestorMetaDataValue } from '../../types'
 import { DavProperty, WebDAV } from '@opencloud-eu/web-client/webdav'
 import { useSpacesStore } from './spaces'
-import { eventBus } from '../../services'
+import { cacheService, eventBus } from '../../services'
 
 export const useResourcesStore = defineStore('resources', () => {
   const spacesStore = useSpacesStore()
@@ -49,7 +49,15 @@ export const useResourcesStore = defineStore('resources', () => {
     resources.value = file
   }
 
+  /** Drops cached previews of resources that are gone, so their object URLs get revoked. */
+  const releasePreviews = (values: Resource[]) => {
+    for (const resource of values) {
+      cacheService.filePreview.delete(resource.id)
+    }
+  }
+
   const removeResources = (values: Resource[]) => {
+    releasePreviews(values)
     resources.value = unref(resources).filter((file) => !values.find(({ id }) => id === file.id))
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -5,7 +5,7 @@ import { getParentPaths } from '../../helpers'
 import { AncestorMetaData, AncestorMetaDataValue } from '../../types'
 import { DavProperty, WebDAV } from '@opencloud-eu/web-client/webdav'
 import { useSpacesStore } from './spaces'
-import { cacheService, eventBus } from '../../services'
+import { eventBus, releaseFilePreviews } from '../../services'
 
 export const useResourcesStore = defineStore('resources', () => {
   const spacesStore = useSpacesStore()
@@ -52,7 +52,7 @@ export const useResourcesStore = defineStore('resources', () => {
   /** Drops cached previews of resources that are gone, so their object URLs get revoked. */
   const releasePreviews = (values: Resource[]) => {
     for (const resource of values) {
-      cacheService.filePreview.delete(resource.id)
+      releaseFilePreviews(resource.id)
     }
   }
 

--- a/packages/web-pkg/src/helpers/cache/cache.ts
+++ b/packages/web-pkg/src/helpers/cache/cache.ts
@@ -12,26 +12,40 @@ class CacheElement<T> {
   }
 }
 
-interface CacheOptions {
+interface CacheOptions<K, V> {
   ttl?: number
   capacity?: number
+
+  /**
+   * Called whenever an entry leaves the cache. `replacedValue` is the value that
+   * left, `value` the new one for that key, set only on replacement.
+   */
+  onEvict?: (event: { key: K; replacedValue: V; value?: V }) => void
 }
 
 export default class Cache<K, V> {
   private map: Map<K, CacheElement<V>>
   private readonly ttl: number
   private readonly capacity: number
+  private readonly onEvict?: (event: { key: K; replacedValue: V; value?: V }) => void
 
-  constructor(options: CacheOptions) {
+  constructor(options: CacheOptions<K, V>) {
     this.ttl = options.ttl || 0
     this.capacity = options.capacity || 0
+    this.onEvict = options.onEvict
 
     this.map = new Map<K, CacheElement<V>>()
   }
 
   public set(key: K, value: V, ttl?: number): V {
-    this.evict()
+    const existing = this.map.get(key)
     this.map.set(key, new CacheElement<V>(value, isNaN(ttl) ? this.ttl : ttl))
+
+    if (existing) {
+      this.onEvict?.({ key, replacedValue: existing.value, value })
+    }
+
+    this.evict()
 
     return value
   }
@@ -46,10 +60,21 @@ export default class Cache<K, V> {
   }
 
   public delete(key: K): boolean {
-    return this.map.delete(key)
+    const entry = this.map.get(key)
+    const deleted = this.map.delete(key)
+
+    if (deleted) {
+      this.onEvict?.({ key, replacedValue: entry.value })
+    }
+
+    return deleted
   }
 
   public clear(): void {
+    if (this.onEvict) {
+      this.map.forEach((entry, key) => this.onEvict({ key, replacedValue: entry.value }))
+    }
+
     return this.map.clear()
   }
 

--- a/packages/web-pkg/src/helpers/cache/cache.ts
+++ b/packages/web-pkg/src/helpers/cache/cache.ts
@@ -1,10 +1,12 @@
 class CacheElement<T> {
   public value: T
   public expires: number
+  public size: number
 
-  constructor(value: T, ttl: number) {
+  constructor(value: T, ttl: number, size = 0) {
     this.value = value
     this.expires = ttl ? new Date().getTime() + ttl : 0
+    this.size = size
   }
 
   get expired(): boolean {
@@ -14,7 +16,21 @@ class CacheElement<T> {
 
 interface CacheOptions<K, V> {
   ttl?: number
+
+  /**
+   * Maximum number of entries. Exceeding it drops the least recently used ones.
+   */
   capacity?: number
+
+  /**
+   * Byte budget across all entries. Only has an effect together with `sizeOf`.
+   */
+  maxBytes?: number
+
+  /**
+   * Byte cost of a value, used for the `maxBytes` budget.
+   */
+  sizeOf?: (value: V) => number
 
   /**
    * Called whenever an entry leaves the cache. `replacedValue` is the value that
@@ -25,49 +41,82 @@ interface CacheOptions<K, V> {
 
 export default class Cache<K, V> {
   private map: Map<K, CacheElement<V>>
+  private totalBytes: number
   private readonly ttl: number
   private readonly capacity: number
+  private readonly maxBytes: number
+  private readonly sizeOf?: (value: V) => number
   private readonly onEvict?: (event: { key: K; replacedValue: V; value?: V }) => void
 
   constructor(options: CacheOptions<K, V>) {
     this.ttl = options.ttl || 0
     this.capacity = options.capacity || 0
+    this.maxBytes = options.maxBytes || 0
+    this.sizeOf = options.sizeOf
     this.onEvict = options.onEvict
 
     this.map = new Map<K, CacheElement<V>>()
+    this.totalBytes = 0
+  }
+
+  /**
+   * Byte cost of all entries, as reported by `sizeOf`.
+   */
+  public get bytes(): number {
+    return this.totalBytes
   }
 
   public set(key: K, value: V, ttl?: number): V {
     const existing = this.map.get(key)
-    this.map.set(key, new CacheElement<V>(value, isNaN(ttl) ? this.ttl : ttl))
+    if (existing) {
+      this.drop(key, existing)
+    }
+
+    const element = new CacheElement<V>(
+      value,
+      isNaN(ttl) ? this.ttl : ttl,
+      this.sizeOf?.(value) || 0
+    )
+    this.map.set(key, element)
+    this.totalBytes += element.size
 
     if (existing) {
       this.onEvict?.({ key, replacedValue: existing.value, value })
     }
 
-    this.evict()
+    this.trim()
 
     return value
   }
 
   public get(key: K): V {
-    this.evict()
     const entry = this.map.get(key)
 
-    if (entry) {
-      return entry.value
+    if (!entry) {
+      return
     }
+
+    if (entry.expired) {
+      this.delete(key)
+      return
+    }
+
+    this.touch(key, entry)
+
+    return entry.value
   }
 
   public delete(key: K): boolean {
     const entry = this.map.get(key)
-    const deleted = this.map.delete(key)
 
-    if (deleted) {
-      this.onEvict?.({ key, replacedValue: entry.value })
+    if (!entry) {
+      return false
     }
 
-    return deleted
+    this.drop(key, entry)
+    this.onEvict?.({ key, replacedValue: entry.value })
+
+    return true
   }
 
   public clear(): void {
@@ -75,7 +124,8 @@ export default class Cache<K, V> {
       this.map.forEach((entry, key) => this.onEvict({ key, replacedValue: entry.value }))
     }
 
-    return this.map.clear()
+    this.map.clear()
+    this.totalBytes = 0
   }
 
   public entries(): [K, V][] {
@@ -89,8 +139,14 @@ export default class Cache<K, V> {
   }
 
   public has(key: K): boolean {
-    this.evict()
-    return this.map.has(key)
+    const entry = this.map.get(key)
+
+    if (entry?.expired) {
+      this.delete(key)
+      return false
+    }
+
+    return !!entry
   }
 
   public values(): V[] {
@@ -98,23 +154,50 @@ export default class Cache<K, V> {
     return [...this.map.values()].map((e) => e.value)
   }
 
+  /**
+   * Drops all expired entries. This is only needed before handing out the whole
+   * content of the cache.
+   */
   public evict(): void {
-    this.map.forEach((mv, mk) => {
-      if (mv.expired) {
-        this.delete(mk)
+    this.map.forEach((entry, key) => {
+      if (entry.expired) {
+        this.delete(key)
       }
     })
 
-    if (!this.capacity) {
+    this.trim()
+  }
+
+  private drop(key: K, entry: CacheElement<V>): void {
+    this.map.delete(key)
+    this.totalBytes -= entry.size
+  }
+
+  /**
+   * Moves an entry to the end of the map, where the most recently used ones live.
+   */
+  private touch(key: K, entry: CacheElement<V>): void {
+    this.map.delete(key)
+    this.map.set(key, entry)
+  }
+
+  /**
+   * Evicts least recently used entries until capacity and byte budget are met.
+   */
+  private trim(): void {
+    if (!this.capacity && !this.maxBytes) {
       return
     }
 
-    for (const [k] of [...this.map.entries()]) {
-      if (this.map.size <= this.capacity) {
-        break
+    for (const key of this.map.keys()) {
+      const overCapacity = this.capacity && this.map.size > this.capacity
+      const overBudget = this.maxBytes && this.totalBytes > this.maxBytes
+
+      if (!overCapacity && !overBudget) {
+        return
       }
 
-      this.delete(k)
+      this.delete(key)
     }
   }
 }

--- a/packages/web-pkg/src/services/cache.ts
+++ b/packages/web-pkg/src/services/cache.ts
@@ -1,13 +1,29 @@
 import { Cache } from '../helpers/cache'
 
-const filePreviewCache = new Cache<
-  string,
-  {
-    etag?: string
-    src?: string
-    dimensions?: [number, number]
+type FilePreviewCacheValue = {
+  etag?: string
+  src?: string
+  dimensions?: [number, number]
+}
+
+const revokePreview = ({
+  replacedValue,
+  value
+}: {
+  replacedValue: FilePreviewCacheValue
+  value?: FilePreviewCacheValue
+}) => {
+  const { src } = replacedValue
+  if (src?.startsWith('blob:') && src !== value?.src) {
+    window.URL.revokeObjectURL(src)
   }
->({ ttl: 10 * 1000, capacity: 250 })
+}
+
+const filePreviewCache = new Cache<string, FilePreviewCacheValue>({
+  ttl: 10 * 1000,
+  capacity: 250,
+  onEvict: revokePreview
+})
 
 class CacheService {
   public get filePreview() {

--- a/packages/web-pkg/src/services/cache.ts
+++ b/packages/web-pkg/src/services/cache.ts
@@ -46,10 +46,10 @@ const filePreviewCache = new Cache<string, FilePreviewCacheValue>({
 })
 
 /** Releases all cached previews of a resource. */
-export function releaseFilePreviews(resourceId: string): void {
-  const prefix = buildFilePreviewCacheKey(resourceId)
+export function releaseFilePreviews(resourceIds: string[]): void {
+  const ids = new Set(resourceIds)
   for (const key of filePreviewCache.keys()) {
-    if (key.startsWith(prefix)) {
+    if (ids.has(key.slice(0, key.indexOf('@')))) {
       filePreviewCache.delete(key)
     }
   }

--- a/packages/web-pkg/src/services/cache.ts
+++ b/packages/web-pkg/src/services/cache.ts
@@ -4,7 +4,20 @@ type FilePreviewCacheValue = {
   etag?: string
   src?: string
   dimensions?: [number, number]
+  size?: number
 }
+
+/**
+ * Budget for cached previews. Sized to hold several folders worth of tile previews
+ * so navigating back does not re-fetch; table thumbnails are nearly free.
+ */
+const previewBudget = 150 * 1024 * 1024 // 150 MB
+
+/**
+ * Entries without a known blob size still need to count towards the budget,
+ * otherwise they could grow it without bound.
+ */
+const fallbackPreviewSize = 100 * 1024 // 100 KB
 
 const revokePreview = ({
   replacedValue,
@@ -20,8 +33,8 @@ const revokePreview = ({
 }
 
 const filePreviewCache = new Cache<string, FilePreviewCacheValue>({
-  ttl: 10 * 1000,
-  capacity: 250,
+  maxBytes: previewBudget,
+  sizeOf: ({ size }) => size || fallbackPreviewSize,
   onEvict: revokePreview
 })
 

--- a/packages/web-pkg/src/services/cache.ts
+++ b/packages/web-pkg/src/services/cache.ts
@@ -3,7 +3,6 @@ import { Cache } from '../helpers/cache'
 type FilePreviewCacheValue = {
   etag?: string
   src?: string
-  dimensions?: [number, number]
   size?: number
 }
 
@@ -32,11 +31,29 @@ const revokePreview = ({
   }
 }
 
+/** Build a cache key for a file, including its dimensions if provided. */
+export function buildFilePreviewCacheKey(
+  resourceId: string,
+  dimensions?: [number, number]
+): string {
+  return `${resourceId}@${dimensions?.join('x') ?? ''}`
+}
+
 const filePreviewCache = new Cache<string, FilePreviewCacheValue>({
   maxBytes: previewBudget,
   sizeOf: ({ size }) => size || fallbackPreviewSize,
   onEvict: revokePreview
 })
+
+/** Releases all cached previews of a resource. */
+export function releaseFilePreviews(resourceId: string): void {
+  const prefix = buildFilePreviewCacheKey(resourceId)
+  for (const key of filePreviewCache.keys()) {
+    if (key.startsWith(prefix)) {
+      filePreviewCache.delete(key)
+    }
+  }
+}
 
 class CacheService {
   public get filePreview() {

--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -76,16 +76,16 @@ export class PreviewService {
     signal?: AbortSignal
   ): Promise<string> {
     const { resource, dimensions } = options
-    const hit = cacheService.filePreview.get(resource.id.toString())
+    const hit = cacheService.filePreview.get(resource.id)
 
     if (hit && hit.etag === resource.etag && isEqual(dimensions, hit.dimensions)) {
       return hit.src
     }
     try {
-      const src = await this.privatePreviewBlob(options, false, true, signal)
+      const { src, size } = await this.fetchPreviewBlob(options, signal)
       return cacheService.filePreview.set(
-        resource.id.toString(),
-        { src, etag: resource.etag, dimensions },
+        resource.id,
+        { src, size, etag: resource.etag, dimensions },
         0
       ).src
     } catch (e) {
@@ -114,10 +114,19 @@ export class PreviewService {
     silenceErrors = true,
     signal?: AbortSignal
   ): Promise<string> {
-    const { resource, dimensions, processor } = options
     if (cached) {
       return this.cacheFactory(options, silenceErrors, signal)
     }
+
+    const { src } = await this.fetchPreviewBlob(options, signal)
+    return src
+  }
+
+  private async fetchPreviewBlob(
+    options: LoadPreviewOptions,
+    signal?: AbortSignal
+  ): Promise<{ src: string; size: number }> {
+    const { resource, dimensions, processor } = options
 
     const url = [
       this.configStore.serverUrl,
@@ -132,12 +141,12 @@ export class PreviewService {
         responseType: 'blob',
         signal
       })
-      return window.URL.createObjectURL(data)
+      return { src: window.URL.createObjectURL(data), size: data.size }
     } catch (e) {
       if ([425, 429].includes(e.status)) {
         const retryAfter = e.response?.headers?.['retry-after'] || 5
         await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000))
-        return this.privatePreviewBlob(options, cached, silenceErrors, signal)
+        return this.fetchPreviewBlob(options, signal)
       }
 
       throw e

--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -1,5 +1,4 @@
-import isEqual from 'lodash-es/isEqual'
-import { cacheService } from '../cache'
+import { buildFilePreviewCacheKey, cacheService } from '../cache'
 import { ClientService } from '../client'
 import { encodePath } from '../../utils'
 import { isPublicSpaceResource } from '@opencloud-eu/web-client'
@@ -76,18 +75,15 @@ export class PreviewService {
     signal?: AbortSignal
   ): Promise<string> {
     const { resource, dimensions } = options
-    const hit = cacheService.filePreview.get(resource.id)
+    const key = buildFilePreviewCacheKey(resource.id, dimensions)
+    const hit = cacheService.filePreview.get(key)
 
-    if (hit && hit.etag === resource.etag && isEqual(dimensions, hit.dimensions)) {
+    if (hit && hit.etag === resource.etag) {
       return hit.src
     }
     try {
       const { src, size } = await this.fetchPreviewBlob(options, signal)
-      return cacheService.filePreview.set(
-        resource.id,
-        { src, size, etag: resource.etag, dimensions },
-        0
-      ).src
+      return cacheService.filePreview.set(key, { src, size, etag: resource.etag }, 0).src
     } catch (e) {
       if (silenceErrors) {
         return

--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -13,6 +13,9 @@ export class PreviewService {
   userStore: UserStore
   authStore: AuthStore
 
+  /** Ongoing preview requests, so concurrent loads of the same key share one fetch. */
+  private inFlightPreviews = new Map<string, Promise<string>>()
+
   constructor({
     clientService,
     userStore,
@@ -81,14 +84,33 @@ export class PreviewService {
     if (hit && hit.etag === resource.etag) {
       return hit.src
     }
+
     try {
-      const { src, size } = await this.fetchPreviewBlob(options, signal)
-      return cacheService.filePreview.set(key, { src, size, etag: resource.etag }, 0).src
+      let request = this.inFlightPreviews.get(key)
+      if (!request) {
+        request = this.fetchAndCachePreview(options, key, signal)
+        this.inFlightPreviews.set(key, request)
+      }
+
+      return await request
     } catch (e) {
       if (silenceErrors) {
         return
       }
       throw e
+    }
+  }
+
+  private async fetchAndCachePreview(
+    options: LoadPreviewOptions,
+    key: string,
+    signal?: AbortSignal
+  ): Promise<string> {
+    try {
+      const { src, size } = await this.fetchPreviewBlob(options, signal)
+      return cacheService.filePreview.set(key, { src, size, etag: options.resource.etag }, 0).src
+    } finally {
+      this.inFlightPreviews.delete(key)
     }
   }
 

--- a/packages/web-pkg/tests/unit/composables/piniaStores/resources.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/resources.spec.ts
@@ -2,7 +2,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { mock } from 'vitest-mock-extended'
 import { Resource } from '@opencloud-eu/web-client'
 import { useResourcesStore } from '../../../../src/composables/piniaStores/resources'
-import { cacheService } from '../../../../src/services'
+import { buildFilePreviewCacheKey, cacheService } from '../../../../src/services'
 
 describe('useResourcesStore', () => {
   beforeEach(() => {
@@ -13,24 +13,35 @@ describe('useResourcesStore', () => {
   describe('preview releasing', () => {
     const file = mock<Resource>({ id: '1', name: 'file.png', type: 'file' })
 
-    it('drops cached previews of removed resources', () => {
+    it('drops cached previews of removed resources, for all dimensions', () => {
       const store = useResourcesStore()
       store.setResources([file])
-      cacheService.filePreview.set('1', { src: 'blob:preview-1' }, 0)
+      cacheService.filePreview.set(
+        buildFilePreviewCacheKey('1', [36, 36]),
+        { src: 'blob:thumbnail-1' },
+        0
+      )
+      cacheService.filePreview.set(
+        buildFilePreviewCacheKey('1', [1200, 1200]),
+        { src: 'blob:preview-1' },
+        0
+      )
 
       store.removeResources([file])
 
-      expect(cacheService.filePreview.get('1')).toBeUndefined()
+      expect(cacheService.filePreview.keys()).toEqual([])
     })
 
     it('keeps cached previews when the resource list is cleared', () => {
       const store = useResourcesStore()
       store.setResources([file])
-      cacheService.filePreview.set('1', { src: 'blob:preview-1' }, 0)
+      cacheService.filePreview.set(buildFilePreviewCacheKey('1'), { src: 'blob:preview-1' }, 0)
 
       store.clearResourceList()
 
-      expect(cacheService.filePreview.get('1')).toEqual({ src: 'blob:preview-1' })
+      expect(cacheService.filePreview.get(buildFilePreviewCacheKey('1'))).toEqual({
+        src: 'blob:preview-1'
+      })
     })
   })
 })

--- a/packages/web-pkg/tests/unit/composables/piniaStores/resources.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/resources.spec.ts
@@ -1,0 +1,36 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { mock } from 'vitest-mock-extended'
+import { Resource } from '@opencloud-eu/web-client'
+import { useResourcesStore } from '../../../../src/composables/piniaStores/resources'
+import { cacheService } from '../../../../src/services'
+
+describe('useResourcesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    cacheService.filePreview.clear()
+  })
+
+  describe('preview releasing', () => {
+    const file = mock<Resource>({ id: '1', name: 'file.png', type: 'file' })
+
+    it('drops cached previews of removed resources', () => {
+      const store = useResourcesStore()
+      store.setResources([file])
+      cacheService.filePreview.set('1', { src: 'blob:preview-1' }, 0)
+
+      store.removeResources([file])
+
+      expect(cacheService.filePreview.get('1')).toBeUndefined()
+    })
+
+    it('keeps cached previews when the resource list is cleared', () => {
+      const store = useResourcesStore()
+      store.setResources([file])
+      cacheService.filePreview.set('1', { src: 'blob:preview-1' }, 0)
+
+      store.clearResourceList()
+
+      expect(cacheService.filePreview.get('1')).toEqual({ src: 'blob:preview-1' })
+    })
+  })
+})

--- a/packages/web-pkg/tests/unit/helpers/cache/cache.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/cache/cache.spec.ts
@@ -132,6 +132,46 @@ describe('Cache', () => {
     expect(cache.entries().length).toBe(0)
   })
 
+  it('calls onEvict when entries leave the cache', () => {
+    const onEvict = vi.fn()
+    const cache = new Cache<number, string>({ capacity: 2, onEvict })
+
+    cache.set(1, 'one')
+    cache.set(2, 'two')
+    expect(onEvict).not.toHaveBeenCalled()
+
+    // exceeding the capacity drops the oldest entry right away
+    cache.set(3, 'three')
+    expect(onEvict).toHaveBeenCalledWith({ key: 1, replacedValue: 'one' })
+    expect(cache.keys()).toEqual([2, 3])
+
+    // replacing a key evicts the previous value and passes on the new one
+    cache.set(3, 'three-updated')
+    expect(onEvict).toHaveBeenCalledWith({ key: 3, replacedValue: 'three', value: 'three-updated' })
+
+    cache.delete(3)
+    expect(onEvict).toHaveBeenCalledWith({ key: 3, replacedValue: 'three-updated' })
+
+    // deleting an unknown key does nothing
+    onEvict.mockClear()
+    cache.delete(3)
+    expect(onEvict).not.toHaveBeenCalled()
+
+    cache.clear()
+    expect(onEvict).toHaveBeenCalledWith({ key: 2, replacedValue: 'two' })
+  })
+
+  it('calls onEvict for expired entries', () => {
+    const onEvict = vi.fn()
+    const cache = new Cache<number, string>({ ttl: 50, onEvict })
+
+    cache.set(1, 'one')
+    vi.setSystemTime(new Date().getTime() + 51)
+
+    expect(cache.get(1)).toBeFalsy()
+    expect(onEvict).toHaveBeenCalledWith({ key: 1, replacedValue: 'one' })
+  })
+
   it('can check if a cache contains a entry for given key', () => {
     const values = [1, 2, 3, 4, 5]
     const cache = newCache(values)
@@ -143,7 +183,7 @@ describe('Cache', () => {
 
 describe('cache', () => {
   describe('CacheElement', () => {
-    let cache: Cache<string, unknown>
+    let cache: Cache<string, string>
     let key: string, value: string, key2: string, value2: string
     let evictSpy: MockInstance
     beforeEach(() => {
@@ -159,7 +199,7 @@ describe('cache', () => {
       expect(cache.set(key, value)).toBe(value)
       expect(cache.get(key)).toBe(value)
     })
-    it('should evict before any access', () => {
+    it('should evict on any access', () => {
       cache.set(key, value)
       cache.get(key)
       cache.entries()

--- a/packages/web-pkg/tests/unit/helpers/cache/cache.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/cache/cache.spec.ts
@@ -140,7 +140,7 @@ describe('Cache', () => {
     cache.set(2, 'two')
     expect(onEvict).not.toHaveBeenCalled()
 
-    // exceeding the capacity drops the oldest entry right away
+    // exceeding the capacity drops the least recently used entry right away
     cache.set(3, 'three')
     expect(onEvict).toHaveBeenCalledWith({ key: 1, replacedValue: 'one' })
     expect(cache.keys()).toEqual([2, 3])
@@ -159,6 +159,54 @@ describe('Cache', () => {
 
     cache.clear()
     expect(onEvict).toHaveBeenCalledWith({ key: 2, replacedValue: 'two' })
+  })
+
+  it('evicts the least recently used entry when over capacity', () => {
+    const cache = new Cache<number, string>({ capacity: 3 })
+
+    cache.set(1, 'one')
+    cache.set(2, 'two')
+    cache.set(3, 'three')
+
+    // touching 1 makes 2 the least recently used one
+    expect(cache.get(1)).toBe('one')
+    cache.set(4, 'four')
+
+    expect(cache.keys()).toEqual([3, 1, 4])
+  })
+
+  it('evicts until the byte budget is met', () => {
+    const cache = new Cache<number, { size: number }>({
+      maxBytes: 100,
+      sizeOf: ({ size }) => size
+    })
+
+    cache.set(1, { size: 40 })
+    cache.set(2, { size: 40 })
+    expect(cache.bytes).toBe(80)
+
+    cache.set(3, { size: 50 })
+
+    expect(cache.keys()).toEqual([2, 3])
+    expect(cache.bytes).toBe(90)
+  })
+
+  it('keeps track of the byte cost on replace, delete and clear', () => {
+    const cache = new Cache<number, { size: number }>({
+      maxBytes: 100,
+      sizeOf: ({ size }) => size
+    })
+
+    cache.set(1, { size: 40 })
+    cache.set(1, { size: 10 })
+    expect(cache.bytes).toBe(10)
+
+    cache.set(2, { size: 20 })
+    cache.delete(2)
+    expect(cache.bytes).toBe(10)
+
+    cache.clear()
+    expect(cache.bytes).toBe(0)
   })
 
   it('calls onEvict for expired entries', () => {
@@ -199,14 +247,17 @@ describe('cache', () => {
       expect(cache.set(key, value)).toBe(value)
       expect(cache.get(key)).toBe(value)
     })
-    it('should evict on any access', () => {
-      cache.set(key, value)
-      cache.get(key)
+    it('should evict before handing out all entries', () => {
       cache.entries()
       cache.keys()
       cache.values()
+      expect(evictSpy).toHaveBeenCalledTimes(3)
+    })
+    it('should not walk the whole cache on single lookups', () => {
+      cache.set(key, value)
+      cache.get(key)
       cache.has(key)
-      expect(evictSpy).toHaveBeenCalledTimes(6)
+      expect(evictSpy).not.toHaveBeenCalled()
     })
     it('should delete key', () => {
       cache.set(key, value)

--- a/packages/web-pkg/tests/unit/services/cache.spec.ts
+++ b/packages/web-pkg/tests/unit/services/cache.spec.ts
@@ -7,5 +7,53 @@ describe('cache', () => {
       const filePreviewCache = cacheService.filePreview
       expect(filePreviewCache).toBeInstanceOf(Cache)
     })
+
+    describe('filePreview object URLs', () => {
+      const revokeObjectURL = vi.fn()
+
+      beforeEach(() => {
+        cacheService.filePreview.clear()
+        revokeObjectURL.mockClear()
+        window.URL.revokeObjectURL = revokeObjectURL
+      })
+
+      it('revokes the object URL when an entry is deleted', () => {
+        cacheService.filePreview.set('1', { src: 'blob:preview-1' }, 0)
+        cacheService.filePreview.delete('1')
+
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-1')
+      })
+
+      it('revokes the object URL when an entry is replaced', () => {
+        cacheService.filePreview.set('1', { src: 'blob:preview-1' }, 0)
+        cacheService.filePreview.set('1', { src: 'blob:preview-2' }, 0)
+
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-1')
+        expect(revokeObjectURL).not.toHaveBeenCalledWith('blob:preview-2')
+      })
+
+      it('does not revoke when the replacement carries the same object URL', () => {
+        cacheService.filePreview.set('1', { src: 'blob:preview-1', etag: 'a' }, 0)
+        cacheService.filePreview.set('1', { src: 'blob:preview-1', etag: 'b' }, 0)
+
+        expect(revokeObjectURL).not.toHaveBeenCalled()
+      })
+
+      it('revokes the object URLs when the cache is cleared', () => {
+        cacheService.filePreview.set('1', { src: 'blob:preview-1' }, 0)
+        cacheService.filePreview.set('2', { src: 'blob:preview-2' }, 0)
+        cacheService.filePreview.clear()
+
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-1')
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-2')
+      })
+
+      it('does not revoke plain URLs', () => {
+        cacheService.filePreview.set('1', { src: 'https://example.org/preview.png' }, 0)
+        cacheService.filePreview.delete('1')
+
+        expect(revokeObjectURL).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/packages/web-pkg/tests/unit/services/previewService.spec.ts
+++ b/packages/web-pkg/tests/unit/services/previewService.spec.ts
@@ -1,4 +1,4 @@
-import { ClientService, PreviewService } from '../../../src/services'
+import { cacheService, ClientService, PreviewService } from '../../../src/services'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 import { Resource, SpaceResource } from '@opencloud-eu/web-client'
@@ -153,6 +153,37 @@ describe('PreviewService', () => {
         )
         expect(preview).toEqual(cachedPreview)
         expect(clientService.httpAuthenticated.get).toHaveBeenCalledTimes(1)
+      })
+      it('stores the blob size so cached previews count towards the budget', async () => {
+        const supportedMimeTypes = ['image/png']
+        const { previewService, clientService } = getWrapper({
+          supportedMimeTypes,
+          version: '1'
+        })
+        clientService.httpAuthenticated.get.mockResolvedValue({
+          data: mock<Blob>({ size: 4096 }),
+          status: 200
+        } as AxiosResponse)
+        window.URL.createObjectURL = vi.fn().mockImplementation(() => 'objectUrl')
+
+        await previewService.loadPreview(
+          {
+            space: mock<SpaceResource>(),
+            resource: mock<Resource>({
+              id: '2',
+              mimeType: supportedMimeTypes[0],
+              webDavPath: '/',
+              etag: '',
+              hasPreview: () => true,
+              canDownload: () => true
+            })
+          },
+          true
+        )
+
+        expect(cacheService.filePreview.get('2')).toEqual(
+          expect.objectContaining({ src: 'objectUrl', size: 4096 })
+        )
       })
     })
     describe('public files', () => {

--- a/packages/web-pkg/tests/unit/services/previewService.spec.ts
+++ b/packages/web-pkg/tests/unit/services/previewService.spec.ts
@@ -1,4 +1,9 @@
-import { cacheService, ClientService, PreviewService } from '../../../src/services'
+import {
+  buildFilePreviewCacheKey,
+  cacheService,
+  ClientService,
+  PreviewService
+} from '../../../src/services'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { createTestingPinia } from '@opencloud-eu/web-test-helpers'
 import { Resource, SpaceResource } from '@opencloud-eu/web-client'
@@ -181,9 +186,48 @@ describe('PreviewService', () => {
           true
         )
 
-        expect(cacheService.filePreview.get('2')).toEqual(
+        expect(cacheService.filePreview.get(buildFilePreviewCacheKey('2'))).toEqual(
           expect.objectContaining({ src: 'objectUrl', size: 4096 })
         )
+      })
+      it('caches previews of the same resource per dimensions', async () => {
+        const supportedMimeTypes = ['image/png']
+        const { previewService, clientService } = getWrapper({
+          supportedMimeTypes,
+          version: '1'
+        })
+        const resourceMock = mock<Resource>({
+          id: '3',
+          mimeType: supportedMimeTypes[0],
+          webDavPath: '/',
+          etag: '',
+          hasPreview: () => true,
+          canDownload: () => true
+        })
+        let objectUrlCount = 0
+        window.URL.createObjectURL = vi
+          .fn()
+          .mockImplementation(() => `blob:objectUrl-${++objectUrlCount}`)
+        window.URL.revokeObjectURL = vi.fn()
+
+        const thumbnail = await previewService.loadPreview(
+          { space: mock<SpaceResource>(), resource: resourceMock, dimensions: [36, 36] },
+          true
+        )
+        const preview = await previewService.loadPreview(
+          { space: mock<SpaceResource>(), resource: resourceMock, dimensions: [1200, 1200] },
+          true
+        )
+
+        expect(thumbnail).not.toEqual(preview)
+        expect(clientService.httpAuthenticated.get).toHaveBeenCalledTimes(2)
+        expect(window.URL.revokeObjectURL).not.toHaveBeenCalled()
+        expect(cacheService.filePreview.get(buildFilePreviewCacheKey('3', [36, 36]))?.src).toEqual(
+          thumbnail
+        )
+        expect(
+          cacheService.filePreview.get(buildFilePreviewCacheKey('3', [1200, 1200]))?.src
+        ).toEqual(preview)
       })
     })
     describe('public files', () => {


### PR DESCRIPTION
* Revoke preview URLs when cache entries get evicted to ensure we don't keep any stale preview URLs for files that are long gone.
* Introduce a byte limit to the preview cache, instead of a plain capacity limit. This makes more sense and generally increases the limit in file lists, which should improve performance in big file lists with lots of previews.
* Calling `get()` and `set()` on the cache stops looping the entire cache to evict and instead does a lookup.

refs https://github.com/opencloud-eu/web/issues/3167