### PR TITLE
feat(web-pkg): add text align support to tiptap-json strategy

### DIFF
--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -11,6 +11,7 @@ import FindAndReplace from '@tiptap/extension-find-and-replace'
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
+import TextAlign from '@tiptap/extension-text-align'
 import { EditorActionGroup, useEditorActions } from '../useEditorActions'
 import {
   BackgroundColor,
@@ -60,6 +61,9 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
       TableHeader,
       TaskList,
       TaskItem.configure({ nested: true }),
+      TextAlign.configure({
+        types: ['heading', 'paragraph']
+      }),
       FontFamily,
       TextStyle,
       Underline,
@@ -97,6 +101,10 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     taskList,
     blockquote,
     codeBlock,
+    alignLeft,
+    alignCenter,
+    alignRight,
+    alignJustify,
     horizontalRule,
     link,
     menuEmoji,
@@ -140,6 +148,11 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
           subscript(),
           superscript()
         ]
+      },
+      {
+        id: 'text-align',
+        title: $gettext('Text align'),
+        actions: [alignLeft(), alignCenter(), alignRight(), alignJustify()]
       },
       {
         id: 'lists',

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -32,6 +32,7 @@ describe('useStrategyTiptapJson', () => {
       expect(names).toContain('image')
       expect(names).toContain('link')
       expect(names).toContain('fileHandler')
+      expect(names).toContain('textAlign')
       const link = strategy.extensions().find(({ name }) => name === 'link')!
       expect(link.options).toMatchObject({
         openOnClick: false,
@@ -42,6 +43,17 @@ describe('useStrategyTiptapJson', () => {
   })
 
   describe('editorActionGroups', () => {
+    it('includes text align actions', () => {
+      const strategy = createStrategy()
+      const textAlignGroup = strategy.editorActionGroups().find((group) => group.id === 'text-align')
+      expect(textAlignGroup?.actions.map((action) => action.id)).toEqual([
+        'align-left',
+        'align-center',
+        'align-right',
+        'align-justify'
+      ])
+    })
+
     it('shows link in both toolbar and slash commands', () => {
       const action = createStrategy()
         .editorActionGroups()
@@ -59,7 +71,13 @@ describe('useStrategyTiptapJson', () => {
       const schema = getSchema(strategy.extensions())
       const json = {
         type: 'doc',
-        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }]
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { textAlign: null },
+            content: [{ type: 'text', text: 'hi' }]
+          }
+        ]
       }
       expect(strategy.serialize(schema.nodeFromJSON(json))).toBe(JSON.stringify(json))
     })

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -45,7 +45,9 @@ describe('useStrategyTiptapJson', () => {
   describe('editorActionGroups', () => {
     it('includes text align actions', () => {
       const strategy = createStrategy()
-      const textAlignGroup = strategy.editorActionGroups().find((group) => group.id === 'text-align')
+      const textAlignGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'text-align')
       expect(textAlignGroup?.actions.map((action) => action.id)).toEqual([
         'align-left',
         'align-center',

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -71,7 +71,14 @@ describe('useStrategyTiptapJson', () => {
     it('returns the ProseMirror document as a JSON string', () => {
       const strategy = createStrategy()
       const schema = getSchema(strategy.extensions())
-      const json = {
+      const json: {
+        type: 'doc'
+        content: Array<{
+          type: 'paragraph'
+          attrs: { textAlign: string | null }
+          content: Array<{ type: 'text'; text: string }>
+        }>
+      } = {
         type: 'doc',
         content: [
           {


### PR DESCRIPTION
## Description

This enhancement adds missing text alignment support to the `tiptap-json` content strategy so it matches the editor capabilities already available in other rich-text strategies.

Changes made:
- Added `TextAlign` extension to `tiptap-json` strategy with `heading` and `paragraph` support
- Added `text-align` action group (`align-left`, `align-center`, `align-right`, `align-justify`) to the `tiptap-json` strategy toolbar actions
- Extended unit tests to verify extension registration and text-align actions
- Updated JSON serialize test expectation to include `attrs.textAlign: null` on paragraph nodes

## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local development environment (macOS), pnpm + Vitest
- test case 1: verify `tiptap-json` strategy includes `textAlign` extension
- test case 2: verify `text-align` group exposes all four alignment actions
- test case 3: verify serialization output for paragraph includes `textAlign` attribute
- `pnpm test:unit --run packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts`

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
