### PR TITLE
feat(web-pkg): move text align into toolbar submenu

### DIFF
--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -102,6 +102,7 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
     heading4,
     blockquote,
     codeBlock,
+    textAlign,
     alignLeft,
     alignCenter,
     alignRight,
@@ -166,12 +167,17 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
       {
         id: 'text-align',
         title: $gettext('Text align'),
-        actions: [alignLeft(), alignCenter(), alignRight(), alignJustify()]
+        actions: [
+          { ...alignLeft(), showInToolbar: false },
+          { ...alignCenter(), showInToolbar: false },
+          { ...alignRight(), showInToolbar: false },
+          { ...alignJustify(), showInToolbar: false }
+        ]
       },
       {
         id: 'lists',
         title: $gettext('Lists'),
-        actions: [bulletList(), orderedList(), taskList()]
+        actions: [textAlign(), bulletList(), orderedList(), taskList()]
       },
       {
         id: 'insert',

--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -153,7 +153,6 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
           blockquote(),
           codeBlock(),
           fontSize(),
-          lineHeight(),
           textColor(),
           backgroundColor(),
           bold(),
@@ -165,6 +164,16 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
         ]
       },
       {
+        id: 'lists',
+        title: $gettext('Lists'),
+        actions: [bulletList(), orderedList(), taskList()]
+      },
+      {
+        id: 'text-layout',
+        title: $gettext('Text layout'),
+        actions: [textAlign(), lineHeight()]
+      },
+      {
         id: 'text-align',
         title: $gettext('Text align'),
         actions: [
@@ -173,11 +182,6 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
           { ...alignRight(), showInToolbar: false },
           { ...alignJustify(), showInToolbar: false }
         ]
-      },
-      {
-        id: 'lists',
-        title: $gettext('Lists'),
-        actions: [textAlign(), bulletList(), orderedList(), taskList()]
       },
       {
         id: 'insert',

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -151,6 +151,16 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
         ]
       },
       {
+        id: 'lists',
+        title: $gettext('Lists'),
+        actions: [bulletList(), orderedList(), taskList()]
+      },
+      {
+        id: 'text-layout',
+        title: $gettext('Text layout'),
+        actions: [textAlign(), lineHeight()]
+      },
+      {
         id: 'text-align',
         title: $gettext('Text align'),
         actions: [
@@ -161,14 +171,9 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
         ]
       },
       {
-        id: 'lists',
-        title: $gettext('Lists'),
-        actions: [textAlign(), bulletList(), orderedList(), taskList()]
-      },
-      {
         id: 'blocks',
         title: $gettext('Blocks'),
-        actions: [lineHeight(), blockquote(), codeBlock()]
+        actions: [blockquote(), codeBlock()]
       },
       {
         id: 'insert',

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -101,6 +101,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     taskList,
     blockquote,
     codeBlock,
+    textAlign,
     alignLeft,
     alignCenter,
     alignRight,
@@ -152,12 +153,17 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
       {
         id: 'text-align',
         title: $gettext('Text align'),
-        actions: [alignLeft(), alignCenter(), alignRight(), alignJustify()]
+        actions: [
+          { ...alignLeft(), showInToolbar: false },
+          { ...alignCenter(), showInToolbar: false },
+          { ...alignRight(), showInToolbar: false },
+          { ...alignJustify(), showInToolbar: false }
+        ]
       },
       {
         id: 'lists',
         title: $gettext('Lists'),
-        actions: [bulletList(), orderedList(), taskList()]
+        actions: [textAlign(), bulletList(), orderedList(), taskList()]
       },
       {
         id: 'blocks',

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -187,6 +187,8 @@ export function useEditorActions(state: TextEditorState) {
     title: $gettext('Align left'),
     icon: 'align-left',
     toolbarAction: (editor) => editor.chain().focus().setTextAlign('left').run(),
+    slashCommandAction: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).setTextAlign('left').run(),
     isActive: (editor) => editor.isActive({ textAlign: 'left' })
   })
 
@@ -195,6 +197,8 @@ export function useEditorActions(state: TextEditorState) {
     title: $gettext('Align center'),
     icon: 'align-center',
     toolbarAction: (editor) => editor.chain().focus().setTextAlign('center').run(),
+    slashCommandAction: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).setTextAlign('center').run(),
     isActive: (editor) => editor.isActive({ textAlign: 'center' })
   })
 
@@ -203,6 +207,8 @@ export function useEditorActions(state: TextEditorState) {
     title: $gettext('Align right'),
     icon: 'align-right',
     toolbarAction: (editor) => editor.chain().focus().setTextAlign('right').run(),
+    slashCommandAction: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).setTextAlign('right').run(),
     isActive: (editor) => editor.isActive({ textAlign: 'right' })
   })
 
@@ -211,7 +217,26 @@ export function useEditorActions(state: TextEditorState) {
     title: $gettext('Align justify'),
     icon: 'align-justify',
     toolbarAction: (editor) => editor.chain().focus().setTextAlign('justify').run(),
+    slashCommandAction: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).setTextAlign('justify').run(),
     isActive: (editor) => editor.isActive({ textAlign: 'justify' })
+  })
+
+  const textAlign = (): EditorAction => ({
+    id: 'text-align',
+    title: $gettext('Text align'),
+    icon: 'align-left',
+    showInSlashCommands: false,
+    childActions: [alignLeft(), alignCenter(), alignRight(), alignJustify()],
+    activeIcon: (editor) => {
+      const action = [alignJustify(), alignRight(), alignCenter(), alignLeft()].find((candidate) =>
+        candidate.isActive?.(editor)
+      )
+      if (!action?.icon) {
+        return undefined
+      }
+      return { icon: action.icon }
+    }
   })
 
   const textColor = (): EditorAction => ({
@@ -979,6 +1004,7 @@ export function useEditorActions(state: TextEditorState) {
     heading4,
     fontSize,
     textColor,
+    textAlign,
     alignLeft,
     alignCenter,
     alignRight,

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -388,6 +388,14 @@ describe('useEditorActions', () => {
           expect(editor._chain.run).toHaveBeenCalled()
         })
 
+        it('slashCommandAction deletes range then sets the correct text alignment', () => {
+          const editor = createMockEditor()
+          actions[name]().slashCommandAction!({ editor, range: mockRange })
+          expect(editor._chain.deleteRange).toHaveBeenCalledWith(mockRange)
+          expect(editor._chain.setTextAlign).toHaveBeenCalledWith(alignment)
+          expect(editor._chain.run).toHaveBeenCalled()
+        })
+
         it('isActive checks the correct alignment', () => {
           const editor = createMockEditor({
             isActive: (attrs) => (attrs as { textAlign?: string } | null)?.textAlign === alignment
@@ -396,6 +404,26 @@ describe('useEditorActions', () => {
         })
       })
     }
+  })
+
+  describe('textAlign menu action', () => {
+    it('contains all text alignment actions as child actions', () => {
+      const action = actions.textAlign()
+      expect(action.showInSlashCommands).toBe(false)
+      expect(action.childActions?.map((child) => child.id)).toEqual([
+        'align-left',
+        'align-center',
+        'align-right',
+        'align-justify'
+      ])
+    })
+
+    it('activeIcon reflects the current active alignment', () => {
+      const editor = createMockEditor({
+        isActive: (attrs) => (attrs as { textAlign?: string } | null)?.textAlign === 'right'
+      })
+      expect(actions.textAlign().activeIcon?.(editor)).toEqual({ icon: 'align-right' })
+    })
   })
 
   describe('list actions', () => {

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -71,14 +71,19 @@ describe('useStrategyHtml', () => {
       expect(link.showInSlashCommands).not.toBe(false)
     })
 
-    it('puts text align menu at the beginning of the lists group', () => {
+    it('puts text align menu in the text layout group with line height', () => {
       const strategy = createStrategy()
-      const listsGroup = strategy.editorActionGroups().find((group) => group.id === 'lists')
+      const textLayoutGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'text-layout')
       const textAlignGroup = strategy
         .editorActionGroups()
         .find((group) => group.id === 'text-align')
-      expect(listsGroup?.actions[0].id).toBe('text-align')
-      expect(listsGroup?.actions[0].childActions?.map((action) => action.id)).toEqual([
+      expect(textLayoutGroup?.actions.map((action) => action.id)).toEqual([
+        'text-align',
+        'line-height'
+      ])
+      expect(textLayoutGroup?.actions[0].childActions?.map((action) => action.id)).toEqual([
         'align-left',
         'align-center',
         'align-right',
@@ -89,6 +94,15 @@ describe('useStrategyHtml', () => {
           .filter((action) => action.id.startsWith('align-'))
           .every((action) => action.showInToolbar === false)
       ).toBe(true)
+      const listsGroup = strategy.editorActionGroups().find((group) => group.id === 'lists')
+      expect(listsGroup?.actions.map((action) => action.id)).toEqual([
+        'bullet-list',
+        'ordered-list',
+        'task-list'
+      ])
+      const groupIds = strategy.editorActionGroups().map((group) => group.id)
+      expect(groupIds.indexOf('text-layout')).toBeGreaterThan(groupIds.indexOf('lists'))
+      expect(groupIds.indexOf('text-align')).toBeGreaterThan(groupIds.indexOf('lists'))
     })
 
     it('includes source mode toggle', () => {

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -71,6 +71,26 @@ describe('useStrategyHtml', () => {
       expect(link.showInSlashCommands).not.toBe(false)
     })
 
+    it('puts text align menu at the beginning of the lists group', () => {
+      const strategy = createStrategy()
+      const listsGroup = strategy.editorActionGroups().find((group) => group.id === 'lists')
+      const textAlignGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'text-align')
+      expect(listsGroup?.actions[0].id).toBe('text-align')
+      expect(listsGroup?.actions[0].childActions?.map((action) => action.id)).toEqual([
+        'align-left',
+        'align-center',
+        'align-right',
+        'align-justify'
+      ])
+      expect(
+        textAlignGroup?.actions
+          .filter((action) => action.id.startsWith('align-'))
+          .every((action) => action.showInToolbar === false)
+      ).toBe(true)
+    })
+
     it('includes source mode toggle', () => {
       const strategy = createStrategy()
       const allIds = strategy.editorActionGroups().flatMap((g) => g.actions.map((a) => a.id))

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -43,14 +43,19 @@ describe('useStrategyTiptapJson', () => {
   })
 
   describe('editorActionGroups', () => {
-    it('puts text align menu at the beginning of the lists group', () => {
+    it('puts text align menu in the text layout group with line height', () => {
       const strategy = createStrategy()
-      const listsGroup = strategy.editorActionGroups().find((group) => group.id === 'lists')
+      const textLayoutGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'text-layout')
       const textAlignGroup = strategy
         .editorActionGroups()
         .find((group) => group.id === 'text-align')
-      expect(listsGroup?.actions[0].id).toBe('text-align')
-      expect(listsGroup?.actions[0].childActions?.map((action) => action.id)).toEqual([
+      expect(textLayoutGroup?.actions.map((action) => action.id)).toEqual([
+        'text-align',
+        'line-height'
+      ])
+      expect(textLayoutGroup?.actions[0].childActions?.map((action) => action.id)).toEqual([
         'align-left',
         'align-center',
         'align-right',
@@ -61,6 +66,15 @@ describe('useStrategyTiptapJson', () => {
           .filter((action) => action.id.startsWith('align-'))
           .every((action) => action.showInToolbar === false)
       ).toBe(true)
+      const listsGroup = strategy.editorActionGroups().find((group) => group.id === 'lists')
+      expect(listsGroup?.actions.map((action) => action.id)).toEqual([
+        'bullet-list',
+        'ordered-list',
+        'task-list'
+      ])
+      const groupIds = strategy.editorActionGroups().map((group) => group.id)
+      expect(groupIds.indexOf('text-layout')).toBeGreaterThan(groupIds.indexOf('lists'))
+      expect(groupIds.indexOf('text-align')).toBeGreaterThan(groupIds.indexOf('lists'))
     })
 
     it('shows link in both toolbar and slash commands', () => {

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -45,9 +45,7 @@ describe('useStrategyTiptapJson', () => {
   describe('editorActionGroups', () => {
     it('puts text align menu at the beginning of the lists group', () => {
       const strategy = createStrategy()
-      const listsGroup = strategy
-        .editorActionGroups()
-        .find((group) => group.id === 'lists')
+      const listsGroup = strategy.editorActionGroups().find((group) => group.id === 'lists')
       const textAlignGroup = strategy
         .editorActionGroups()
         .find((group) => group.id === 'text-align')

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -43,17 +43,26 @@ describe('useStrategyTiptapJson', () => {
   })
 
   describe('editorActionGroups', () => {
-    it('includes text align actions', () => {
+    it('puts text align menu at the beginning of the lists group', () => {
       const strategy = createStrategy()
+      const listsGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'lists')
       const textAlignGroup = strategy
         .editorActionGroups()
         .find((group) => group.id === 'text-align')
-      expect(textAlignGroup?.actions.map((action) => action.id)).toEqual([
+      expect(listsGroup?.actions[0].id).toBe('text-align')
+      expect(listsGroup?.actions[0].childActions?.map((action) => action.id)).toEqual([
         'align-left',
         'align-center',
         'align-right',
         'align-justify'
       ])
+      expect(
+        textAlignGroup?.actions
+          .filter((action) => action.id.startsWith('align-'))
+          .every((action) => action.showInToolbar === false)
+      ).toBe(true)
     })
 
     it('shows link in both toolbar and slash commands', () => {


### PR DESCRIPTION
## Description

This enhancement reorganizes text alignment controls in the text editor so toolbar and command-group structure are clearer and more consistent.

Changes made:
- Introduced a `text-align` menu action with child actions for left/center/right/justify (submenu pattern, similar to color controls)
- Added a new `Text layout` toolbar group and placed `text-align` before `line-height` inside that group
- Kept `Lists` as its own toolbar group before `Text layout`
- Kept a dedicated `Text align` command group for slash commands
- Extended strategy and editor-action tests for submenu behavior, ordering, and command execution

## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local development environment (macOS), pnpm + Vitest
- test case 1: verify `text-align` is rendered as submenu action with expected child actions
- test case 2: verify toolbar group order (`Lists` before `Text layout`) and `Text layout` action order (`text-align` before `line-height`)
- test case 3: verify text-align command group and command execution paths
- `pnpm test:unit --run packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts packages/web-pkg/tests/unit/editor/strategies/html.spec.ts packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts`

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
