### PR TITLE
fix(web-pkg): improve text editor action-group consistency

### DIFF
--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -186,12 +186,12 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
       {
         id: 'insert',
         title: $gettext('Insert'),
+        actions: [link(), image(), imageUrl(), imageUpload(), createTable(), menuEmoji(), horizontalRule()]
+      },
+      {
+        id: 'table-tools',
+        title: $gettext('Table tools'),
         actions: [
-          link(),
-          image(),
-          imageUrl(),
-          imageUpload(),
-          createTable(),
           toggleHeaderRow(),
           addRowBefore(),
           addRowAfter(),
@@ -199,9 +199,7 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
           addColumnBefore(),
           addColumnAfter(),
           deleteColumn(),
-          deleteTable(),
-          menuEmoji(),
-          horizontalRule()
+          deleteTable()
         ]
       },
       {

--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -186,7 +186,15 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
       {
         id: 'insert',
         title: $gettext('Insert'),
-        actions: [link(), image(), imageUrl(), imageUpload(), createTable(), menuEmoji(), horizontalRule()]
+        actions: [
+          link(),
+          image(),
+          imageUrl(),
+          imageUpload(),
+          createTable(),
+          menuEmoji(),
+          horizontalRule()
+        ]
       },
       {
         id: 'table-tools',

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -139,6 +139,8 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
           heading2(),
           heading3(),
           heading4(),
+          blockquote(),
+          codeBlock(),
           fontSize(),
           textColor(),
           backgroundColor(),
@@ -171,19 +173,14 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
         ]
       },
       {
-        id: 'blocks',
-        title: $gettext('Blocks'),
-        actions: [blockquote(), codeBlock()]
-      },
-      {
         id: 'insert',
         title: $gettext('Insert'),
+        actions: [link(), image(), imageUrl(), imageUpload(), createTable(), menuEmoji(), horizontalRule()]
+      },
+      {
+        id: 'table-tools',
+        title: $gettext('Table tools'),
         actions: [
-          link(),
-          image(),
-          imageUrl(),
-          imageUpload(),
-          createTable(),
           toggleHeaderRow(),
           addRowBefore(),
           addRowAfter(),
@@ -191,9 +188,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
           addColumnBefore(),
           addColumnAfter(),
           deleteColumn(),
-          deleteTable(),
-          menuEmoji(),
-          horizontalRule()
+          deleteTable()
         ]
       },
       {

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -175,7 +175,15 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
       {
         id: 'insert',
         title: $gettext('Insert'),
-        actions: [link(), image(), imageUrl(), imageUpload(), createTable(), menuEmoji(), horizontalRule()]
+        actions: [
+          link(),
+          image(),
+          imageUrl(),
+          imageUpload(),
+          createTable(),
+          menuEmoji(),
+          horizontalRule()
+        ]
       },
       {
         id: 'table-tools',

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -71,6 +71,25 @@ describe('useStrategyHtml', () => {
       expect(link.showInSlashCommands).not.toBe(false)
     })
 
+    it('puts table editing actions into a dedicated table tools group', () => {
+      const strategy = createStrategy()
+      const insertGroup = strategy.editorActionGroups().find((group) => group.id === 'insert')
+      const tableToolsGroup = strategy.editorActionGroups().find((group) => group.id === 'table-tools')
+
+      expect(insertGroup?.actions.map((action) => action.id)).toContain('table')
+      expect(insertGroup?.actions.map((action) => action.id)).not.toContain('add-row-before')
+      expect(tableToolsGroup?.actions.map((action) => action.id)).toEqual([
+        'toggle-header-row',
+        'add-row-before',
+        'add-row-after',
+        'delete-row',
+        'add-column-before',
+        'add-column-after',
+        'delete-column',
+        'delete-table'
+      ])
+    })
+
     it('puts text align menu in the text layout group with line height', () => {
       const strategy = createStrategy()
       const textLayoutGroup = strategy

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -74,7 +74,9 @@ describe('useStrategyHtml', () => {
     it('puts table editing actions into a dedicated table tools group', () => {
       const strategy = createStrategy()
       const insertGroup = strategy.editorActionGroups().find((group) => group.id === 'insert')
-      const tableToolsGroup = strategy.editorActionGroups().find((group) => group.id === 'table-tools')
+      const tableToolsGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'table-tools')
 
       expect(insertGroup?.actions.map((action) => action.id)).toContain('table')
       expect(insertGroup?.actions.map((action) => action.id)).not.toContain('add-row-before')

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -43,6 +43,33 @@ describe('useStrategyTiptapJson', () => {
   })
 
   describe('editorActionGroups', () => {
+    it('puts table editing actions into a dedicated table tools group', () => {
+      const strategy = createStrategy()
+      const insertGroup = strategy.editorActionGroups().find((group) => group.id === 'insert')
+      const tableToolsGroup = strategy.editorActionGroups().find((group) => group.id === 'table-tools')
+
+      expect(insertGroup?.actions.map((action) => action.id)).toContain('table')
+      expect(insertGroup?.actions.map((action) => action.id)).not.toContain('add-row-before')
+      expect(tableToolsGroup?.actions.map((action) => action.id)).toEqual([
+        'toggle-header-row',
+        'add-row-before',
+        'add-row-after',
+        'delete-row',
+        'add-column-before',
+        'add-column-after',
+        'delete-column',
+        'delete-table'
+      ])
+    })
+
+    it('keeps blockquote and code block in the formatting group', () => {
+      const strategy = createStrategy()
+      const formattingGroup = strategy.editorActionGroups().find((group) => group.id === 'formatting')
+      expect(formattingGroup?.actions.map((action) => action.id)).toContain('blockquote')
+      expect(formattingGroup?.actions.map((action) => action.id)).toContain('code-block')
+      expect(strategy.editorActionGroups().some((group) => group.id === 'blocks')).toBe(false)
+    })
+
     it('puts text align menu in the text layout group with line height', () => {
       const strategy = createStrategy()
       const textLayoutGroup = strategy

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -46,7 +46,9 @@ describe('useStrategyTiptapJson', () => {
     it('puts table editing actions into a dedicated table tools group', () => {
       const strategy = createStrategy()
       const insertGroup = strategy.editorActionGroups().find((group) => group.id === 'insert')
-      const tableToolsGroup = strategy.editorActionGroups().find((group) => group.id === 'table-tools')
+      const tableToolsGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'table-tools')
 
       expect(insertGroup?.actions.map((action) => action.id)).toContain('table')
       expect(insertGroup?.actions.map((action) => action.id)).not.toContain('add-row-before')
@@ -64,7 +66,9 @@ describe('useStrategyTiptapJson', () => {
 
     it('keeps blockquote and code block in the formatting group', () => {
       const strategy = createStrategy()
-      const formattingGroup = strategy.editorActionGroups().find((group) => group.id === 'formatting')
+      const formattingGroup = strategy
+        .editorActionGroups()
+        .find((group) => group.id === 'formatting')
       expect(formattingGroup?.actions.map((action) => action.id)).toContain('blockquote')
       expect(formattingGroup?.actions.map((action) => action.id)).toContain('code-block')
       expect(strategy.editorActionGroups().some((group) => group.id === 'blocks')).toBe(false)


### PR DESCRIPTION
## Description

This bugfix focuses on editor action-group consistency for table and block actions.

Changes made:
- Added a dedicated `Table tools` group for table-editing actions (`add/delete row`, `add/delete column`, `toggle header row`, `delete table`)
- Kept `createTable` in `Insert` so table creation stays separate from table editing
- In tiptap-json, removed the separate `Blocks` group
- In tiptap-json, moved `blockquote` and `code-block` into `Formatting` directly below `Heading 4`
- Updated strategy unit tests for the new group composition and ordering

## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local development environment (macOS), pnpm + Vitest
- test case 1: verify table-editing actions are in `Table tools` and `createTable` remains in `Insert`
- test case 2: verify tiptap-json no longer exposes a separate `Blocks` group
- test case 3: verify `blockquote` and `code-block` are part of `Formatting` in tiptap-json
- `pnpm test:unit --run packages/web-pkg/tests/unit/editor/strategies/html.spec.ts packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts`

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
