### PR TITLE
perf: drop queued previews leaving the viewport

### DIFF
--- a/packages/design-system/src/components/OcTable/OcTable.vue
+++ b/packages/design-system/src/components/OcTable/OcTable.vue
@@ -80,6 +80,7 @@
         @dragenter="dropRowStyling(item, false, $event)"
         @dragleave="dropRowStyling(item, true, $event)"
         @item-visible="$emit('itemVisible', item)"
+        @item-hidden="$emit('itemHidden', item)"
       >
         <template v-for="(_, name) in $slots" #[name]="slotProps">
           <slot :name="name" v-bind="slotProps" />
@@ -256,6 +257,11 @@ export interface Emits {
    * @docs Emitted when an item has been scrolled into the view.
    */
   (e: 'itemVisible', item: Item): void
+
+  /**
+   * @docs Emitted when an item has been scrolled out of the view.
+   */
+  (e: 'itemHidden', item: Item): void
 }
 
 export interface Slots {

--- a/packages/design-system/src/components/OcTableRow/OcTableRow.vue
+++ b/packages/design-system/src/components/OcTableRow/OcTableRow.vue
@@ -13,6 +13,7 @@
     @dragleave.prevent="$emit('dragleave', $event)"
     @dragover.prevent
     @item-visible="$emit('itemVisible')"
+    @item-hidden="$emit('itemHidden')"
   >
     <oc-td
       v-for="(field, tdIndex) in fields"
@@ -114,6 +115,7 @@ defineEmits<{
   (e: 'dragenter', event: DragEvent): void
   (e: 'dragleave', event: DragEvent): void
   (e: 'itemVisible'): void
+  (e: 'itemHidden'): void
 }>()
 
 defineSlots<{

--- a/packages/design-system/src/components/OcTableTr/OcTableTr.vue
+++ b/packages/design-system/src/components/OcTableTr/OcTableTr.vue
@@ -39,7 +39,8 @@ const emit = defineEmits([
   'dragleave',
   'dragover',
   'mouseleave',
-  'itemVisible'
+  'itemVisible',
+  'itemHidden'
 ])
 
 const observerTarget = customRef((track, trigger) => {
@@ -64,7 +65,8 @@ const { isVisible } = lazy
   ? useIsVisible({
       ...lazy,
       target: observerTarget as Ref<HTMLElement>,
-      onVisibleCallback: () => emit('itemVisible')
+      onVisibleCallback: () => emit('itemVisible'),
+      onHiddenCallback: () => emit('itemHidden')
     })
   : { isVisible: ref(true) }
 

--- a/packages/design-system/src/composables/useIsVisible/index.ts
+++ b/packages/design-system/src/composables/useIsVisible/index.ts
@@ -1,15 +1,17 @@
-import { Ref, onBeforeUnmount, ref, unref, watch } from 'vue'
+import { Ref, onBeforeUnmount, ref, watch } from 'vue'
 
 export const useIsVisible = ({
   target,
   mode = 'show',
   rootMargin = '100px',
-  onVisibleCallback
+  onVisibleCallback,
+  onHiddenCallback
 }: {
   target: Ref<Element>
   mode?: string
   rootMargin?: string
   onVisibleCallback?: () => void
+  onHiddenCallback?: () => void
 }) => {
   const isSupported = window && 'IntersectionObserver' in window
   if (!isSupported) {
@@ -19,6 +21,7 @@ export const useIsVisible = ({
   }
 
   const isVisible = ref(false)
+  let hasBeenVisible = false
   const observer = new IntersectionObserver(
     (intersectionObserverEntries: IntersectionObserverEntry[]) => {
       /**
@@ -28,21 +31,31 @@ export const useIsVisible = ({
        */
       const isIntersecting = intersectionObserverEntries.at(-1).isIntersecting
 
-      isVisible.value = isIntersecting
-      if (unref(isVisible) && onVisibleCallback) {
-        onVisibleCallback()
+      /**
+       * In mode `show` the target stays visible once it has been visible.
+       */
+      if (mode === 'showHide' || !hasBeenVisible) {
+        isVisible.value = isIntersecting
+      }
+
+      if (isIntersecting) {
+        hasBeenVisible = true
+        onVisibleCallback?.()
+      } else if (hasBeenVisible) {
+        onHiddenCallback?.()
       }
 
       /**
        * if given mode is `showHide` we need to keep the observation alive.
+       * the same applies if the caller wants to be notified about targets leaving the viewport.
        */
-      if (mode === 'showHide') {
+      if (mode === 'showHide' || onHiddenCallback) {
         return
       }
       /**
        * if the mode is `show` which is the default, the implementation needs to unsubscribe the target from the observer
        */
-      if (!isVisible.value) {
+      if (!isIntersecting) {
         return
       }
 

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -116,6 +116,7 @@
               ...(isProjectSpaceResource($event) && { processor: ProcessorType.enum.fit })
             })
           "
+          @item-hidden="dropPreview($event)"
           @sort="handleSort"
           @update:selected-ids="selectedResourcesIds = $event"
         >
@@ -265,7 +266,7 @@ const {
   folderViewExtensionPoint: folderViewsSearchExtensionPoint
 })
 
-const { loadPreview } = useLoadPreview(viewMode)
+const { loadPreview, dropPreview } = useLoadPreview(viewMode)
 const keyActions = useKeyboardActions()
 useKeyboardFileNavigation(keyActions, paginatedResources, viewMode)
 useKeyboardFileMouseActions(keyActions, viewMode)

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -31,6 +31,7 @@
       :view-size="viewSize"
       @file-click="triggerDefaultAction"
       @item-visible="loadPreview({ space: getMatchingSpace($event), resource: $event })"
+      @item-hidden="dropPreview($event)"
       @sort="sortHandler"
       @update:selected-ids="selectedResourcesIds = $event"
     >
@@ -121,7 +122,7 @@ const {
 const { $gettext } = useGettext()
 const { getMatchingSpace } = useGetMatchingSpace()
 
-const { loadPreview } = useLoadPreview(computed(() => viewMode))
+const { loadPreview, dropPreview } = useLoadPreview(computed(() => viewMode))
 
 const { triggerDefaultAction } = useFileActions()
 const { actions: hideShareActions } = useFileActionsToggleHideShare()

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -78,6 +78,7 @@
               ...(isProjectSpaceResource($event) && { processor: ProcessorType.enum.fit })
             })
           "
+          @item-hidden="dropPreview($event)"
           @sort="handleSort"
           @update:selected-ids="selectedResourcesIds = $event"
         >
@@ -211,7 +212,7 @@ const {
 
 const { triggerDefaultAction } = useFileActions()
 
-const { loadPreview } = useLoadPreview(viewMode)
+const { loadPreview, dropPreview } = useLoadPreview(viewMode)
 
 const breadcrumbs = computed(() => {
   return [

--- a/packages/web-app-files/src/views/shares/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/shares/SharedViaLink.vue
@@ -46,6 +46,7 @@
           :view-size="viewSize"
           @file-click="triggerDefaultAction"
           @item-visible="loadPreview({ space: getMatchingSpace($event), resource: $event })"
+          @item-hidden="dropPreview($event)"
           @sort="handleSort"
           @update:selected-ids="selectedResourcesIds = $event"
         >
@@ -125,7 +126,7 @@ const {
 
 const { triggerDefaultAction } = useFileActions()
 
-const { loadPreview } = useLoadPreview(viewMode)
+const { loadPreview, dropPreview } = useLoadPreview(viewMode)
 
 const filterTerm = ref('')
 const filteredItems = computed(() => {

--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -70,6 +70,7 @@
           :view-size="viewSize"
           @file-click="triggerDefaultAction"
           @item-visible="loadPreview({ space: getMatchingSpace($event), resource: $event })"
+          @item-hidden="dropPreview($event)"
           @sort="handleSort"
           @update:selected-ids="selectedResourcesIds = $event"
         >
@@ -154,7 +155,7 @@ const {
 
 const { triggerDefaultAction } = useFileActions()
 
-const { loadPreview } = useLoadPreview(viewMode)
+const { loadPreview, dropPreview } = useLoadPreview(viewMode)
 
 const breadcrumbs = computed(() => {
   return [

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -62,6 +62,7 @@
               @file-dropped="fileDropped"
               @file-click="triggerDefaultAction"
               @item-visible="loadPreview({ space, resource: $event })"
+              @item-hidden="dropPreview($event)"
               @sort="handleSort"
               @update:selected-ids="selectedResourcesIds = $event"
             >
@@ -357,7 +358,7 @@ const {
   folderViewExtensionPoint: folderViewsFolderExtensionPoint
 })
 
-const { loadPreview } = useLoadPreview(viewMode)
+const { loadPreview, dropPreview } = useLoadPreview(viewMode)
 
 const keyActions = useKeyboardActions()
 useKeyboardFileNavigation(keyActions, paginatedResources, viewMode)

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -83,6 +83,7 @@
                 processor: ProcessorType.enum.fit
               })
             "
+            @item-hidden="dropPreview($event)"
             @update:selected-ids="selectedResourcesIds = $event"
           >
             <template #image="{ resource }">
@@ -341,7 +342,7 @@ watch(selectedResourcesIds, async (ids) => {
     graphClient: clientService.graphAuthenticated
   })
 })
-const { loadPreview } = useLoadPreview(viewMode)
+const { loadPreview, dropPreview } = useLoadPreview(viewMode)
 
 const keyActions = useKeyboardActions()
 useKeyboardFileNavigation(keyActions, items, viewMode)

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -63,6 +63,7 @@
                 processor: ProcessorType.enum.fit
               })
             "
+            @item-hidden="dropPreview($event)"
             @update:selected-ids="loadGraphPermissions"
           >
             <template #contextMenu="{ resource }">
@@ -157,7 +158,7 @@ const resourcesViewDefaults = useResourcesViewDefaults<SpaceResource, any, any>(
 const { fileListHeaderY, viewMode, viewModes, viewSize, sortFields, folderView } =
   resourcesViewDefaults
 
-const { loadPreview } = useLoadPreview(viewMode)
+const { loadPreview, dropPreview } = useLoadPreview(viewMode)
 
 const { areEmptyTrashesShown } = storeToRefs(resourcesStore)
 

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -155,6 +155,7 @@ const emit = defineEmits<{
   (e: 'fileNameClicked', event: MouseEvent | KeyboardEvent): void
   (e: 'contextmenu', event: MouseEvent | KeyboardEvent): void
   (e: 'itemVisible'): void
+  (e: 'itemHidden'): void
   (e: 'tileClicked', event: [Resource, MouseEvent | KeyboardEvent]): void
 }>()
 
@@ -219,7 +220,8 @@ const resourceDescription = computed(() => {
 const { isVisible } = lazy
   ? useIsVisible({
       target: observerTargetElement,
-      onVisibleCallback: () => emit('itemVisible')
+      onVisibleCallback: () => emit('itemVisible'),
+      onHiddenCallback: () => emit('itemHidden')
     })
   : { isVisible: ref(true) }
 

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -72,6 +72,7 @@
           @drop="fileDropped(resource, $event)"
           @dragover="$event.preventDefault()"
           @item-visible="$emit('itemVisible', resource)"
+          @item-hidden="$emit('itemHidden', resource)"
           @tile-clicked="fileContainerClicked({ resource, event: $event[1] })"
         >
           <template #selection="{ selected }">
@@ -209,6 +210,7 @@ const emit = defineEmits<{
   (e: 'fileDropped', id: string): void
   (e: 'sort', value: { sortBy: string; sortDir: SortDir }): void
   (e: 'itemVisible', resource: Resource): void
+  (e: 'itemHidden', resource: Resource): void
   (e: 'update:selectedIds', ids: string[]): void
 }>()
 

--- a/packages/web-pkg/src/composables/resources/useLoadPreview.ts
+++ b/packages/web-pkg/src/composables/resources/useLoadPreview.ts
@@ -34,11 +34,17 @@ type LoadPreviewOptions = {
   updateStore?: boolean
 }
 
+type QueuedPreview = {
+  controller: AbortController
+  isRunning: boolean
+}
+
 export const useLoadPreview = (viewMode?: Ref<string>) => {
   const previewService = usePreviewService()
   const { updateResourceField } = useResourcesStore()
   const spacesStore = useSpacesStore()
   const previewQueue = new PQueue({ concurrency: 4 })
+  const queuedPreviews = new Map<string, QueuedPreview>()
 
   const isTilesView = computed(() => unref(viewMode) === FolderViewModeConstants.name.tiles)
   const defaultProcessor = computed(() =>
@@ -60,32 +66,44 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
       spacesStore.addToImagesLoading(space.id)
     }
 
-    const preview = yield previewQueue.add(() =>
-      previewService.loadPreview(
-        {
-          space,
-          resource: item,
-          processor: processor || unref(defaultProcessor),
-          dimensions: dimensions || unref(defaultDimensions)
+    const queued: QueuedPreview = { controller: new AbortController(), isRunning: false }
+    queuedPreviews.set(resource.id, queued)
+
+    try {
+      const preview = yield previewQueue.add(
+        () => {
+          queued.isRunning = true
+          return previewService.loadPreview(
+            {
+              space,
+              resource: item,
+              processor: processor || unref(defaultProcessor),
+              dimensions: dimensions || unref(defaultDimensions)
+            },
+            true,
+            true,
+            signal
+          )
         },
-        true,
-        true,
-        signal
+        { signal: queued.controller.signal }
       )
-    )
 
-    if (preview && updateStore) {
-      updateResourceField({ id: resource.id, field: 'thumbnail', value: preview })
-    }
+      if (preview && updateStore) {
+        updateResourceField({ id: resource.id, field: 'thumbnail', value: preview })
+      }
 
-    if (isSpaceImage) {
-      spacesStore.removeFromImagesLoading(space.id)
+      return preview
+    } finally {
+      queuedPreviews.delete(resource.id)
+
+      if (isSpaceImage) {
+        spacesStore.removeFromImagesLoading(space.id)
+      }
     }
-    return preview
   })
 
   const loadPreview = async (options: LoadPreviewOptions) => {
-    const { resource, cancelRunning } = options
+    const { resource, cancelRunning, updateStore = true } = options
     if (cancelRunning) {
       cancelTasks()
     }
@@ -99,14 +117,37 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
       return null
     }
 
+    // already queued or running, no need to load it twice
+    if (queuedPreviews.has(resource.id)) {
+      return
+    }
+
+    // store-backed previews are loaded once, direct callers may want other dimensions
+    if (updateStore && resource.thumbnail) {
+      return resource.thumbnail
+    }
+
     try {
       return await loadPreviewTask.perform(options)
     } catch (e) {
-      // ignore errors on cancel
-      if (e !== 'cancel') {
+      // ignore errors on cancel or when the preview was dropped while queued
+      if (e !== 'cancel' && (e as Error)?.name !== 'AbortError') {
         console.error(e)
       }
     }
+  }
+
+  /**
+   * Remove a still queued preview from the queue, e.g. because the resource left the viewport.
+   * Running requests are left alone, their bytes are already paid for.
+   */
+  const dropPreview = (resource: Resource) => {
+    const queued = queuedPreviews.get(resource.id)
+    if (!queued || queued.isRunning) {
+      return
+    }
+
+    queued.controller.abort()
   }
 
   const previewsLoading = computed(() => loadPreviewTask.isRunning)
@@ -114,10 +155,11 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
   const cancelTasks = () => {
     loadPreviewTask.cancelAll()
     previewQueue.clear()
+    queuedPreviews.clear()
     spacesStore.purgeImagesLoading()
   }
 
   onUnmounted(cancelTasks)
 
-  return { loadPreview, previewsLoading }
+  return { loadPreview, dropPreview, previewsLoading }
 }

--- a/packages/web-pkg/tests/unit/composables/resources/useLoadPreview.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useLoadPreview.spec.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 import { defaultComponentMocks, getComposableWrapper } from '@opencloud-eu/web-test-helpers'
-import { mock } from 'vitest-mock-extended'
+import { mock, MockProxy } from 'vitest-mock-extended'
 import { buildSpaceImageResource, Resource, SpaceResource } from '@opencloud-eu/web-client'
 import { useLoadPreview } from '../../../../src/composables/resources'
 import { usePreviewService } from '../../../../src/composables/previewService'
@@ -26,7 +26,7 @@ describe('useLoadPreview', () => {
       getWrapper({
         setup: async ({ loadPreview }) => {
           const space = mock<SpaceResource>()
-          const resource = mock<Resource>({ isInVault: false })
+          const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
           const preview = await loadPreview({ space, resource })
           expect(preview).toEqual(loadedPreview)
         },
@@ -69,7 +69,8 @@ describe('useLoadPreview', () => {
             const space = mock<SpaceResource>({
               driveType: 'project',
               isInVault: false,
-              disabled: false
+              disabled: false,
+              thumbnail: undefined
             })
             const resource = space
             const preview = await loadPreview({ space, resource })
@@ -85,7 +86,8 @@ describe('useLoadPreview', () => {
               driveType: 'project',
               isInVault: false,
               disabled: false,
-              spaceImageData: { id: '1' }
+              spaceImageData: { id: '1' },
+              thumbnail: undefined
             })
             const resource = space
             const spacesStore = useSpacesStore()
@@ -101,7 +103,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ dimensions: ImageDimension.Thumbnail }),
@@ -116,7 +118,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ dimensions: [768, 768] }),
@@ -134,7 +136,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ dimensions: [448, 448] }),
@@ -152,7 +154,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ dimensions: [320, 320] }),
@@ -170,7 +172,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ dimensions: [512, 512] }),
@@ -188,7 +190,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ dimensions: [768, 768] }),
@@ -204,7 +206,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource, dimensions: ImageDimension.Preview })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ dimensions: ImageDimension.Preview }),
@@ -221,7 +223,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ processor: ProcessorType.enum.thumbnail }),
@@ -236,7 +238,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ processor: ProcessorType.enum.fit }),
@@ -252,7 +254,7 @@ describe('useLoadPreview', () => {
         getWrapper({
           setup: async ({ loadPreview }, { previewService }) => {
             const space = mock<SpaceResource>()
-            const resource = mock<Resource>({ isInVault: false })
+            const resource = mock<Resource>({ isInVault: false, thumbnail: undefined })
             await loadPreview({ space, resource, processor: ProcessorType.enum.resize })
             expect(previewService.loadPreview).toHaveBeenCalledWith(
               expect.objectContaining({ processor: ProcessorType.enum.resize }),
@@ -265,7 +267,66 @@ describe('useLoadPreview', () => {
       })
     })
   })
+
+  describe('dropPreview', () => {
+    it('drops a preview that is still queued', async () => {
+      let assertions: Promise<void>
+      getWrapper({
+        setup: ({ loadPreview, dropPreview }, { previewService }) => {
+          assertions = (async () => {
+            previewService.loadPreview.mockReturnValue(new Promise(() => {}))
+            const space = mock<SpaceResource>()
+            const running = Array.from({ length: 4 }, (_, i) =>
+              mock<Resource>({ id: `running-${i}`, isInVault: false, thumbnail: undefined })
+            )
+            const queued = mock<Resource>({ id: 'queued', isInVault: false, thumbnail: undefined })
+
+            running.forEach((resource) => loadPreview({ space, resource }))
+            const queuedPreview = loadPreview({ space, resource: queued })
+            await flushQueue()
+            dropPreview(queued)
+
+            expect(await queuedPreview).toBeUndefined()
+            // only the four running previews made it to the preview service
+            expect(previewService.loadPreview).toHaveBeenCalledTimes(4)
+          })()
+        }
+      })
+      await assertions
+    })
+    it('keeps a preview that is already running', async () => {
+      let assertions: Promise<void>
+      getWrapper({
+        setup: ({ loadPreview, dropPreview }, { previewService }) => {
+          assertions = (async () => {
+            let resolvePreview: (preview: string) => void
+            previewService.loadPreview.mockReturnValue(
+              new Promise((resolve) => (resolvePreview = resolve))
+            )
+            const space = mock<SpaceResource>()
+            const resource = mock<Resource>({
+              id: 'running',
+              isInVault: false,
+              thumbnail: undefined
+            })
+
+            const preview = loadPreview({ space, resource })
+            await flushQueue()
+            dropPreview(resource)
+            resolvePreview('blob:image')
+
+            expect(await preview).toEqual('blob:image')
+          })()
+        }
+      })
+      await assertions
+    })
+  })
 })
+
+function flushQueue() {
+  return new Promise((resolve) => setTimeout(resolve))
+}
 
 function getWrapper({
   setup,
@@ -274,7 +335,7 @@ function getWrapper({
 }: {
   setup: (
     instance: ReturnType<typeof useLoadPreview>,
-    mocks: { previewService: PreviewService }
+    mocks: { previewService: MockProxy<PreviewService> }
   ) => void
   loadedPreview?: string
   viewMode?: string


### PR DESCRIPTION
Drop previews from the loading queue when they have not yet been loaded and leave the viewport.

This boosts performance when scrolling over a big file list fast, since there is no need to load a preview for a resource the user just scrolled by fast.

refs https://github.com/opencloud-eu/web/issues/3167