### PR TITLE
perf: decode thumbnails asynchronously

### DIFF
--- a/packages/design-system/src/components/OcImage/OcImage.vue
+++ b/packages/design-system/src/components/OcImage/OcImage.vue
@@ -1,5 +1,12 @@
 <template>
-  <img :src="src" :alt="alt" :aria-hidden="`${ariaHidden}`" :title="title" :loading="loadingType" />
+  <img
+    :src="src"
+    :alt="alt"
+    :aria-hidden="`${ariaHidden}`"
+    :title="title"
+    :loading="loadingType"
+    :decoding="decoding"
+  />
 </template>
 
 <script setup lang="ts">
@@ -23,9 +30,19 @@ export interface Props {
    * @docs The image title attribute.
    */
   title?: string
+  /**
+   * @docs The decoding hint of the image. Falls back to the browser default.
+   */
+  decoding?: 'sync' | 'async' | 'auto'
 }
 
-const { src, alt = '', title, loadingType = 'eager' } = defineProps<Props>()
+const {
+  src,
+  alt = '',
+  title = undefined,
+  loadingType = 'eager',
+  decoding = undefined
+} = defineProps<Props>()
 
 const ariaHidden = computed(() => alt.length === 0)
 </script>

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -5,7 +5,13 @@
         class="relative flex items-center justify-center bg-role-surface-container rounded-xl p-4 mb-4"
       >
         <div v-if="preview" data-testid="preview">
-          <img key="file-thumbnail" :src="preview" class="details-preview h-[160px]" alt="" />
+          <img
+            key="file-thumbnail"
+            :src="preview"
+            class="details-preview h-[160px]"
+            alt=""
+            decoding="async"
+          />
         </div>
         <resource-icon
           v-else

--- a/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
@@ -19,6 +19,7 @@
         class="cursor-pointer rounded-lg size-full max-h-full object-cover"
         alt=""
         :src="imageContent"
+        decoding="async"
         @click="toggleImageExpanded"
       />
       <resource-icon v-else :resource="space" size-class="size-full" class="rounded-lg" />

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -99,6 +99,7 @@
                   }"
                   :src="resource.thumbnail"
                   alt=""
+                  decoding="async"
                 />
                 <resource-icon
                   v-else
@@ -120,6 +121,7 @@
                   :class="{ 'opacity-80 grayscale': resource.disabled }"
                   :src="resource.thumbnail"
                   alt=""
+                  decoding="async"
                 />
                 <resource-icon
                   v-else

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -106,7 +106,7 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
 
 exports[`SpaceHeader > space image > should show the set image 1`] = `
 "<div class="space-header py-4 flex">
-  <div class="space-header-image mr-6 aspect-[16/9] w-[180px] max-h-[100px] shrink-0"><img class="cursor-pointer rounded-lg size-full max-h-full object-cover" alt="" src="blob:image"></div>
+  <div class="space-header-image mr-6 aspect-[16/9] w-[180px] max-h-[100px] shrink-0"><img class="cursor-pointer rounded-lg size-full max-h-full object-cover" alt="" src="blob:image" decoding="async"></div>
   <div class="flex-1">
     <div class="flex items-center justify-between max-w-full">
       <div class="flex items-center max-w-full">

--- a/packages/web-app-preview/src/components/PhotoRollItem.vue
+++ b/packages/web-app-preview/src/components/PhotoRollItem.vue
@@ -18,6 +18,7 @@
         class="object-cover h-25 rounded-md aspect-video"
         :alt="item.name"
         referrerpolicy="no-referrer"
+        decoding="async"
       />
       <div v-else class="aspect-video h-25 flex items-center justify-center">
         <resource-icon class="aspect-video" :resource="iconResource" size-class="size-12" />

--- a/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
@@ -25,6 +25,7 @@
         class="rounded-xs size-6 object-cover max-w-fit"
         :aria-label="tooltipLabelIcon"
         alt=""
+        decoding="async"
       />
       <resource-icon
         v-else

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -63,6 +63,7 @@
               }"
               :src="resource.thumbnail"
               :data-test-thumbnail-resource-name="resource.name"
+              decoding="async"
               @click.stop="$emit('tileClicked', [resource, $event])"
             />
             <resource-icon

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
@@ -9,7 +9,7 @@
       class="bg-role-surface-container rounded-xl flex items-center justify-center p-4 mb-4"
     >
       <div v-if="spaceImage">
-        <img :src="spaceImage" alt="" class="h-[160px] rounded-lg" />
+        <img :src="spaceImage" alt="" class="h-[160px] rounded-lg" decoding="async" />
       </div>
       <div v-else class="w-full aspect-[16/9] h-[160px]">
         <resource-icon


### PR DESCRIPTION
Add a [decoding prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#decoding) to `OcImage` and set `decoding="async"` on thumbnails in `ResourceTile`, `ResourceListItem`, `Projects`, `FileDetails`, `SpaceHeader` and `SpaceDetails`.

refs https://github.com/opencloud-eu/web/issues/3167