### PR TITLE
feat: add accessibility hint for code block exit

### DIFF
--- a/packages/web-pkg/src/editor/components/CodeBlockComponent.vue
+++ b/packages/web-pkg/src/editor/components/CodeBlockComponent.vue
@@ -14,7 +14,14 @@
         @update:model-value="updateSelectedLanguage"
       />
     </div>
-    <pre><code><node-view-content /></code></pre>
+    <span :id="hintId" class="sr-only">
+      {{ $gettext('Press Shift+Enter to exit the code block.') }}
+    </span>
+    <pre
+      role="textbox"
+      :aria-describedby="hintId"
+      aria-multiline="true"
+    ><code><node-view-content /></code></pre>
   </node-view-wrapper>
 </template>
 
@@ -22,9 +29,12 @@
 import { computed } from 'vue'
 import { NodeViewContent, nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3'
 import { useGettext } from 'vue3-gettext'
+import { v4 as uuidV4 } from 'uuid'
 
 const props = defineProps(nodeViewProps)
 const { $gettext } = useGettext()
+
+const hintId = `code-block-hint-${uuidV4()}`
 
 type LanguageOption = {
   label: string

--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -140,9 +140,6 @@
 
 /* Codeblock styles */
 .text-editor-content .ProseMirror pre {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-    monospace;
   font-size: calc(14px * var(--text-editor-zoom-factor));
   background: var(--oc-role-surface-container);
   padding: 8px 12px;
@@ -153,9 +150,6 @@
 
 /* Inline code styles */
 .text-editor-content .ProseMirror :not(pre) > code {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-    monospace;
   font-size: calc(13px * var(--text-editor-zoom-factor));
   padding: 2px 4px;
   border-radius: 6px;

--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -1,214 +1,216 @@
 .text-editor-content {
-    --text-editor-zoom-factor: 1;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-    overflow: auto;
-    container-type: inline-size;
+  --text-editor-zoom-factor: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+  container-type: inline-size;
 }
 
 .text-editor-provider .text-editor-content .ProseMirror {
-    max-width: 800px;
-    padding: 1rem;
+  max-width: 800px;
+  padding: 1rem;
 }
 
 .text-editor-content .ProseMirror {
-    flex: 1;
-    min-height: 100%;
-    height: 100%;
-    width: 100%;
-    box-sizing: border-box;
-    outline: none;
-    border: none;
-    margin: 0 auto;
-    padding: 0;
-    font-size: calc(15px * var(--text-editor-zoom-factor));
-    line-height: 1.6;
+  flex: 1;
+  min-height: 100%;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  outline: none;
+  border: none;
+  margin: 0 auto;
+  padding: 0;
+  font-size: calc(15px * var(--text-editor-zoom-factor));
+  line-height: 1.6;
 }
 
 .text-editor-content .ProseMirror:focus,
 .text-editor-content .ProseMirror:focus-visible {
-    outline: none;
-    box-shadow: none;
+  outline: none;
+  box-shadow: none;
 }
 
 .text-editor-content .ProseMirror p.is-editor-empty:first-child::before {
-    content: attr(data-placeholder);
-    float: left;
-    color: var(--oc-role-outline-variant, rgba(0, 0, 0, 0.4));
-    pointer-events: none;
-    user-select: none;
-    height: 0;
+  content: attr(data-placeholder);
+  float: left;
+  color: var(--oc-role-outline-variant, rgba(0, 0, 0, 0.4));
+  pointer-events: none;
+  user-select: none;
+  height: 0;
 }
 
 .text-editor-content .ProseMirror .text-editor-slash-filter {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.125rem;
-    background: var(--oc-role-surface-container);
-    color: var(--oc-role-on-surface-variant);
-    border-radius: 0.25rem;
-    padding: 0.125rem 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  background: var(--oc-role-surface-container);
+  color: var(--oc-role-on-surface-variant);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.25rem;
 }
 
 .text-editor-content .ProseMirror .text-editor-slash-filter::first-letter {
-    color: var(--oc-role-secondary);
+  color: var(--oc-role-secondary);
 }
 
 .text-editor-content .ProseMirror .text-editor-slash-filter--empty::after {
-    content: attr(data-decoration-content);
-    color: var(--oc-role-on-surface-variant);
-    opacity: 0.9;
+  content: attr(data-decoration-content);
+  color: var(--oc-role-on-surface-variant);
+  opacity: 0.9;
 }
 
 .text-editor-content .ProseMirror p {
-    margin: 0 0 8px;
+  margin: 0 0 8px;
 }
 
 .text-editor-content .ProseMirror h1,
 .text-editor-content .ProseMirror h2,
 .text-editor-content .ProseMirror h3,
 .text-editor-content .ProseMirror h4 {
-    margin: 0 0 8px;
-    line-height: 1.25;
-    font-weight: 600;
+  margin: 0 0 8px;
+  line-height: 1.25;
+  font-weight: 600;
 }
 
 .text-editor-content .ProseMirror h1 {
-    font-size: calc(30px * var(--text-editor-zoom-factor));
+  font-size: calc(30px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror h2 {
-    font-size: calc(24px * var(--text-editor-zoom-factor));
+  font-size: calc(24px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror h3 {
-    font-size: calc(20px * var(--text-editor-zoom-factor));
+  font-size: calc(20px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror h4 {
-    font-size: calc(17px * var(--text-editor-zoom-factor));
+  font-size: calc(17px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror a {
-    color: var(--oc-role-primary);
-    text-decoration: underline;
-    cursor: pointer;
+  color: var(--oc-role-primary);
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .text-editor-content .ProseMirror ul:not(.vs__dropdown-menu) {
-    list-style-type: disc;
-    padding-left: 20px;
-    margin: 4px 0 8px;
+  list-style-type: disc;
+  padding-left: 20px;
+  margin: 4px 0 8px;
 }
 
 .text-editor-content .ProseMirror ol {
-    list-style-type: decimal;
-    padding-left: 20px;
-    margin: 4px 0 8px;
+  list-style-type: decimal;
+  padding-left: 20px;
+  margin: 4px 0 8px;
 }
 
 .text-editor-content .ProseMirror li:not(.vs__dropdown-option):not(.vs__no-options) {
-    margin: 2px 0;
+  margin: 2px 0;
 }
 
 .text-editor-content .ProseMirror strong {
-    font-weight: 600;
+  font-weight: 600;
 }
 
 .text-editor-content .ProseMirror em {
-    font-style: italic;
+  font-style: italic;
 }
 
 .text-editor-content .ProseMirror u {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .text-editor-content .ProseMirror blockquote {
-    border-left: 2px solid var(--oc-role-outline-variant);
-    padding-left: 12px;
-    margin: 4px 0 8px;
-    font-style: italic;
-    opacity: 0.9;
+  border-left: 2px solid var(--oc-role-outline-variant);
+  padding-left: 12px;
+  margin: 4px 0 8px;
+  font-style: italic;
+  opacity: 0.9;
 }
 
 .text-editor-content textarea {
-    font-size: calc(15px * var(--text-editor-zoom-factor));
-    line-height: 1.6;
+  font-size: calc(15px * var(--text-editor-zoom-factor));
+  line-height: 1.6;
 }
 
 /* Codeblock styles */
 .text-editor-content .ProseMirror pre {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
-    font-size: calc(14px * var(--text-editor-zoom-factor));
-    background: var(--oc-role-surface-container);
-    padding: 8px 12px;
-    border-radius: 6px;
-    margin: 1.5rem 0;
-    overflow-x: auto;
+  font-size: calc(14px * var(--text-editor-zoom-factor));
+  background: var(--oc-role-surface-container);
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin: 1.5rem 0;
+  overflow-x: auto;
 }
 
 /* Inline code styles */
 .text-editor-content .ProseMirror :not(pre) > code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
-    font-size: calc(13px * var(--text-editor-zoom-factor));
-    padding: 2px 4px;
-    border-radius: 6px;
-    background: var(--oc-role-surface-container);
+  font-size: calc(13px * var(--text-editor-zoom-factor));
+  padding: 2px 4px;
+  border-radius: 6px;
+  background: var(--oc-role-surface-container);
 }
 
 .text-editor-content .ProseMirror .code-block {
-    position: relative;
+  position: relative;
 }
 
 /* Table styles */
 .text-editor-content .ProseMirror table {
-    border-collapse: collapse;
-    margin: 8px 0;
-    width: 100%;
+  border-collapse: collapse;
+  margin: 8px 0;
+  width: 100%;
 }
 
 .text-editor-content .ProseMirror th,
 .text-editor-content .ProseMirror td {
-    border: 1px solid var(--oc-role-outline-variant);
-    padding: 6px 10px;
-    text-align: left;
+  border: 1px solid var(--oc-role-outline-variant);
+  padding: 6px 10px;
+  text-align: left;
 }
 
 .text-editor-content .ProseMirror th {
-    font-weight: 600;
-    background: rgba(148, 163, 184, 0.08);
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.08);
 }
 
 /* Task list styles */
 .text-editor-content .ProseMirror ul[data-type='taskList'] {
-    list-style-type: none;
-    padding-left: 4px;
+  list-style-type: none;
+  padding-left: 4px;
 }
 
 .text-editor-content .ProseMirror ul[data-type='taskList'] li {
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .text-editor-content .ProseMirror ul[data-type='taskList'] li label {
-    margin-top: 2px;
+  margin-top: 2px;
 }
 
 /* Horizontal rule */
 .text-editor-content .ProseMirror hr {
-    border: none;
-    border-top: 1px solid var(--oc-role-outline-variant);
-    margin: 12px 0;
+  border: none;
+  border-top: 1px solid var(--oc-role-outline-variant);
+  margin: 12px 0;
 }
 
 /* Reduce max-width to make room for drag handle + plus button when container is narrow */
 @container (max-width: 840px) {
-    .text-editor-provider .text-editor-content .ProseMirror {
-        max-width: calc(100% - 6rem);
-    }
+  .text-editor-provider .text-editor-content .ProseMirror {
+    max-width: calc(100% - 6rem);
+  }
 }

--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -167,7 +167,7 @@
 }
 
 .text-editor-content .ProseMirror .code-block pre code > [data-node-view-content] {
-  display: inline;
+  display: block;
   margin: 0;
   padding: 0;
 }

--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -1,222 +1,214 @@
 .text-editor-content {
-  --text-editor-zoom-factor: 1;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  overflow: auto;
-  container-type: inline-size;
+    --text-editor-zoom-factor: 1;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: auto;
+    container-type: inline-size;
 }
 
 .text-editor-provider .text-editor-content .ProseMirror {
-  max-width: 800px;
-  padding: 1rem;
+    max-width: 800px;
+    padding: 1rem;
 }
 
 .text-editor-content .ProseMirror {
-  flex: 1;
-  min-height: 100%;
-  height: 100%;
-  width: 100%;
-  box-sizing: border-box;
-  outline: none;
-  border: none;
-  margin: 0 auto;
-  padding: 0;
-  font-size: calc(15px * var(--text-editor-zoom-factor));
-  line-height: 1.6;
+    flex: 1;
+    min-height: 100%;
+    height: 100%;
+    width: 100%;
+    box-sizing: border-box;
+    outline: none;
+    border: none;
+    margin: 0 auto;
+    padding: 0;
+    font-size: calc(15px * var(--text-editor-zoom-factor));
+    line-height: 1.6;
 }
 
 .text-editor-content .ProseMirror:focus,
 .text-editor-content .ProseMirror:focus-visible {
-  outline: none;
-  box-shadow: none;
+    outline: none;
+    box-shadow: none;
 }
 
 .text-editor-content .ProseMirror p.is-editor-empty:first-child::before {
-  content: attr(data-placeholder);
-  float: left;
-  color: var(--oc-role-outline-variant, rgba(0, 0, 0, 0.4));
-  pointer-events: none;
-  user-select: none;
-  height: 0;
+    content: attr(data-placeholder);
+    float: left;
+    color: var(--oc-role-outline-variant, rgba(0, 0, 0, 0.4));
+    pointer-events: none;
+    user-select: none;
+    height: 0;
 }
 
 .text-editor-content .ProseMirror .text-editor-slash-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.125rem;
-  background: var(--oc-role-surface-container);
-  color: var(--oc-role-on-surface-variant);
-  border-radius: 0.25rem;
-  padding: 0.125rem 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.125rem;
+    background: var(--oc-role-surface-container);
+    color: var(--oc-role-on-surface-variant);
+    border-radius: 0.25rem;
+    padding: 0.125rem 0.25rem;
 }
 
 .text-editor-content .ProseMirror .text-editor-slash-filter::first-letter {
-  color: var(--oc-role-secondary);
+    color: var(--oc-role-secondary);
 }
 
 .text-editor-content .ProseMirror .text-editor-slash-filter--empty::after {
-  content: attr(data-decoration-content);
-  color: var(--oc-role-on-surface-variant);
-  opacity: 0.9;
+    content: attr(data-decoration-content);
+    color: var(--oc-role-on-surface-variant);
+    opacity: 0.9;
 }
 
 .text-editor-content .ProseMirror p {
-  margin: 0 0 8px;
+    margin: 0 0 8px;
 }
 
 .text-editor-content .ProseMirror h1,
 .text-editor-content .ProseMirror h2,
 .text-editor-content .ProseMirror h3,
 .text-editor-content .ProseMirror h4 {
-  margin: 0 0 8px;
-  line-height: 1.25;
-  font-weight: 600;
+    margin: 0 0 8px;
+    line-height: 1.25;
+    font-weight: 600;
 }
 
 .text-editor-content .ProseMirror h1 {
-  font-size: calc(30px * var(--text-editor-zoom-factor));
+    font-size: calc(30px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror h2 {
-  font-size: calc(24px * var(--text-editor-zoom-factor));
+    font-size: calc(24px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror h3 {
-  font-size: calc(20px * var(--text-editor-zoom-factor));
+    font-size: calc(20px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror h4 {
-  font-size: calc(17px * var(--text-editor-zoom-factor));
+    font-size: calc(17px * var(--text-editor-zoom-factor));
 }
 
 .text-editor-content .ProseMirror a {
-  color: var(--oc-role-primary);
-  text-decoration: underline;
-  cursor: pointer;
+    color: var(--oc-role-primary);
+    text-decoration: underline;
+    cursor: pointer;
 }
 
 .text-editor-content .ProseMirror ul:not(.vs__dropdown-menu) {
-  list-style-type: disc;
-  padding-left: 20px;
-  margin: 4px 0 8px;
+    list-style-type: disc;
+    padding-left: 20px;
+    margin: 4px 0 8px;
 }
 
 .text-editor-content .ProseMirror ol {
-  list-style-type: decimal;
-  padding-left: 20px;
-  margin: 4px 0 8px;
+    list-style-type: decimal;
+    padding-left: 20px;
+    margin: 4px 0 8px;
 }
 
 .text-editor-content .ProseMirror li:not(.vs__dropdown-option):not(.vs__no-options) {
-  margin: 2px 0;
+    margin: 2px 0;
 }
 
 .text-editor-content .ProseMirror strong {
-  font-weight: 600;
+    font-weight: 600;
 }
 
 .text-editor-content .ProseMirror em {
-  font-style: italic;
+    font-style: italic;
 }
 
 .text-editor-content .ProseMirror u {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 .text-editor-content .ProseMirror blockquote {
-  border-left: 2px solid var(--oc-role-outline-variant);
-  padding-left: 12px;
-  margin: 4px 0 8px;
-  font-style: italic;
-  opacity: 0.9;
+    border-left: 2px solid var(--oc-role-outline-variant);
+    padding-left: 12px;
+    margin: 4px 0 8px;
+    font-style: italic;
+    opacity: 0.9;
 }
 
 .text-editor-content textarea {
-  font-size: calc(15px * var(--text-editor-zoom-factor));
-  line-height: 1.6;
+    font-size: calc(15px * var(--text-editor-zoom-factor));
+    line-height: 1.6;
 }
 
 /* Codeblock styles */
 .text-editor-content .ProseMirror pre {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
-  font-size: calc(14px * var(--text-editor-zoom-factor));
-  background: var(--oc-role-surface-container);
-  padding: 8px 12px;
-  border-radius: 6px;
-  overflow-x: auto;
+    font-size: calc(14px * var(--text-editor-zoom-factor));
+    background: var(--oc-role-surface-container);
+    padding: 8px 12px;
+    border-radius: 6px;
+    margin: 1.5rem 0;
+    overflow-x: auto;
 }
 
 /* Inline code styles */
 .text-editor-content .ProseMirror :not(pre) > code {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
-  font-size: calc(13px * var(--text-editor-zoom-factor));
-  padding: 2px 4px;
-  border-radius: 4px;
-  background: var(--oc-role-surface-container);
+    font-size: calc(13px * var(--text-editor-zoom-factor));
+    padding: 2px 4px;
+    border-radius: 6px;
+    background: var(--oc-role-surface-container);
 }
 
 .text-editor-content .ProseMirror .code-block {
-  position: relative;
-  margin: 8px 0;
-}
-
-.text-editor-content .ProseMirror .code-block pre code > [data-node-view-content] {
-  display: block;
-  margin: 0;
-  padding: 0;
+    position: relative;
 }
 
 /* Table styles */
 .text-editor-content .ProseMirror table {
-  border-collapse: collapse;
-  margin: 8px 0;
-  width: 100%;
+    border-collapse: collapse;
+    margin: 8px 0;
+    width: 100%;
 }
 
 .text-editor-content .ProseMirror th,
 .text-editor-content .ProseMirror td {
-  border: 1px solid var(--oc-role-outline-variant);
-  padding: 6px 10px;
-  text-align: left;
+    border: 1px solid var(--oc-role-outline-variant);
+    padding: 6px 10px;
+    text-align: left;
 }
 
 .text-editor-content .ProseMirror th {
-  font-weight: 600;
-  background: rgba(148, 163, 184, 0.08);
+    font-weight: 600;
+    background: rgba(148, 163, 184, 0.08);
 }
 
 /* Task list styles */
 .text-editor-content .ProseMirror ul[data-type='taskList'] {
-  list-style-type: none;
-  padding-left: 4px;
+    list-style-type: none;
+    padding-left: 4px;
 }
 
 .text-editor-content .ProseMirror ul[data-type='taskList'] li {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
 }
 
 .text-editor-content .ProseMirror ul[data-type='taskList'] li label {
-  margin-top: 2px;
+    margin-top: 2px;
 }
 
 /* Horizontal rule */
 .text-editor-content .ProseMirror hr {
-  border: none;
-  border-top: 1px solid var(--oc-role-outline-variant);
-  margin: 12px 0;
+    border: none;
+    border-top: 1px solid var(--oc-role-outline-variant);
+    margin: 12px 0;
 }
 
 /* Reduce max-width to make room for drag handle + plus button when container is narrow */
 @container (max-width: 840px) {
-  .text-editor-provider .text-editor-content .ProseMirror {
-    max-width: calc(100% - 6rem);
-  }
+    .text-editor-provider .text-editor-content .ProseMirror {
+        max-width: calc(100% - 6rem);
+    }
 }


### PR DESCRIPTION
## Description

Adds ARIA attributes to the code block component to improve accessibility for keyboard navigation. When tab indentation is enabled in code blocks, users can no longer use the Tab key to exit. This PR adds `aria-describedby` to inform screen reader users that Shift+Enter is the keyboard shortcut to exit the code block.

The implementation uses:
- `aria-describedby`
- A visually hidden `<span>` with Tailwind's `sr-only` class containing the hint text
- UUID v4 for generating unique IDs to support multiple code blocks on the same page

## Related Issue

N/A

## How Has This Been Tested

- **Test environment:** Local development
- **Test cases:**
  - Screen reader announces the code block and the exit hint when focused
  - Shift+Enter successfully exits the code block
  - Tab key continues to indent within the code block
  - Multiple code blocks on the same page have unique ARIA references

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt (code improvements)
- [ ] Tests (added or updated tests)
- [ ] Documentation
- [ ] Maintenance