### PR TITLE
fix(design-system): useIsVisible observer look-ahead

### DIFF
--- a/packages/design-system/src/components/OcTable/OcTable.vue
+++ b/packages/design-system/src/components/OcTable/OcTable.vue
@@ -63,6 +63,7 @@
         :dom-selector="domSelector(item) || trIndex"
         :padding-x="paddingX"
         :lazy="lazy"
+        :scroll-container="scrollContainer"
         :drag-drop="dragDrop"
         :is-highlighted="isHighlighted ?? defaultIsHighlighted"
         :is-disabled="isDisabled ?? defaultIsDisabled"
@@ -193,6 +194,11 @@ export interface Props {
    */
   lazy?: boolean
   /**
+   * @docs The scrollable element the lazy look-ahead is measured against. Falls back
+   * to the closest scrollable ancestor.
+   */
+  scrollContainer?: Element
+  /**
    * @docs The horizontal padding size of the table.
    * @default small
    */
@@ -289,6 +295,7 @@ const {
   idKey = 'id',
   itemDomSelector,
   lazy = false,
+  scrollContainer = undefined,
   paddingX = 'small',
   sortBy,
   sortDir,

--- a/packages/design-system/src/components/OcTableTr/OcTableTr.vue
+++ b/packages/design-system/src/components/OcTableTr/OcTableTr.vue
@@ -26,9 +26,10 @@ import OcTd from '../OcTableTd/OcTableTd.vue'
 
 export interface Props {
   lazy?: { colspan: number }
+  scrollContainer?: Element
 }
 
-const { lazy } = defineProps<Props>()
+const { lazy, scrollContainer } = defineProps<Props>()
 
 const emit = defineEmits([
   'contextmenu',
@@ -65,6 +66,7 @@ const { isVisible } = lazy
   ? useIsVisible({
       ...lazy,
       target: observerTarget as Ref<HTMLElement>,
+      root: computed(() => scrollContainer),
       onVisibleCallback: () => emit('itemVisible'),
       onHiddenCallback: () => emit('itemHidden')
     })

--- a/packages/design-system/src/composables/useIsVisible/index.spec.ts
+++ b/packages/design-system/src/composables/useIsVisible/index.spec.ts
@@ -20,7 +20,8 @@ const mockIntersectionObserver = () => {
       unobserveMock,
       disconnectMock,
       callback: (args: unknown[], fastForward = 0) => {
-        ;(window.IntersectionObserver as any).mock.calls[0][0](args)
+        const observerMock = window.IntersectionObserver as any
+        observerMock.mock.calls[0][0](args, observerMock.mock.instances[0])
         vi.advanceTimersByTime(fastForward)
       }
     }
@@ -34,21 +35,24 @@ const mockIntersectionObserver = () => {
 }
 
 const createWrapper = (options = {}) =>
-  mount({
-    template: `
-      <div>
-      <div ref="target">{{ isVisible }}</div>
-      </div>`,
-    setup: () => {
-      const target = ref<HTMLElement>()
-      const { isVisible } = useIsVisible({ ...options, target })
+  mount(
+    {
+      template: `<div ref="target">{{ isVisible }}</div>`,
+      setup: () => {
+        const target = ref<HTMLElement>()
+        const { isVisible } = useIsVisible({
+          root: ref(document.createElement('div')),
+          ...options,
+          target
+        })
 
-      return {
-        isVisible,
-        target
+        return { isVisible, target }
       }
-    }
-  })
+    },
+    { attachTo: document.body }
+  )
+
+const observerOptions = (call = 0) => (window.IntersectionObserver as any).mock.calls[call][1]
 
 describe('useIsVisible', () => {
   beforeEach(() => {
@@ -57,6 +61,8 @@ describe('useIsVisible', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
   })
 
   const { enable: enableIntersectionObserver, disable: disableIntersectionObserver } =
@@ -76,6 +82,55 @@ describe('useIsVisible', () => {
     expect(observeMock).toHaveBeenCalledTimes(1)
   })
 
+  it('does not create an observer before the target is mounted', () => {
+    enableIntersectionObserver()
+    createWrapper()
+
+    expect(window.IntersectionObserver).not.toHaveBeenCalled()
+  })
+
+  it('uses a look-ahead of one root height by default', async () => {
+    enableIntersectionObserver()
+    createWrapper()
+    await nextTick()
+
+    expect(observerOptions().rootMargin).toBe('100% 0%')
+  })
+
+  it('uses the given root', async () => {
+    enableIntersectionObserver()
+    const root = document.createElement('div')
+    createWrapper({ root: ref(root) })
+    await nextTick()
+
+    expect(observerOptions().root).toBe(root)
+  })
+
+  it('falls back to the viewport until the root resolves', async () => {
+    enableIntersectionObserver()
+    createWrapper({ root: ref<Element>(null) })
+    await nextTick()
+
+    expect(observerOptions().root).toBeNull()
+  })
+
+  it('re-creates the observer and unobserves the old target if the root changes', async () => {
+    const { unobserveMock, observeMock } = enableIntersectionObserver()
+    const firstRoot = document.createElement('div')
+    const secondRoot = document.createElement('div')
+    const root = ref(firstRoot)
+    const wrapper = createWrapper({ root })
+    await nextTick()
+
+    root.value = secondRoot
+    await nextTick()
+
+    expect(window.IntersectionObserver).toHaveBeenCalledTimes(2)
+    expect(observerOptions(1).root).toBe(secondRoot)
+    expect(observeMock).toHaveBeenCalledTimes(2)
+    expect(unobserveMock).toHaveBeenCalledWith(wrapper.vm.$refs.target)
+  })
+
   it('only shows once and then gets unobserved if the the composable is in the default show mode', async () => {
     const { unobserveMock, callback: observerCallback } = enableIntersectionObserver()
     const wrapper = createWrapper()
@@ -83,7 +138,7 @@ describe('useIsVisible', () => {
     await nextTick()
     expect((wrapper.vm.$refs.target as any).innerHTML).toBe('false')
 
-    observerCallback([{ isIntersecting: true }])
+    observerCallback([{ isIntersecting: true, target: wrapper.vm.$refs.target }])
     await nextTick()
     expect((wrapper.vm.$refs.target as any).innerHTML).toBe('true')
     expect(unobserveMock).toHaveBeenCalledTimes(1)
@@ -96,17 +151,18 @@ describe('useIsVisible', () => {
     await nextTick()
     expect((wrapper.vm.$refs.target as any).innerHTML).toBe('false')
 
-    observerCallback([{ isIntersecting: true }])
+    observerCallback([{ isIntersecting: true, target: wrapper.vm.$refs.target }])
     await nextTick()
     expect((wrapper.vm.$refs.target as any).innerHTML).toBe('true')
     expect(unobserveMock).toHaveBeenCalledTimes(0)
   })
 
-  it('disconnects the observer before component gets unmounted', () => {
+  it('disconnects the observer before component gets unmounted', async () => {
     const { disconnectMock } = enableIntersectionObserver()
     const wrapper = createWrapper()
 
     expect(disconnectMock).toHaveBeenCalledTimes(0)
+    await nextTick()
     wrapper.unmount()
     expect(disconnectMock).toHaveBeenCalledTimes(1)
   })

--- a/packages/design-system/src/composables/useIsVisible/index.ts
+++ b/packages/design-system/src/composables/useIsVisible/index.ts
@@ -2,13 +2,28 @@ import { Ref, onBeforeUnmount, ref, watch } from 'vue'
 
 export const useIsVisible = ({
   target,
+  root,
   mode = 'show',
-  rootMargin = '100px',
+  rootMargin = '100% 0%',
   onVisibleCallback,
   onHiddenCallback
 }: {
   target: Ref<Element>
-  mode?: string
+  /**
+   * The scrollable element the look-ahead is measured against. Until it resolves,
+   * the viewport is used, which gives no look-ahead inside a scroll container.
+   */
+  root: Ref<Element | null | undefined>
+  /**
+   * The mode determines whether the target should be observed for visibility
+   * changes after it has been visible once.
+   * @default 'show'
+   */
+  mode?: 'show' | 'showHide'
+  /**
+   * Percentages resolve against the root, so `100% 0%` gives a look-ahead of one
+   * root height above and below without any horizontal buffer.
+   */
   rootMargin?: string
   onVisibleCallback?: () => void
   onHiddenCallback?: () => void
@@ -22,55 +37,82 @@ export const useIsVisible = ({
 
   const isVisible = ref(false)
   let hasBeenVisible = false
-  const observer = new IntersectionObserver(
-    (intersectionObserverEntries: IntersectionObserverEntry[]) => {
-      /**
-       * In some edge cases intersectionObserverEntries contains 2 entries with the first one having wrong rootBounds.
-       * This happens for some reason when the table is being re-sorted immediately after being rendered.
-       * Therefore we always check the last entry for isIntersecting.
-       */
-      const isIntersecting = intersectionObserverEntries.at(-1).isIntersecting
+  let observer: IntersectionObserver
+  let observedRoot: Element | null
 
-      /**
-       * In mode `show` the target stays visible once it has been visible.
-       */
-      if (mode === 'showHide' || !hasBeenVisible) {
-        isVisible.value = isIntersecting
-      }
+  const createObserver = (rootElement: Element | null) =>
+    new IntersectionObserver(
+      (
+        intersectionObserverEntries: IntersectionObserverEntry[],
+        intersectionObserver: IntersectionObserver
+      ) => {
+        /**
+         * In some edge cases intersectionObserverEntries contains 2 entries with the first one having wrong rootBounds.
+         * This happens for some reason when the table is being re-sorted immediately after being rendered.
+         * Therefore we always check the last entry for isIntersecting.
+         */
+        const entry = intersectionObserverEntries.at(-1)
+        const isIntersecting = entry.isIntersecting
 
-      if (isIntersecting) {
-        hasBeenVisible = true
-        onVisibleCallback?.()
-      } else if (hasBeenVisible) {
-        onHiddenCallback?.()
-      }
+        /**
+         * In mode `show` the target stays visible once it has been visible.
+         */
+        if (mode === 'showHide' || !hasBeenVisible) {
+          isVisible.value = isIntersecting
+        }
 
-      /**
-       * if given mode is `showHide` we need to keep the observation alive.
-       * the same applies if the caller wants to be notified about targets leaving the viewport.
-       */
-      if (mode === 'showHide' || onHiddenCallback) {
-        return
-      }
-      /**
-       * if the mode is `show` which is the default, the implementation needs to unsubscribe the target from the observer
-       */
-      if (!isIntersecting) {
-        return
-      }
+        if (isIntersecting) {
+          hasBeenVisible = true
+          onVisibleCallback?.()
+        } else if (hasBeenVisible) {
+          onHiddenCallback?.()
+        }
 
-      observer.unobserve(target.value)
-    },
-    {
-      rootMargin
+        /**
+         * if given mode is `showHide` we need to keep the observation alive.
+         * the same applies if the caller wants to be notified about targets leaving the viewport.
+         */
+        if (mode === 'showHide' || onHiddenCallback) {
+          return
+        }
+        /**
+         * if the mode is `show` which is the default, the implementation needs to unsubscribe the target from the observer
+         */
+        if (!isIntersecting) {
+          return
+        }
+
+        intersectionObserver.unobserve(entry.target)
+      },
+      {
+        root: rootElement,
+        rootMargin
+      }
+    )
+
+  /**
+   * The observer is created lazily, so it picks up the root and the target as soon
+   * as both are available, and gets re-created whenever the root changes.
+   */
+  watch([target, root], ([targetElement, rootElement], [previousTargetElement]) => {
+    if (observer && previousTargetElement) {
+      observer.unobserve(previousTargetElement)
     }
-  )
 
-  watch(target, () => {
-    observer.observe(target.value)
+    if (!targetElement) {
+      return
+    }
+
+    if (!observer || rootElement !== observedRoot) {
+      observer?.disconnect()
+      observer = createObserver(rootElement ?? null)
+      observedRoot = rootElement
+    }
+
+    observer.observe(targetElement)
   })
 
-  onBeforeUnmount(() => observer.disconnect())
+  onBeforeUnmount(() => observer?.disconnect())
 
   return {
     isVisible

--- a/packages/web-app-files/src/components/FilesViewWrapper.vue
+++ b/packages/web-app-files/src/components/FilesViewWrapper.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    id="files-view-wrapper"
     class="files-view-wrapper relative grid grid-cols-1 flex-1 focus:outline-0 h-full overflow-y-auto gap-0"
   >
     <div id="files-view" v-bind="$attrs" class="outline-0 z-0 flex flex-col">

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Projects view > different files view states > lists all available project spaces 1`] = `
 "<div class="flex w-full">
-  <div class="files-view-wrapper relative grid grid-cols-1 flex-1 focus:outline-0 h-full overflow-y-auto gap-0">
+  <div id="files-view-wrapper" class="files-view-wrapper relative grid grid-cols-1 flex-1 focus:outline-0 h-full overflow-y-auto gap-0">
     <div id="files-view" class="outline-0 z-0 flex flex-col">
       <app-bar-stub viewmodedefault="resource-tiles" breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" viewmodes="[object Object]" hasbulkactions="true" hasviewoptions="true" hashiddenfiles="false" hasfileextensions="false" haspagination="true" showactionsbar="true" showactionsonselection="true" batchactionsloading="false"></app-bar-stub>
       <table data-v-3c9ab66c="" class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table" sort-fields="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" view-size="1" id="files-space-table">

--- a/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`TrashOverview > view states > should render trash list 1`] = `
 "<div class="flex w-full">
-  <div class="files-view-wrapper relative grid grid-cols-1 flex-1 focus:outline-0 h-full overflow-y-auto gap-0">
+  <div id="files-view-wrapper" class="files-view-wrapper relative grid grid-cols-1 flex-1 focus:outline-0 h-full overflow-y-auto gap-0">
     <div id="files-view" class="outline-0 z-0 flex flex-col">
       <app-bar-stub viewmodedefault="resource-tiles" breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" viewmodes="[object Object]" hasbulkactions="false" hasviewoptions="true" hashiddenfiles="false" hasfileextensions="false" haspagination="true" showactionsbar="false" showactionsonselection="false" batchactionsloading="false"></app-bar-stub>
       <div class="flex justify-end flex-wrap items-end mx-4 mb-4">

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -24,6 +24,7 @@
     :sort-by="sortBy"
     :sort-dir="sortDir"
     :lazy="lazy"
+    :scroll-container="scrollContainer"
     padding-x="medium"
     @highlight="fileContainerClicked({ resource: $event[0], event: $event[1] })"
     @contextmenu-clicked="
@@ -298,6 +299,7 @@ import {
   useCapabilityStore,
   useEmbedMode,
   useExtensionRegistry,
+  useFilesViewScrollContainer,
   useFolderLink,
   useGetMatchingSpace,
   useIsTopBarSticky,
@@ -440,6 +442,8 @@ const { userContextReady } = storeToRefs(authStore)
 
 const resourcesStore = useResourcesStore()
 const { areFileExtensionsShown } = storeToRefs(resourcesStore)
+
+const scrollContainer = useFilesViewScrollContainer()
 
 // Stable resolvers passed to OcTable. Reading the store happens inside each row's
 // render (not here), so a selection change re-renders only the affected rows -

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -129,7 +129,12 @@ import { useGettext } from 'vue3-gettext'
 import { isSpaceResource } from '@opencloud-eu/web-client'
 import { useIsVisible } from '@opencloud-eu/design-system/composables'
 import { OcCard } from '@opencloud-eu/design-system/components'
-import { useFolderLink, useResourceLink, useResourcesStore } from '../../composables'
+import {
+  useFilesViewScrollContainer,
+  useFolderLink,
+  useResourceLink,
+  useResourcesStore
+} from '../../composables'
 
 const {
   resource,
@@ -185,6 +190,7 @@ const isResourceSelected = computed(() => resourcesStore.selectedIdsSet.has(reso
 
 const observerTarget = useTemplateRef<InstanceType<typeof OcCard>>('observerTarget')
 const observerTargetElement = computed<HTMLElement>(() => unref(observerTarget)?.$el)
+const scrollContainer = useFilesViewScrollContainer()
 
 const showStatusIcon = computed(() => {
   return resource.locked || resource.processing
@@ -227,6 +233,7 @@ const resourceDescription = computed(() => {
 const { isVisible } = lazy
   ? useIsVisible({
       target: observerTargetElement,
+      root: scrollContainer,
       onVisibleCallback: () => emit('itemVisible'),
       onHiddenCallback: () => emit('itemHidden')
     })

--- a/packages/web-pkg/src/composables/filesList/index.ts
+++ b/packages/web-pkg/src/composables/filesList/index.ts
@@ -1,1 +1,2 @@
+export * from './useFilesViewScrollContainer'
 export * from './useResourceRouteResolver'

--- a/packages/web-pkg/src/composables/filesList/useFilesViewScrollContainer.ts
+++ b/packages/web-pkg/src/composables/filesList/useFilesViewScrollContainer.ts
@@ -1,0 +1,20 @@
+import { Ref, onMounted, ref, unref } from 'vue'
+
+const scrollContainerId = 'files-view-wrapper'
+
+/**
+ * Resolves the scrollable element the files views are rendered in. The lookup is
+ * repeated on mount, because on the very first render the container might not be in
+ * the DOM yet (if the container gets rendered in the same tick as the component).
+ */
+export function useFilesViewScrollContainer(): Ref<HTMLElement | null> {
+  const scrollContainer = ref(document.getElementById(scrollContainerId))
+
+  onMounted(() => {
+    if (!unref(scrollContainer)) {
+      scrollContainer.value = document.getElementById(scrollContainerId)
+    }
+  })
+
+  return scrollContainer
+}

--- a/packages/web-pkg/tests/unit/composables/filesList/useFilesViewScrollContainer.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/filesList/useFilesViewScrollContainer.spec.ts
@@ -1,0 +1,44 @@
+import { defineComponent, unref } from 'vue'
+import { mount } from '@opencloud-eu/web-test-helpers'
+import { useFilesViewScrollContainer } from '../../../../src/composables/filesList'
+
+const consumer = defineComponent({
+  setup: () => ({ scrollContainer: useFilesViewScrollContainer() }),
+  template: '<div />'
+})
+
+describe('useFilesViewScrollContainer', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('resolves the scroll container', () => {
+    const element = document.createElement('div')
+    element.id = 'files-view-wrapper'
+    document.body.appendChild(element)
+
+    const wrapper = mount(consumer, { attachTo: document.body })
+
+    expect(unref(wrapper.vm.scrollContainer)).toBe(element)
+  })
+
+  it('resolves the scroll container that gets mounted alongside the consumer', () => {
+    const wrapper = mount(
+      {
+        components: { consumer },
+        template: '<div id="files-view-wrapper"><consumer ref="consumer" /></div>'
+      },
+      { attachTo: document.body }
+    )
+
+    expect(unref((wrapper.vm.$refs.consumer as any).scrollContainer)).toBe(
+      document.getElementById('files-view-wrapper')
+    )
+  })
+
+  it('stays empty if there is no scroll container', () => {
+    const wrapper = mount(consumer, { attachTo: document.body })
+
+    expect(unref(wrapper.vm.scrollContainer)).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes the look-ahead of the `useIsVisible` composable by passing it the parent scroll container as `root` property and creating the observer lazily to ensure the target element is mounted.

You can test this by adjusting your browser window size so it fits e.g. 15 tiles in the file list. Now open a folder with >30 images and look at the network tab. It should load ~30 thumbnails because of the fixed look-ahead, which is now about one viewport.

### Breaking for devs

The `root` prop of the `useIsVisible` composable is mandatory now.

fixes https://github.com/opencloud-eu/web/issues/3168