### PR TITLE
fix(epub-reader): select first chapter when opening EPUB for the first time

### DIFF
--- a/packages/web-app-epub-reader/src/App.vue
+++ b/packages/web-app-epub-reader/src/App.vue
@@ -546,6 +546,9 @@ watch(
       )
       if (resolvedCurrentChapter) {
         currentChapter.value = resolvedCurrentChapter
+      } else if (!unref(currentChapter) && unref(chapters).length > 0) {
+        // If no chapter could be resolved and none is set yet, default to first chapter
+        currentChapter.value = unref(chapters)[0]
       }
     })
   },


### PR DESCRIPTION
## Description

This PR fixes a bug where no chapter was selected in the chapter list when opening an EPUB file for the first time (i.e., when no previous reading location was stored in localStorage).

## Changes

- Modified the `relocated` event handler in `App.vue` to set the first chapter as a fallback when `resolveCurrentChapter()` returns `undefined` and no chapter is currently selected
- This ensures users always see which chapter they're currently reading, even on first open

## Related Issue

N/A

## How Has This Been Tested

Tested locally by:
- Opening an EPUB file for the first time (clearing localStorage first)
- Verifying that the first chapter is now highlighted in the chapter list
- Verifying that navigation still works correctly
- Verifying that chapter selection still works when reopening a previously read EPUB

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt (code quality, refactoring, documentation)
- [ ] Tests (adding, updating, or removing tests)
- [ ] Documentation (adding, updating, or removing documentation)
- [ ] Maintenance (dependency updates, CI/CD, tooling)