### PR TITLE
fix: improve code block visibility in dark mode

### DIFF
--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -141,7 +141,7 @@
 /* Codeblock styles */
 .text-editor-content .ProseMirror pre {
   font-size: calc(14px * var(--text-editor-zoom-factor));
-  background: var(--oc-role-surface-container);
+  background: var(--oc-role-surface-container-high);
   padding: 8px 12px;
   border-radius: 6px;
   margin: 1.5rem 0;
@@ -153,7 +153,7 @@
   font-size: calc(13px * var(--text-editor-zoom-factor));
   padding: 2px 4px;
   border-radius: 6px;
-  background: var(--oc-role-surface-container);
+  background: var(--oc-role-surface-container-high);
 }
 
 .text-editor-content .ProseMirror .code-block {


### PR DESCRIPTION
## Description

This bugfix improves code readability in dark mode by increasing contrast for editor code backgrounds.

Changes made:
- Updated `pre` code block background token from `var(--oc-role-surface-container)` to `var(--oc-role-surface-container-high)`
- Updated inline `code` background token from `var(--oc-role-surface-container)` to `var(--oc-role-surface-container-high)`

File changed:
- `packages/web-pkg/src/editor/styles/text-editor.css`

## Related Issue

- Fixes #<issue_number>

## How Has This Been Tested?

- test environment: Local development environment
- test case 1: Opened text editor in dark mode and verified improved code block contrast
- test case 2: Verified inline code background is consistently more visible in dark mode
- test case 3: Confirmed no visual regression in editor code styling structure

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)