### PR TITLE
Add basic print action to text editor toolbar

### DIFF
--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -91,6 +91,7 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
     undo,
     redo,
     zoomMenu,
+    print,
     toggleSourceMode,
     fontSize,
     lineHeight,
@@ -141,7 +142,7 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu()]
+        actions: [undo(), redo(), zoomMenu(), print()]
       },
       {
         id: 'view-options',

--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -1,5 +1,3 @@
-import { ContentTypeStrategy, ExtensionsOptions } from './types'
-import { useGettext } from 'vue3-gettext'
 import type { Extension } from '@tiptap/core'
 import { getHTMLFromFragment } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
@@ -13,7 +11,6 @@ import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import TextAlign from '@tiptap/extension-text-align'
-
 import {
   TextStyle,
   FontFamily,
@@ -22,6 +19,7 @@ import {
   FontSize,
   LineHeight
 } from '@tiptap/extension-text-style'
+import { useGettext } from 'vue3-gettext'
 import { EditorActionGroup, useEditorActions } from '../useEditorActions'
 import { TextEditorState } from '../../types'
 import {
@@ -29,6 +27,7 @@ import {
   createLinkExtension,
   imageFileHandlerExtension
 } from '../../extensions'
+import { ContentTypeStrategy, ExtensionsOptions } from './types'
 
 export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrategy => {
   const { $gettext } = useGettext()

--- a/packages/web-pkg/src/editor/composables/strategies/html.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/html.ts
@@ -142,7 +142,7 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu(), print()]
+        actions: [undo(), redo(), zoomMenu()]
       },
       {
         id: 'view-options',
@@ -223,6 +223,11 @@ export const useStrategyHtml = (editorState: TextEditorState): ContentTypeStrate
         id: 'search',
         title: $gettext('Search'),
         actions: [menuSearchAndReplace()]
+      },
+      {
+        id: 'export',
+        title: $gettext('Export'),
+        actions: [print()]
       }
     ]
   }

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -97,6 +97,7 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
     undo,
     redo,
     zoomMenu,
+    print,
     toggleSourceMode,
     bold,
     italic,
@@ -134,7 +135,7 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu()]
+        actions: [undo(), redo(), zoomMenu(), print()]
       },
       {
         id: 'view-options',

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -135,7 +135,7 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu(), print()]
+        actions: [undo(), redo(), zoomMenu()]
       },
       {
         id: 'view-options',
@@ -189,6 +189,11 @@ export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeSt
         id: 'search',
         title: $gettext('Search'),
         actions: [menuSearchAndReplace()]
+      },
+      {
+        id: 'export',
+        title: $gettext('Export'),
+        actions: [print()]
       }
     ]
   }

--- a/packages/web-pkg/src/editor/composables/strategies/markdown.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/markdown.ts
@@ -1,5 +1,3 @@
-import { EditorActionGroup, useEditorActions } from '../useEditorActions'
-import { ContentTypeStrategy, ExtensionsOptions } from './types'
 import type { Extension, JSONContent } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import StarterKit from '@tiptap/starter-kit'
@@ -10,12 +8,14 @@ import { Table, TableRow, TableCell, TableHeader } from '@tiptap/extension-table
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import { useGettext } from 'vue3-gettext'
+import { EditorActionGroup, useEditorActions } from '../useEditorActions'
 import { TextEditorState } from '../../types'
 import {
   createCodeBlockLowlight,
   createLinkExtension,
   imageFileHandlerExtension
 } from '../../extensions'
+import { ContentTypeStrategy, ExtensionsOptions } from './types'
 
 export const useStrategyMarkdown = (editorState: TextEditorState): ContentTypeStrategy => {
   const { $gettext } = useGettext()

--- a/packages/web-pkg/src/editor/composables/strategies/plainText.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/plainText.ts
@@ -68,7 +68,7 @@ export const useStrategyPlainText = (editorState: TextEditorState): ContentTypeS
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu(), print()]
+        actions: [undo(), redo(), zoomMenu()]
       },
       {
         id: 'emoji',
@@ -79,6 +79,11 @@ export const useStrategyPlainText = (editorState: TextEditorState): ContentTypeS
         id: 'search',
         title: $gettext('Search'),
         actions: [menuSearchAndReplace()]
+      },
+      {
+        id: 'export',
+        title: $gettext('Export'),
+        actions: [print()]
       }
     ]
   }

--- a/packages/web-pkg/src/editor/composables/strategies/plainText.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/plainText.ts
@@ -61,13 +61,14 @@ export const useStrategyPlainText = (editorState: TextEditorState): ContentTypeS
     ]
   }
 
-  const { undo, redo, zoomMenu, menuEmoji, menuSearchAndReplace } = useEditorActions(editorState)
+  const { undo, redo, zoomMenu, print, menuEmoji, menuSearchAndReplace } =
+    useEditorActions(editorState)
   const editorActionGroups = (): EditorActionGroup[] => {
     return [
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu()]
+        actions: [undo(), redo(), zoomMenu(), print()]
       },
       {
         id: 'emoji',

--- a/packages/web-pkg/src/editor/composables/strategies/plainText.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/plainText.ts
@@ -2,10 +2,10 @@ import { Extension, getText, getTextSerializersFromSchema } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import StarterKit from '@tiptap/starter-kit'
 import FindAndReplace from '@tiptap/extension-find-and-replace'
+import { useGettext } from 'vue3-gettext'
 import { EditorActionGroup, useEditorActions } from '../useEditorActions'
 import { ContentTypeStrategy, ExtensionsOptions } from './types'
 import { TextEditorState } from '../../types'
-import { useGettext } from 'vue3-gettext'
 
 export const useStrategyPlainText = (editorState: TextEditorState): ContentTypeStrategy => {
   const { $gettext } = useGettext()

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -89,6 +89,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
     undo,
     redo,
     zoomMenu,
+    print,
     fontSize,
     lineHeight,
     backgroundColor,
@@ -136,7 +137,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu()]
+        actions: [undo(), redo(), zoomMenu(), print()]
       },
       {
         id: 'formatting',

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -137,7 +137,7 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
       {
         id: 'navigation',
         title: $gettext('Navigation'),
-        actions: [undo(), redo(), zoomMenu(), print()]
+        actions: [undo(), redo(), zoomMenu()]
       },
       {
         id: 'formatting',
@@ -212,6 +212,11 @@ export const useStrategyTiptapJson = (editorState: TextEditorState): ContentType
         id: 'search',
         title: $gettext('Search'),
         actions: [menuSearchAndReplace()]
+      },
+      {
+        id: 'export',
+        title: $gettext('Export'),
+        actions: [print()]
       }
     ]
   }

--- a/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
+++ b/packages/web-pkg/src/editor/composables/strategies/tiptapJson.ts
@@ -1,5 +1,3 @@
-import { ContentTypeStrategy, ExtensionsOptions } from './types'
-import { useGettext } from 'vue3-gettext'
 import type { Extension } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import StarterKit from '@tiptap/starter-kit'
@@ -12,7 +10,6 @@ import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import TextAlign from '@tiptap/extension-text-align'
-import { EditorActionGroup, useEditorActions } from '../useEditorActions'
 import {
   BackgroundColor,
   Color,
@@ -21,12 +18,15 @@ import {
   LineHeight,
   TextStyle
 } from '@tiptap/extension-text-style'
+import { useGettext } from 'vue3-gettext'
+import { EditorActionGroup, useEditorActions } from '../useEditorActions'
 import { TextEditorState } from '../../types'
 import {
   createCodeBlockLowlight,
   createLinkExtension,
   imageFileHandlerExtension
 } from '../../extensions'
+import { ContentTypeStrategy, ExtensionsOptions } from './types'
 
 export const useStrategyTiptapJson = (editorState: TextEditorState): ContentTypeStrategy => {
   const { $gettext } = useGettext()

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -173,7 +173,13 @@ export function useEditorActions(state: TextEditorState) {
     title: $gettext('Print'),
     icon: 'printer',
     iconFillType: 'line',
-    toolbarAction: (editor) => printEditorContent(editor, document.title || $gettext('Document')),
+    toolbarAction: (editor) => {
+      const fileName = unref(currentResource)?.name
+      if (!fileName) {
+        return
+      }
+      printEditorContent(editor, fileName)
+    },
     showInSlashCommands: false
   })
 

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -14,6 +14,7 @@ import FilePickerModal from '../../components/Modals/FilePickerModal.vue'
 import { arrayBufferToDataUrl } from '../../helpers'
 import { TextEditorState } from '../types'
 import { requestLinkPanel } from '../helpers/link'
+import { printEditorContent } from '../helpers/print'
 import TextEditorSearchAndReplacePanel from '../components/TextEditorSearchAndReplacePanel.vue'
 import TextEditorTableSizeSelector from '../components/TextEditorTableSizeSelector.vue'
 
@@ -165,6 +166,15 @@ export function useEditorActions(state: TextEditorState) {
     showInSlashCommands: false,
     menuCloseOnClick: false,
     childActions: [zoomOut(), zoomIn(), zoomReset()]
+  })
+
+  const print = (): EditorAction => ({
+    id: 'print',
+    title: $gettext('Print'),
+    icon: 'printer',
+    iconFillType: 'line',
+    toolbarAction: (editor) => printEditorContent(editor, document.title || $gettext('Document')),
+    showInSlashCommands: false
   })
 
   // Text formatting actions
@@ -994,6 +1004,7 @@ export function useEditorActions(state: TextEditorState) {
     zoomOut,
     zoomReset,
     zoomMenu,
+    print,
     toggleSourceMode,
     // Text formatting
     heading,

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -1,20 +1,16 @@
 import { computed, markRaw, ref, unref } from 'vue'
 import type { Component } from 'vue'
 import type { Editor, Range } from '@tiptap/core'
-import type {} from '@tiptap/extension-text-align'
 import { useGettext } from 'vue3-gettext'
 import { storeToRefs } from 'pinia'
 import type { Resource } from '@opencloud-eu/web-client'
 import { OcEmojiPicker } from '@opencloud-eu/design-system/components'
 import { useModals, useThemeStore } from '../../composables'
-import { useClientService } from '../../composables/clientService'
-import { useGetMatchingSpace } from '../../composables/spaces'
-import { useFolderLink } from '../../composables/folderLink'
+import { useClientService, useGetMatchingSpace, useFolderLink } from '../../composables'
 import FilePickerModal from '../../components/Modals/FilePickerModal.vue'
-import { arrayBufferToDataUrl } from '../../helpers'
+import { arrayBufferToDataUrl, withoutExtension } from '../../helpers'
 import { TextEditorState } from '../types'
-import { requestLinkPanel } from '../helpers/link'
-import { printEditorContent } from '../helpers/print'
+import { requestLinkPanel, printEditorContent } from '../helpers'
 import TextEditorSearchAndReplacePanel from '../components/TextEditorSearchAndReplacePanel.vue'
 import TextEditorTableSizeSelector from '../components/TextEditorTableSizeSelector.vue'
 
@@ -60,11 +56,6 @@ export interface EditorActionGroup {
   id: string
   title: string
   actions: EditorAction[]
-}
-
-export interface ContentTypeActions {
-  toolbarGroups: EditorAction[][]
-  slashCommandGroups: EditorActionGroup[]
 }
 
 export function useEditorActions(state: TextEditorState) {
@@ -178,7 +169,9 @@ export function useEditorActions(state: TextEditorState) {
       if (!fileName) {
         return
       }
-      printEditorContent(editor, fileName)
+      const extension = unref(currentResource)?.extension
+      const title = extension ? withoutExtension(fileName, extension) : fileName
+      printEditorContent(editor, title)
     },
     showInSlashCommands: false
   })

--- a/packages/web-pkg/src/editor/helpers/index.ts
+++ b/packages/web-pkg/src/editor/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './link'
+export * from './print'

--- a/packages/web-pkg/src/editor/helpers/print.ts
+++ b/packages/web-pkg/src/editor/helpers/print.ts
@@ -2,39 +2,30 @@ import type { Editor } from '@tiptap/core'
 import printEditorCss from '../styles/print-editor.css?raw'
 
 export function printEditorContent(editor: Editor, title: string): void {
-  const printFrame = document.createElement('iframe')
-  printFrame.style.cssText = `
-    position: fixed;
-    width: 0;
-    height: 0;
-    border: 0;
-  `
+  const printWindow = window.open('', '_blank')
 
-  const content = editor.getHTML()
-
-  printFrame.onload = () => {
-    const printWindow = printFrame.contentWindow
-    if (!printWindow) {
-      printFrame.remove()
-      return
-    }
-
-    printWindow.focus()
-    printWindow.print()
-    setTimeout(() => printFrame.remove(), 1000)
+  if (!printWindow) {
+    return
   }
 
-  printFrame.srcdoc = `
-    <!doctype html>
-    <html>
-      <head>
-        <meta charset="utf-8">
-        <title>${title}</title>
-        <style>${printEditorCss}</style>
-      </head>
-      <body>${content}</body>
-    </html>
+  const { document } = printWindow
+
+  document.title = title
+
+  const style = document.createElement('style')
+  style.textContent = `
+    ${printEditorCss}
+    body { padding: 20mm; }
+    @media print { body { padding: 0; } }
   `
 
-  document.body.appendChild(printFrame)
+  const content = document.createElement('div')
+  content.innerHTML = editor.getHTML()
+
+  document.head.append(style)
+  document.body.append(content)
+
+  printWindow.focus()
+  printWindow.print()
+  printWindow.close()
 }

--- a/packages/web-pkg/src/editor/helpers/print.ts
+++ b/packages/web-pkg/src/editor/helpers/print.ts
@@ -11,6 +11,7 @@ export function printEditorContent(editor: Editor, title: string): void {
   `
 
   const content = editor.getHTML()
+  console.log(content)
 
   printFrame.onload = () => {
     const printWindow = printFrame.contentWindow

--- a/packages/web-pkg/src/editor/helpers/print.ts
+++ b/packages/web-pkg/src/editor/helpers/print.ts
@@ -11,7 +11,6 @@ export function printEditorContent(editor: Editor, title: string): void {
   `
 
   const content = editor.getHTML()
-  console.log(content)
 
   printFrame.onload = () => {
     const printWindow = printFrame.contentWindow

--- a/packages/web-pkg/src/editor/helpers/print.ts
+++ b/packages/web-pkg/src/editor/helpers/print.ts
@@ -1,0 +1,40 @@
+import type { Editor } from '@tiptap/core'
+import printEditorCss from '../styles/print-editor.css?raw'
+
+export function printEditorContent(editor: Editor, title: string): void {
+  const printFrame = document.createElement('iframe')
+  printFrame.style.cssText = `
+    position: fixed;
+    width: 0;
+    height: 0;
+    border: 0;
+  `
+
+  const content = editor.getHTML()
+
+  printFrame.onload = () => {
+    const printWindow = printFrame.contentWindow
+    if (!printWindow) {
+      printFrame.remove()
+      return
+    }
+
+    printWindow.focus()
+    printWindow.print()
+    setTimeout(() => printFrame.remove(), 1000)
+  }
+
+  printFrame.srcdoc = `
+    <!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <title>${title}</title>
+        <style>${printEditorCss}</style>
+      </head>
+      <body>${content}</body>
+    </html>
+  `
+
+  document.body.appendChild(printFrame)
+}

--- a/packages/web-pkg/src/editor/index.ts
+++ b/packages/web-pkg/src/editor/index.ts
@@ -5,9 +5,8 @@ export type {
   TextEditorState,
   TextEditorLinkPanelRequest
 } from './types'
-export { useTextEditor } from './composables/useTextEditor'
-export { useContentStrategy } from './composables/useContentStrategy'
-export type { ContentTypeStrategy, ExtensionsOptions } from './composables/strategies/types'
+export { useTextEditor, useContentStrategy } from './composables'
+export type { ContentTypeStrategy, ExtensionsOptions } from './composables/strategies'
 export { makeTiptapYjsAdapter } from './yjsAdapter'
 export { default as TextEditorProvider } from './components/TextEditorProvider.vue'
 export { default as TextEditorContent } from './components/TextEditorContent.vue'

--- a/packages/web-pkg/src/editor/styles/print-editor.css
+++ b/packages/web-pkg/src/editor/styles/print-editor.css
@@ -105,6 +105,10 @@ td {
   text-align: left;
 }
 
+th {
+  background: rgba(148, 163, 184, 0.08);
+}
+
 hr {
   border: 0;
   border-top: 1px solid #ccc;

--- a/packages/web-pkg/src/editor/styles/print-editor.css
+++ b/packages/web-pkg/src/editor/styles/print-editor.css
@@ -9,6 +9,8 @@ body {
   font-size: 11pt;
   line-height: 1.5;
   color: #000;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
 }
 
 h1,

--- a/packages/web-pkg/src/editor/styles/print-editor.css
+++ b/packages/web-pkg/src/editor/styles/print-editor.css
@@ -1,0 +1,115 @@
+@page {
+  size: A4;
+  margin: 20mm;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  font-size: 11pt;
+  line-height: 1.5;
+  color: #000;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+p {
+  margin: 0 0 1em;
+}
+
+ul,
+ol {
+  padding-left: 1.5em;
+}
+
+ul[data-type='taskList'] {
+  list-style: none;
+  padding-left: 0;
+}
+
+ul[data-type='taskList'] li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5em;
+}
+
+ul[data-type='taskList'] li > label {
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+
+ul[data-type='taskList'] li > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+ul[data-type='taskList'] li > div > p {
+  margin: 0;
+}
+
+blockquote {
+  margin: 1em 0;
+  padding-left: 1em;
+  border-left: 3px solid #ccc;
+}
+
+pre {
+  padding: 1em;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+:not(pre) > code {
+  border: 1px solid #ccc;
+}
+
+pre code {
+  border: 0;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+tr {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+th,
+td {
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  text-align: left;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid #ccc;
+  margin: 2em 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/packages/web-pkg/src/editor/yjsAdapter.ts
+++ b/packages/web-pkg/src/editor/yjsAdapter.ts
@@ -6,7 +6,7 @@ import type { MaybeRefOrGetter } from 'vue'
 import type * as Y from 'yjs'
 import type { Schema } from '@tiptap/pm/model'
 import type { YjsAdapter } from '../composables/yjs/types'
-import type { ContentTypeStrategy } from './composables/strategies/types'
+import type { ContentTypeStrategy } from './composables/strategies'
 import { DEFAULT_YDOC_FRAGMENT } from './types'
 
 /**

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -10,6 +10,11 @@ vi.mock('vue3-gettext', () => ({
   useGettext: () => ({ $gettext: (text: string) => text })
 }))
 
+const printEditorContentMock = vi.fn()
+vi.mock('../../../../src/editor/helpers/print', () => ({
+  printEditorContent: (...args: unknown[]) => printEditorContentMock(...args)
+}))
+
 import { useEditorActions } from '../../../../src/editor/composables/useEditorActions'
 import type { TextEditorLinkPanelRequest, TextEditorState } from '../../../../src/editor/types'
 import type { Resource } from '@opencloud-eu/web-client'
@@ -43,6 +48,7 @@ describe('useEditorActions', () => {
     createTestingPinia({ stubActions: false })
     state = createState()
     actions = useEditorActions(state)
+    printEditorContentMock.mockReset()
   })
 
   describe('history', () => {
@@ -79,6 +85,16 @@ describe('useEditorActions', () => {
     it('undo and redo are hidden from slash commands', () => {
       expect(actions.undo().showInSlashCommands).toBe(false)
       expect(actions.redo().showInSlashCommands).toBe(false)
+    })
+
+    it('print is hidden from slash commands', () => {
+      expect(actions.print().showInSlashCommands).toBe(false)
+    })
+
+    it('print delegates to print helper with editor and fallback title', () => {
+      const editor = createMockEditor()
+      actions.print().toolbarAction!(editor)
+      expect(printEditorContentMock).toHaveBeenCalledWith(editor, expect.any(String))
     })
   })
 

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -27,7 +27,9 @@ function createState(): TextEditorState {
     sourceMode: ref(false),
     linkPanel: ref<TextEditorLinkPanelRequest | null>(null),
     editorZoom: ref(100),
-    currentResource: ref<Resource | null>(mock<Resource>({ id: 'resource', path: '/' }))
+    currentResource: ref<Resource | null>(
+      mock<Resource>({ id: 'resource', path: '/', name: 'My note.md' })
+    )
   }
 }
 
@@ -91,10 +93,17 @@ describe('useEditorActions', () => {
       expect(actions.print().showInSlashCommands).toBe(false)
     })
 
-    it('print delegates to print helper with editor and fallback title', () => {
+    it('print delegates to print helper with editor and resource file name', () => {
       const editor = createMockEditor()
       actions.print().toolbarAction!(editor)
-      expect(printEditorContentMock).toHaveBeenCalledWith(editor, expect.any(String))
+      expect(printEditorContentMock).toHaveBeenCalledWith(editor, 'My note.md')
+    })
+
+    it('print does nothing when resource has no name', () => {
+      state.currentResource.value = null
+      const editor = createMockEditor()
+      actions.print().toolbarAction!(editor)
+      expect(printEditorContentMock).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -28,7 +28,7 @@ function createState(): TextEditorState {
     linkPanel: ref<TextEditorLinkPanelRequest | null>(null),
     editorZoom: ref(100),
     currentResource: ref<Resource | null>(
-      mock<Resource>({ id: 'resource', path: '/', name: 'My note.md' })
+      mock<Resource>({ id: 'resource', path: '/', name: 'My note.md', extension: 'md' })
     )
   }
 }
@@ -93,10 +93,10 @@ describe('useEditorActions', () => {
       expect(actions.print().showInSlashCommands).toBe(false)
     })
 
-    it('print delegates to print helper with editor and resource file name', () => {
+    it('print delegates to print helper with editor and resource file name without extension', () => {
       const editor = createMockEditor()
       actions.print().toolbarAction!(editor)
-      expect(printEditorContentMock).toHaveBeenCalledWith(editor, 'My note.md')
+      expect(printEditorContentMock).toHaveBeenCalledWith(editor, 'My note')
     })
 
     it('print does nothing when resource has no name', () => {

--- a/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
@@ -43,7 +43,10 @@ describe('printEditorContent', () => {
   })
 
   it('defines print color adjustment in the stylesheet', () => {
-    const stylesheetPath = resolve(process.cwd(), 'packages/web-pkg/src/editor/styles/print-editor.css')
+    const stylesheetPath = resolve(
+      process.cwd(),
+      'packages/web-pkg/src/editor/styles/print-editor.css'
+    )
     const stylesheet = readFileSync(stylesheetPath, 'utf8')
 
     expect(stylesheet).toContain('-webkit-print-color-adjust: exact;')

--- a/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
@@ -48,6 +48,8 @@ describe('printEditorContent', () => {
 
     expect(stylesheet).toContain('-webkit-print-color-adjust: exact;')
     expect(stylesheet).toContain('print-color-adjust: exact;')
+    expect(stylesheet).toContain('th {')
+    expect(stylesheet).toContain('background: rgba(148, 163, 184, 0.08);')
   })
 
   it('focuses and prints when iframe window is available', () => {

--- a/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Editor } from '@tiptap/core'
+import { printEditorContent } from '../../../../src/editor/helpers/print'
+
+function createEditor(content: string): Editor {
+  return {
+    getHTML: () => content
+  } as unknown as Editor
+}
+
+function getPrintFrame(): HTMLIFrameElement {
+  const printFrame = document.body.querySelector('iframe')
+  if (!printFrame) {
+    throw new Error('Expected print iframe to be appended')
+  }
+  return printFrame
+}
+
+describe('printEditorContent', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('embeds editor html in the print document', () => {
+    const editor = createEditor(
+      '<p><span style="background-color: #ffffcc; color: #000000;">highlighted</span></p>'
+    )
+
+    printEditorContent(editor, 'My document')
+
+    const printFrame = getPrintFrame()
+    expect(printFrame.srcdoc).toContain('<title>My document</title>')
+    expect(printFrame.srcdoc).toContain('background-color: #ffffcc; color: #000000;')
+    expect(printFrame.srcdoc).toContain('<style>')
+  })
+
+  it('defines print color adjustment in the stylesheet', () => {
+    const stylesheetPath = resolve(process.cwd(), 'packages/web-pkg/src/editor/styles/print-editor.css')
+    const stylesheet = readFileSync(stylesheetPath, 'utf8')
+
+    expect(stylesheet).toContain('-webkit-print-color-adjust: exact;')
+    expect(stylesheet).toContain('print-color-adjust: exact;')
+  })
+
+  it('focuses and prints when iframe window is available', () => {
+    const editor = createEditor('<p>content</p>')
+    printEditorContent(editor, 'My document')
+
+    const printFrame = getPrintFrame()
+    const focus = vi.fn()
+    const print = vi.fn()
+    Object.defineProperty(printFrame, 'contentWindow', {
+      value: { focus, print },
+      configurable: true
+    })
+
+    printFrame.onload?.(new Event('load'))
+
+    expect(focus).toHaveBeenCalledOnce()
+    expect(print).toHaveBeenCalledOnce()
+
+    vi.runAllTimers()
+    expect(document.body.contains(printFrame)).toBe(false)
+  })
+
+  it('removes iframe and skips print when iframe window is unavailable', () => {
+    const editor = createEditor('<p>content</p>')
+    printEditorContent(editor, 'My document')
+
+    const printFrame = getPrintFrame()
+    Object.defineProperty(printFrame, 'contentWindow', {
+      value: null,
+      configurable: true
+    })
+
+    printFrame.onload?.(new Event('load'))
+
+    expect(document.body.contains(printFrame)).toBe(false)
+  })
+})

--- a/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/helpers/print.spec.ts
@@ -10,36 +10,65 @@ function createEditor(content: string): Editor {
   } as unknown as Editor
 }
 
-function getPrintFrame(): HTMLIFrameElement {
-  const printFrame = document.body.querySelector('iframe')
-  if (!printFrame) {
-    throw new Error('Expected print iframe to be appended')
+function createMockWindow() {
+  const mockDocument = {
+    title: '',
+    head: {
+      append: vi.fn()
+    },
+    body: {
+      append: vi.fn()
+    },
+    createElement: vi.fn((tag: string) => {
+      if (tag === 'style') {
+        return { textContent: '' }
+      }
+      if (tag === 'div') {
+        return { innerHTML: '' }
+      }
+      return {}
+    })
   }
-  return printFrame
+
+  return {
+    document: mockDocument,
+    focus: vi.fn(),
+    print: vi.fn(),
+    close: vi.fn()
+  }
 }
 
 describe('printEditorContent', () => {
+  let windowOpenSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(() => {
-    document.body.innerHTML = ''
-    vi.useFakeTimers()
+    windowOpenSpy = vi.spyOn(window, 'open')
   })
 
   afterEach(() => {
-    vi.useRealTimers()
-    document.body.innerHTML = ''
+    windowOpenSpy.mockRestore()
   })
 
   it('embeds editor html in the print document', () => {
+    const mockWindow = createMockWindow()
+    windowOpenSpy.mockReturnValue(mockWindow as any)
+
     const editor = createEditor(
       '<p><span style="background-color: #ffffcc; color: #000000;">highlighted</span></p>'
     )
 
     printEditorContent(editor, 'My document')
 
-    const printFrame = getPrintFrame()
-    expect(printFrame.srcdoc).toContain('<title>My document</title>')
-    expect(printFrame.srcdoc).toContain('background-color: #ffffcc; color: #000000;')
-    expect(printFrame.srcdoc).toContain('<style>')
+    expect(mockWindow.document.title).toBe('My document')
+    expect(mockWindow.document.head.append).toHaveBeenCalled()
+    expect(mockWindow.document.body.append).toHaveBeenCalled()
+
+    const styleCall = mockWindow.document.head.append.mock.calls[0][0]
+    expect(styleCall.textContent).toContain('body { padding: 20mm; }')
+    expect(styleCall.textContent).toContain('@media print { body { padding: 0; } }')
+
+    const contentCall = mockWindow.document.body.append.mock.calls[0][0]
+    expect(contentCall.innerHTML).toContain('background-color: #ffffcc; color: #000000;')
   })
 
   it('defines print color adjustment in the stylesheet', () => {
@@ -55,39 +84,24 @@ describe('printEditorContent', () => {
     expect(stylesheet).toContain('background: rgba(148, 163, 184, 0.08);')
   })
 
-  it('focuses and prints when iframe window is available', () => {
+  it('focuses, prints and closes the window', () => {
+    const mockWindow = createMockWindow()
+    windowOpenSpy.mockReturnValue(mockWindow as any)
+
     const editor = createEditor('<p>content</p>')
     printEditorContent(editor, 'My document')
 
-    const printFrame = getPrintFrame()
-    const focus = vi.fn()
-    const print = vi.fn()
-    Object.defineProperty(printFrame, 'contentWindow', {
-      value: { focus, print },
-      configurable: true
-    })
-
-    printFrame.onload?.(new Event('load'))
-
-    expect(focus).toHaveBeenCalledOnce()
-    expect(print).toHaveBeenCalledOnce()
-
-    vi.runAllTimers()
-    expect(document.body.contains(printFrame)).toBe(false)
+    expect(mockWindow.focus).toHaveBeenCalledOnce()
+    expect(mockWindow.print).toHaveBeenCalledOnce()
+    expect(mockWindow.close).toHaveBeenCalledOnce()
   })
 
-  it('removes iframe and skips print when iframe window is unavailable', () => {
+  it('returns early when window.open fails', () => {
+    windowOpenSpy.mockReturnValue(null)
+
     const editor = createEditor('<p>content</p>')
     printEditorContent(editor, 'My document')
 
-    const printFrame = getPrintFrame()
-    Object.defineProperty(printFrame, 'contentWindow', {
-      value: null,
-      configurable: true
-    })
-
-    printFrame.onload?.(new Event('load'))
-
-    expect(document.body.contains(printFrame)).toBe(false)
+    expect(windowOpenSpy).toHaveBeenCalledWith('', '_blank')
   })
 })

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -155,7 +155,7 @@ describe('useStrategyHtml', () => {
         groups.find((g) => g.id === 'view-options')?.actions.map((a) => a.id) || []
       const searchGroupIds = groups.find((g) => g.id === 'search')?.actions.map((a) => a.id) || []
 
-      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom'])
+      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom', 'print'])
       expect(sourceGroupIds).toEqual(['source-mode'])
       expect(searchGroupIds).toEqual(['menu-search-and-replace'])
     })

--- a/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/html.spec.ts
@@ -140,13 +140,13 @@ describe('useStrategyHtml', () => {
       expect(allIds).toContain('source-mode')
     })
 
-    it('places search group at the end', () => {
+    it('places export group at the end', () => {
       const strategy = createStrategy()
       const groupIds = strategy.editorActionGroups().map((g) => g.id)
-      expect(groupIds.at(-1)).toBe('search')
+      expect(groupIds.at(-1)).toBe('export')
     })
 
-    it('keeps navigation, source toggle and search actions in dedicated groups', () => {
+    it('keeps navigation, source toggle, search and export actions in dedicated groups', () => {
       const strategy = createStrategy()
       const groups = strategy.editorActionGroups()
       const navigationIds =
@@ -154,10 +154,12 @@ describe('useStrategyHtml', () => {
       const sourceGroupIds =
         groups.find((g) => g.id === 'view-options')?.actions.map((a) => a.id) || []
       const searchGroupIds = groups.find((g) => g.id === 'search')?.actions.map((a) => a.id) || []
+      const exportGroupIds = groups.find((g) => g.id === 'export')?.actions.map((a) => a.id) || []
 
-      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom', 'print'])
+      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom'])
       expect(sourceGroupIds).toEqual(['source-mode'])
       expect(searchGroupIds).toEqual(['menu-search-and-replace'])
+      expect(exportGroupIds).toEqual(['print'])
     })
   })
 

--- a/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
@@ -113,13 +113,13 @@ describe('useStrategyMarkdown', () => {
       expect(allIds).toContain('source-mode')
     })
 
-    it('places search group at the end', () => {
+    it('places export group at the end', () => {
       const strategy = createStrategy()
       const groupIds = strategy.editorActionGroups().map((g) => g.id)
-      expect(groupIds.at(-1)).toBe('search')
+      expect(groupIds.at(-1)).toBe('export')
     })
 
-    it('keeps navigation, source toggle and search actions in dedicated groups', () => {
+    it('keeps navigation, source toggle, search and export actions in dedicated groups', () => {
       const strategy = createStrategy()
       const groups = strategy.editorActionGroups()
       const navigationIds =
@@ -127,10 +127,12 @@ describe('useStrategyMarkdown', () => {
       const sourceGroupIds =
         groups.find((g) => g.id === 'view-options')?.actions.map((a) => a.id) || []
       const searchGroupIds = groups.find((g) => g.id === 'search')?.actions.map((a) => a.id) || []
+      const exportGroupIds = groups.find((g) => g.id === 'export')?.actions.map((a) => a.id) || []
 
-      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom', 'print'])
+      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom'])
       expect(sourceGroupIds).toEqual(['source-mode'])
       expect(searchGroupIds).toEqual(['menu-search-and-replace'])
+      expect(exportGroupIds).toEqual(['print'])
     })
 
     it('returns expected group structure', () => {

--- a/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts
@@ -128,7 +128,7 @@ describe('useStrategyMarkdown', () => {
         groups.find((g) => g.id === 'view-options')?.actions.map((a) => a.id) || []
       const searchGroupIds = groups.find((g) => g.id === 'search')?.actions.map((a) => a.id) || []
 
-      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom'])
+      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom', 'print'])
       expect(sourceGroupIds).toEqual(['source-mode'])
       expect(searchGroupIds).toEqual(['menu-search-and-replace'])
     })

--- a/packages/web-pkg/tests/unit/editor/strategies/plainText.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/plainText.spec.ts
@@ -66,7 +66,8 @@ describe('useStrategyPlainText', () => {
       expect(navigationGroup?.actions.map((action) => action.id)).toEqual([
         'undo',
         'redo',
-        'menu-zoom'
+        'menu-zoom',
+        'print'
       ])
 
       expect(emojiGroup).toMatchObject({

--- a/packages/web-pkg/tests/unit/editor/strategies/plainText.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/plainText.spec.ts
@@ -51,13 +51,14 @@ describe('useStrategyPlainText', () => {
   })
 
   describe('editorActionGroups', () => {
-    it('returns navigation group with zoom, emoji group, and search group', () => {
+    it('returns navigation, emoji, search and export groups', () => {
       const strategy = createStrategy()
       const groups = strategy.editorActionGroups()
-      expect(groups).toHaveLength(3)
+      expect(groups).toHaveLength(4)
       const navigationGroup = groups.find((group) => group.id === 'navigation')
       const emojiGroup = groups.find((group) => group.id === 'emoji')
       const searchGroup = groups.find((group) => group.id === 'search')
+      const exportGroup = groups.find((group) => group.id === 'export')
 
       expect(navigationGroup).toMatchObject({
         id: 'navigation',
@@ -66,8 +67,7 @@ describe('useStrategyPlainText', () => {
       expect(navigationGroup?.actions.map((action) => action.id)).toEqual([
         'undo',
         'redo',
-        'menu-zoom',
-        'print'
+        'menu-zoom'
       ])
 
       expect(emojiGroup).toMatchObject({
@@ -81,7 +81,12 @@ describe('useStrategyPlainText', () => {
         title: 'Search'
       })
       expect(searchGroup?.actions.map((action) => action.id)).toEqual(['menu-search-and-replace'])
-      expect(groups.at(-1)?.id).toBe('search')
+      expect(exportGroup).toMatchObject({
+        id: 'export',
+        title: 'Export'
+      })
+      expect(exportGroup?.actions.map((action) => action.id)).toEqual(['print'])
+      expect(groups.at(-1)?.id).toBe('export')
       expect(
         strategy.editorActionGroups().flatMap(({ actions }) => actions.map(({ id }) => id))
       ).not.toContain('link')

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -153,16 +153,18 @@ describe('useStrategyTiptapJson', () => {
   })
 
   describe('editorActionGroups', () => {
-    it('keeps zoom in navigation and search as the last group', () => {
+    it('keeps zoom in navigation and export as the last group', () => {
       const strategy = createStrategy()
       const groups = strategy.editorActionGroups()
       const navigationIds =
         groups.find((g) => g.id === 'navigation')?.actions.map((a) => a.id) || []
       const searchIds = groups.find((g) => g.id === 'search')?.actions.map((a) => a.id) || []
+      const exportIds = groups.find((g) => g.id === 'export')?.actions.map((a) => a.id) || []
 
-      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom', 'print'])
+      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom'])
       expect(searchIds).toEqual(['menu-search-and-replace'])
-      expect(groups.at(-1)?.id).toBe('search')
+      expect(exportIds).toEqual(['print'])
+      expect(groups.at(-1)?.id).toBe('export')
     })
   })
 

--- a/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts
@@ -160,7 +160,7 @@ describe('useStrategyTiptapJson', () => {
         groups.find((g) => g.id === 'navigation')?.actions.map((a) => a.id) || []
       const searchIds = groups.find((g) => g.id === 'search')?.actions.map((a) => a.id) || []
 
-      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom'])
+      expect(navigationIds).toEqual(['undo', 'redo', 'menu-zoom', 'print'])
       expect(searchIds).toEqual(['menu-search-and-replace'])
       expect(groups.at(-1)?.id).toBe('search')
     })


### PR DESCRIPTION
## Description

This PR adds a print action to the text editor toolbar and provides a basic print pipeline that renders editor HTML into a print iframe.

The print logic is extracted into a dedicated helper and uses a separate print stylesheet.

Disclaimer: this is intentionally a very basic implementation, but **we need to provide a print/PDF export option** so users can print or export their content as PDF.

<img width="1285" height="1154" alt="image" src="https://github.com/user-attachments/assets/0b09ec94-a26c-48c6-ae39-0d77ddf571e4" />

<img width="1308" height="1202" alt="image" src="https://github.com/user-attachments/assets/6c4bd19f-d230-42f0-b539-8d06baa7e03f" />


## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local development environment (macOS)
- test case 1: `pnpm test:unit --run packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts packages/web-pkg/tests/unit/editor/strategies/html.spec.ts packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts packages/web-pkg/tests/unit/editor/strategies/plainText.spec.ts`
- test case 2: manually verified print action opens print flow and includes table/task-list/code print styling

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)