### PR TITLE
test(e2e): add yjs tests for solo editing (& more)

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1566,8 +1566,6 @@ def yjsService():
                 "PORT": "1234",
                 "OPENCLOUD_URL": "https://opencloud:9200",
                 "NODE_TLS_REJECT_UNAUTHORIZED": "0",
-                "NODE_ENV": "development",
-                "DEV_FAKE_TOKEN": "dev-integration-token",
             },
             "commands": [
                 "cd services/yjs",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -440,9 +440,6 @@ services:
       OPENCLOUD_URL: https://host.docker.internal:9200
       # Dev only: accept the self-signed cert from OC's Traefik
       NODE_TLS_REJECT_UNAUTHORIZED: '0'
-      # Dev only: allows the integration tests to bypass real OIDC tokens
-      NODE_ENV: development
-      DEV_FAKE_TOKEN: dev-integration-token
     volumes:
       # Dev only: edit the server without rebuilding the image
       - ./services/yjs/src:/app/src:ro

--- a/services/yjs/README.md
+++ b/services/yjs/README.md
@@ -17,12 +17,10 @@ Every connection is authenticated and authorized against OpenCloud:
 
 ## Configuration
 
-| Variable         | Default      | Description                                                                  |
-| ---------------- | ------------ | ---------------------------------------------------------------------------- |
-| `OPENCLOUD_URL`  | -            | Required. Base URL of the OpenCloud server, e.g. `https://cloud.example.com` |
-| `PORT`           | `1234`       | Port to listen on                                                            |
-| `NODE_ENV`       | `production` | Set by the image. Must be `development` to allow `DEV_FAKE_TOKEN`            |
-| `DEV_FAKE_TOKEN` | unset        | Dev only. Bypasses auth for a fixed token. Requires `NODE_ENV=development`   |
+| Variable        | Default | Description                                                                  |
+| --------------- | ------- | ---------------------------------------------------------------------------- |
+| `OPENCLOUD_URL` | -       | Required. Base URL of the OpenCloud server, e.g. `https://cloud.example.com` |
+| `PORT`          | `1234`  | Port to listen on                                                            |
 
 ## Routing
 

--- a/services/yjs/src/server.ts
+++ b/services/yjs/src/server.ts
@@ -8,18 +8,6 @@ if (!opencloudUrl) {
   process.exit(1)
 }
 
-// Dev-only escape hatch for the integration test harness. Refused outright in
-// production so a stray env var can never turn into an auth bypass.
-const devFakeToken = process.env.DEV_FAKE_TOKEN ?? ''
-
-if (devFakeToken) {
-  if (process.env.NODE_ENV !== 'development') {
-    console.error('DEV_FAKE_TOKEN requires NODE_ENV=development')
-    process.exit(1)
-  }
-  console.warn('DEV_FAKE_TOKEN is set, authentication can be bypassed. Never do this in production')
-}
-
 /** The subset of the Graph `/me` response this service relies on. */
 type GraphUser = {
   id?: string
@@ -198,24 +186,6 @@ const server = new Server({
     }
 
     const clientAppVersion = requestParameters.get('appVersion') ?? ''
-
-    // Dev shortcut for integration tests: any token matching DEV_FAKE_TOKEN
-    // returns a synthetic identity. The ACL check is skipped (tests use random
-    // documentNames that don't exist in OC). Disabled when DEV_FAKE_TOKEN is
-    // unset.
-    if (devFakeToken && token === devFakeToken) {
-      const id = 'dev-fake-user'
-      // Gated the same way as a real connection, so the two paths cannot drift.
-      enforceAppVersion(documentName, clientAppVersion)
-      console.log(`[onAuthenticate] dev-fake document=${JSON.stringify(documentName)}`)
-      return {
-        user: {
-          id,
-          displayName: 'Dev Fake User',
-          color: deterministicColor(id)
-        }
-      }
-    }
 
     const me = await validateTokenAgainstOpenCloud(token)
     const id = me.id ?? me.userPrincipalName ?? me.mail ?? 'unknown'

--- a/tests/e2e/features/file-action/saveAs.feature
+++ b/tests/e2e/features/file-action/saveAs.feature
@@ -24,9 +24,11 @@ Feature: rename
       | resource     |
       | textfile.txt |
     Then "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    And "Alice" enters the text "lorem ipsum update" in editor "TextEditor"
+    And "Alice" saves the file viewer
     When "Alice" saves the current file as "textfile.txt"
     Then file "textfile (1).txt" should be opened in texteditor for user "Alice"
-    And "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    And "Alice" should see the content "lorem ipsum update" in editor "TextEditor"
     When "Alice" switches to tab 1
     And "Alice" closes the file viewer
     Then following resources should be displayed in the files list for user "Alice"
@@ -40,7 +42,7 @@ Feature: rename
       | textfile.txt |
     When "Alice" saves the current file as "top-folder/newfile.txt"
     Then file "newfile.txt" should be opened in texteditor for user "Alice"
-    And "Alice" should see the content "lorem ipsum" in editor "TextEditor"
+    And "Alice" should see the content "lorem ipsum update" in editor "TextEditor"
     When "Alice" closes the file viewer
     Then following resources should be displayed in the files list for user "Alice"
       | resource    |

--- a/tests/e2e/features/yjs/collaborativeEditing.feature
+++ b/tests/e2e/features/yjs/collaborativeEditing.feature
@@ -144,3 +144,34 @@ Feature: yjs collaborative editing
     And "Alice" sees the current file as clean
 
     And "Alice" logs out
+
+  Scenario: an editor joins a session that was initiated by a viewer
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+      | Brian |
+    And "Alice" creates the following file into personal space using API
+      | pathToFile | content     |
+      | example.md | lorem ipsum |
+    And "Alice" shares the following resources using API
+      | resource   | recipient | type | role     |
+      | example.md | Brian     | user | Can view |
+
+    And "Brian" logs in
+    And "Brian" navigates to the shared with me page
+    And "Brian" opens file "example.md" via "text-editor" using the context menu
+    And "Brian" is in a text-editor
+
+    When "Alice" logs in
+    And "Alice" opens the "files" app
+    And "Alice" opens file "example.md" via "text-editor" using the context menu
+    And "Alice" is in a text-editor
+
+    Then "Alice" should see the text "lorem ipsum" in the text-editor
+    And "Brian" should see the text "lorem ipsum" in the text-editor
+
+    When "Alice" enters the text "Alice says hello" in editor "TextEditor"
+    Then "Brian" should see the text "Alice says hello" in the text-editor
+
+    And "Alice" logs out
+    And "Brian" logs out

--- a/tests/e2e/features/yjs/soloEditing.feature
+++ b/tests/e2e/features/yjs/soloEditing.feature
@@ -1,0 +1,46 @@
+Feature: yjs single user editing
+  As a user
+  I want to be able to work with text documents in the text editor
+  So that I can edit my documents directly in the Web UI
+
+  Scenario: opening and editing a file in the text editor
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+    And "Alice" creates the following file into personal space using API
+      | pathToFile | content     |
+      | example.md | lorem ipsum |
+
+    And "Alice" logs in
+    And "Alice" opens the "files" app
+    And "Alice" opens file "example.md" via "text-editor" using the context menu
+    And "Alice" is in a text-editor
+    And "Alice" enters the text "Lorem ipsum update" in editor "TextEditor"
+    Then "Alice" sees the current file as dirty
+
+    When "Alice" saves the file viewer
+    Then "Alice" sees the current file as clean
+    And "Alice" should see the text "Lorem ipsum update" in the text-editor
+
+    When "Alice" reloads the page
+    Then "Alice" should see the text "Lorem ipsum update" in the text-editor
+
+    When "Alice" enters the text "Lorem ipsum another update" in editor "TextEditor"
+    Then "Alice" sees the current file as dirty
+    And "Alice" closes the file viewer
+    And "Alice" sees the save conflict dialog and chooses the following action
+      | action |
+      | Save   |
+    And "Alice" opens file "example.md" via "text-editor" using the context menu
+    Then "Alice" should see the text "Lorem ipsum another update" in the text-editor
+
+    When "Alice" enters the text "Replace content" in editor "TextEditor"
+    Then "Alice" sees the current file as dirty
+    And "Alice" closes the file viewer
+    And "Alice" sees the save conflict dialog and chooses the following action
+      | action     |
+      | Don't Save |
+    And "Alice" opens file "example.md" via "text-editor" using the context menu
+    Then "Alice" should see the text "Lorem ipsum another update" in the text-editor
+
+    And "Alice" logs out

--- a/tests/e2e/steps/ui/public.ts
+++ b/tests/e2e/steps/ui/public.ts
@@ -189,3 +189,12 @@ When(
     await processDelete(stepTable, pageObject, actionType)
   }
 )
+
+When(
+  '{string} sees the save conflict dialog and chooses the following action',
+  async ({ world }: { world: World }, stepUser: string, stepTable: DataTable): Promise<void> => {
+    const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+    const [{ action }] = stepTable.hashes()
+    await editor.resolveSaveConflict(page, action)
+  }
+)

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test'
+import { expect, Locator, Page } from '@playwright/test'
 
 const closeTextEditorOrViewerButton = '#app-top-bar-close'
 const saveTextEditorOrViewerButton = '#app-save-action'
@@ -7,11 +7,19 @@ const pdfViewer = '#pdf-viewer'
 const imageViewer = '.stage'
 const textEditorContent = '.tiptap.ProseMirror'
 const collaborationCursorLabel = '.collaboration-cursor__label'
+const saveConflictDialog = '.oc-modal'
+const filesListUrl = /.*\/files\/(spaces|shares|link|search)\/.*/
+const saveConflictDialogButtons: Record<string, string> = {
+  Save: '.oc-modal-body-actions-confirm',
+  "Don't Save": '.oc-modal-body-actions-secondary',
+  Cancel: '.oc-modal-body-actions-cancel'
+}
 
 export const close = async (page: Page) => {
-  const navigationPromise = page.waitForURL(/.*\/files\/(spaces|shares|link|search)\/.*/)
+  const navigationPromise = page.waitForURL(filesListUrl)
   await page.locator(closeTextEditorOrViewerButton).click()
-  await navigationPromise
+  // unsaved changes block the navigation until the save conflict dialog is resolved
+  await Promise.race([navigationPromise, page.locator(saveConflictDialog).waitFor()])
 }
 
 export const save = async (page: Page): Promise<unknown> => {
@@ -46,3 +54,24 @@ export const textEditorContentLocator = (page: Page): Locator => page.locator(te
 
 export const collaborationCaretLocator = (page: Page, displayName: string): Locator =>
   page.locator(collaborationCursorLabel, { hasText: displayName })
+
+export const resolveSaveConflict = async (page: Page, action: string): Promise<void> => {
+  const button = saveConflictDialogButtons[action]
+  if (!button) {
+    throw new Error(`save conflict dialog action "${action}" not implemented`)
+  }
+
+  const dialog = page.locator(saveConflictDialog)
+  await expect(dialog).toBeVisible()
+
+  if (action === 'Cancel') {
+    await dialog.locator(button).click()
+    await expect(dialog).not.toBeVisible()
+    return
+  }
+
+  const navigationPromise = page.waitForURL(filesListUrl)
+  await dialog.locator(button).click()
+  await navigationPromise
+  await page.locator('#app-loading-spinner').waitFor({ state: 'detached' })
+}


### PR DESCRIPTION
Add yjs e2e tests for solo editing, editing without having yjs configured and for an editor joining a viewer in a session.

Also remove the `DEV_FAKE_TOKEN` and `NODE_ENV` flags from the yjs server because this is not needed.

refs https://github.com/opencloud-eu/web/issues/3064