### PR TITLE
Reload previews after view mode changes to avoid blurry tiles

### DIFF
--- a/packages/web-pkg/src/composables/resources/useLoadPreview.ts
+++ b/packages/web-pkg/src/composables/resources/useLoadPreview.ts
@@ -34,9 +34,15 @@ type LoadPreviewOptions = {
   updateStore?: boolean
 }
 
+type PreviewProfile = {
+  dimensions: [number, number]
+  processor: ProcessorType
+}
+
 type QueuedPreview = {
   controller: AbortController
   isRunning: boolean
+  profile: PreviewProfile
 }
 
 export const useLoadPreview = (viewMode?: Ref<string>) => {
@@ -45,6 +51,7 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
   const spacesStore = useSpacesStore()
   const previewQueue = new PQueue({ concurrency: 4 })
   const queuedPreviews = new Map<string, QueuedPreview>()
+  const loadedPreviewProfiles = new Map<string, PreviewProfile>()
 
   const isTilesView = computed(() => unref(viewMode) === FolderViewModeConstants.name.tiles)
   const defaultProcessor = computed(() =>
@@ -55,18 +62,34 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
     unref(isTilesView) ? unref(previewDimensions) : ImageDimension.Thumbnail
   )
 
+  const isProfileCompatible = (loaded: PreviewProfile, requested: PreviewProfile) => {
+    return (
+      loaded.processor === requested.processor &&
+      loaded.dimensions[0] >= requested.dimensions[0] &&
+      loaded.dimensions[1] >= requested.dimensions[1]
+    )
+  }
+
   const loadPreviewTask = useTask<string, LoadPreviewOptions[]>(function* (
     signal,
     { space, resource, dimensions, processor, updateStore = true }
   ) {
     const item = isProjectSpaceResource(resource) ? buildSpaceImageResource(resource) : resource
     const isSpaceImage = item.id === space.spaceImageData?.id
+    const profile: PreviewProfile = {
+      dimensions: dimensions || unref(defaultDimensions),
+      processor: processor || unref(defaultProcessor)
+    }
 
     if (isSpaceImage) {
       spacesStore.addToImagesLoading(space.id)
     }
 
-    const queued: QueuedPreview = { controller: new AbortController(), isRunning: false }
+    const queued: QueuedPreview = {
+      controller: new AbortController(),
+      isRunning: false,
+      profile
+    }
     queuedPreviews.set(resource.id, queued)
 
     try {
@@ -90,6 +113,7 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
 
       if (preview && updateStore) {
         updateResourceField({ id: resource.id, field: 'thumbnail', value: preview })
+        loadedPreviewProfiles.set(resource.id, profile)
       }
 
       return preview
@@ -117,18 +141,38 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
       return null
     }
 
+    const dimensions = options.dimensions || unref(defaultDimensions)
+    const processor = options.processor || unref(defaultProcessor)
+    const profile: PreviewProfile = { dimensions, processor }
+
     // already queued or running, no need to load it twice
-    if (queuedPreviews.has(resource.id)) {
-      return
+    const queued = queuedPreviews.get(resource.id)
+    if (queued) {
+      if (isProfileCompatible(queued.profile, profile)) {
+        return
+      }
+      if (!queued.isRunning) {
+        queued.controller.abort()
+      }
     }
 
-    // store-backed previews are loaded once, direct callers may want other dimensions
-    if (updateStore && resource.thumbnail) {
+    // store-backed previews can be reused if they were loaded with a compatible profile
+    const loadedProfile = loadedPreviewProfiles.get(resource.id)
+    if (
+      updateStore &&
+      resource.thumbnail &&
+      loadedProfile &&
+      isProfileCompatible(loadedProfile, profile)
+    ) {
       return resource.thumbnail
     }
 
     try {
-      return await loadPreviewTask.perform(options)
+      return await loadPreviewTask.perform({
+        ...options,
+        dimensions,
+        processor
+      })
     } catch (e) {
       // ignore errors on cancel or when the preview was dropped while queued
       if (e !== 'cancel' && (e as Error)?.name !== 'AbortError') {
@@ -148,6 +192,7 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
     }
 
     queued.controller.abort()
+    loadedPreviewProfiles.delete(resource.id)
   }
 
   const previewsLoading = computed(() => loadPreviewTask.isRunning)
@@ -156,6 +201,7 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
     loadPreviewTask.cancelAll()
     previewQueue.clear()
     queuedPreviews.clear()
+    loadedPreviewProfiles.clear()
     spacesStore.purgeImagesLoading()
   }
 

--- a/packages/web-pkg/tests/unit/composables/resources/useLoadPreview.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useLoadPreview.spec.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, Ref } from 'vue'
 import { defaultComponentMocks, getComposableWrapper } from '@opencloud-eu/web-test-helpers'
 import { mock, MockProxy } from 'vitest-mock-extended'
 import { buildSpaceImageResource, Resource, SpaceResource } from '@opencloud-eu/web-client'
@@ -266,6 +266,100 @@ describe('useLoadPreview', () => {
         })
       })
     })
+
+    it('reuses an existing thumbnail only for the same preview profile', () => {
+      getWrapper({
+        setup: async ({ loadPreview }, { previewService }) => {
+          const space = mock<SpaceResource>()
+          const resource = mock<Resource>({
+            id: 'resource-1',
+            isInVault: false,
+            thumbnail: undefined
+          })
+
+          await loadPreview({ space, resource })
+          resource.thumbnail = 'blob:image'
+
+          await loadPreview({ space, resource })
+
+          expect(previewService.loadPreview).toHaveBeenCalledTimes(1)
+        }
+      })
+    })
+
+    it('reuses an existing thumbnail for smaller dimensions with the same processor', () => {
+      getWrapper({
+        setup: async ({ loadPreview }, { previewService }) => {
+          const space = mock<SpaceResource>()
+          const resource = mock<Resource>({
+            id: 'resource-1',
+            isInVault: false,
+            thumbnail: undefined
+          })
+
+          await loadPreview({
+            space,
+            resource,
+            processor: ProcessorType.enum.resize,
+            dimensions: [512, 512]
+          })
+          resource.thumbnail = 'blob:image'
+
+          await loadPreview({
+            space,
+            resource,
+            processor: ProcessorType.enum.resize,
+            dimensions: [320, 320]
+          })
+
+          expect(previewService.loadPreview).toHaveBeenCalledTimes(1)
+        }
+      })
+    })
+
+    it('reloads preview when view mode changes and requires a different profile', () => {
+      const viewMode = ref<string>(FolderViewModeConstants.name.table)
+
+      getWrapper({
+        viewMode,
+        setup: async ({ loadPreview }, { previewService }) => {
+          const space = mock<SpaceResource>()
+          const resource = mock<Resource>({
+            id: 'resource-2',
+            isInVault: false,
+            thumbnail: undefined
+          })
+
+          await loadPreview({ space, resource })
+          resource.thumbnail = 'blob:table'
+
+          viewMode.value = FolderViewModeConstants.name.tiles
+          await loadPreview({ space, resource })
+
+          expect(previewService.loadPreview).toHaveBeenCalledTimes(2)
+          expect(previewService.loadPreview).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+              dimensions: ImageDimension.Thumbnail,
+              processor: ProcessorType.enum.thumbnail
+            }),
+            expect.anything(),
+            expect.anything(),
+            expect.anything()
+          )
+          expect(previewService.loadPreview).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+              dimensions: [768, 768],
+              processor: ProcessorType.enum.fit
+            }),
+            expect.anything(),
+            expect.anything(),
+            expect.anything()
+          )
+        }
+      })
+    })
   })
 
   describe('dropPreview', () => {
@@ -338,7 +432,7 @@ function getWrapper({
     mocks: { previewService: MockProxy<PreviewService> }
   ) => void
   loadedPreview?: string
-  viewMode?: string
+  viewMode?: string | Ref<string>
 }) {
   const mocks = defaultComponentMocks()
   const previewService = mock<PreviewService>()
@@ -348,7 +442,8 @@ function getWrapper({
   return {
     wrapper: getComposableWrapper(
       () => {
-        const instance = useLoadPreview(viewMode ? ref(viewMode) : undefined)
+        const modeRef = typeof viewMode === 'string' ? ref(viewMode) : viewMode
+        const instance = useLoadPreview(modeRef)
         setup(instance, { previewService })
       },
       {


### PR DESCRIPTION
## Description

This bugfix resolves a regression where previews could remain low-resolution after switching view modes (for example from table to tiles) in Spaces and Personal.

`useLoadPreview` now tracks the loaded preview profile per resource (processor + dimensions) and only reuses an existing thumbnail if the requested profile matches.  
When the profile changes due to a view-mode change, the preview is loaded again with the correct dimensions/processor.

The test suite was extended with regression coverage for:
- reusing cached thumbnails only for the same profile
- reloading previews when the view mode changes and requires a different profile

## Related Issue

- Fixes #3228

## How Has This Been Tested?

- test environment: local development environment (pnpm workspace)
- test case 1: `pnpm test:unit --run packages/web-pkg/tests/unit/composables/resources/useLoadPreview.spec.ts`
- test case 2: `pnpm test:unit --run packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts`

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
