### PR TITLE
fix(preview): reload thumbnails when preview profile changes

### DIFF
--- a/packages/web-pkg/src/composables/resources/useLoadPreview.ts
+++ b/packages/web-pkg/src/composables/resources/useLoadPreview.ts
@@ -122,11 +122,6 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
       return
     }
 
-    // store-backed previews are loaded once, direct callers may want other dimensions
-    if (updateStore && resource.thumbnail) {
-      return resource.thumbnail
-    }
-
     try {
       return await loadPreviewTask.perform(options)
     } catch (e) {

--- a/packages/web-pkg/src/constants.ts
+++ b/packages/web-pkg/src/constants.ts
@@ -1,5 +1,5 @@
 export abstract class ImageDimension {
-  static readonly Thumbnail: [number, number] = [32, 32]
+  static readonly Thumbnail: [number, number] = [64, 64]
   static readonly Small: [number, number] = [320, 320]
   static readonly Medium: [number, number] = [448, 448]
   /** @deprecated use `previewDimensions` of `useTileSize` instead */
@@ -15,7 +15,5 @@ export abstract class ImageType {
 }
 
 export const AVATAR_UPLOAD_MAX_FILE_SIZE_MB = 10
-
-export const RESOURCE_MAX_CHARACTER_LENGTH = 63
 
 export const RESOURCE_NAME_MAX_BYTES = 256


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

This bugfix resolves a regression where previews could remain low-resolution after switching view modes (for example from table to tiles) in Spaces and Personal.

<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes #3228 

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
