### PR TITLE
feat: redesign plain layout pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,10 @@
           window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
         var shouldUseDark = storedThemeIsDark !== null ? isDark : prefersDark
         var themeName = shouldUseDark ? 'dark' : 'light'
-        var backgroundColor = shouldUseDark ? '#191c1d' : '#ffffff'
+        var backgroundColor = shouldUseDark ? '#1d2021' : '#f6f8fa'
 
         document.documentElement.style.colorScheme = themeName
+        document.documentElement.dataset.colorScheme = themeName
         document.documentElement.style.backgroundColor = backgroundColor
       }
 
@@ -57,14 +58,25 @@
       .splash-hide {
         display: none;
       }
+      /* Mirrors the OcSpinner component (size large) */
       #loading {
-        height: 34px;
-        width: 34px;
-        border: 1px solid #4c5f79;
-        border-radius: 50%;
-        border-top-color: #fff;
-        animation: spin 1s ease-in-out infinite;
-        -webkit-animation: spin 1s linear infinite;
+        position: relative;
+        display: inline-block;
+        width: 32px;
+        height: 32px;
+        animation: spin 1s linear infinite;
+      }
+      #loading::after {
+        content: '';
+        position: relative;
+        display: block;
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
+        background-color: transparent;
+        border: 1px solid currentColor;
+        border-bottom-color: transparent;
+        border-radius: 9999px;
       }
       #splash-incompatible button {
         margin: 30px 0;
@@ -72,12 +84,7 @@
 
       @keyframes spin {
         to {
-          -webkit-transform: rotate(360deg);
-        }
-      }
-      @-webkit-keyframes spin {
-        to {
-          -webkit-transform: rotate(360deg);
+          transform: rotate(360deg);
         }
       }
     </style>
@@ -118,7 +125,7 @@
       </button>
     </div>
     <div id="splash-loading" class="splash-banner splash-hide">
-      <div id="loading" class="inline-block"></div>
+      <span id="loading" aria-hidden="true" tabindex="-1"></span>
     </div>
     <div id="opencloud"></div>
     <noscript>

--- a/packages/design-system/src/styles/tailwind.css
+++ b/packages/design-system/src/styles/tailwind.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @import './defaults.css';
 
+@custom-variant dark (&:where([data-color-scheme='dark'], [data-color-scheme='dark'] *));
+
 @theme {
   --font-sans: var(--oc-font-family);
 

--- a/packages/extension-sdk/src/tailwind.css
+++ b/packages/extension-sdk/src/tailwind.css
@@ -2,6 +2,8 @@
 @import 'tailwindcss/theme.css' layer(theme) prefix(ext);
 @import 'tailwindcss/utilities.css' layer(utilities) prefix(ext);
 
+@custom-variant dark (&:where([data-color-scheme='dark'], [data-color-scheme='dark'] *));
+
 @theme {
   --font-sans: var(--oc-font-family);
 

--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -127,6 +127,7 @@ export const useThemeStore = defineStore('theme', () => {
     }
 
     document.documentElement.style.colorScheme = theme.isDark ? 'dark' : 'light'
+    document.documentElement.dataset.colorScheme = theme.isDark ? 'dark' : 'light'
     // expose the active theme on the DOM so deployment CSS (a global stylesheet or
     // theme.json) can attach structural styles (borders, radii, ...) that the
     // design-token system alone cannot express

--- a/packages/web-runtime/src/components/PlainCard.vue
+++ b/packages/web-runtime/src/components/PlainCard.vue
@@ -1,0 +1,46 @@
+<template>
+  <oc-card class="w-full rounded-xl shadow-md dark:border" body-class="p-6 sm:p-8">
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-4">
+        <span
+          v-if="icon"
+          class="flex size-11 shrink-0 items-center justify-center rounded-lg bg-role-secondary-container"
+        >
+          <oc-icon
+            :name="icon"
+            :fill-type="iconFillType"
+            size-class="size-5"
+            color="var(--oc-role-on-secondary-container)"
+          />
+        </span>
+        <div class="flex flex-col gap-1">
+          <h2 class="my-0 text-2xl font-bold" v-text="title" />
+          <p v-if="description" class="my-0 text-role-on-surface-variant" v-text="description" />
+        </div>
+      </div>
+      <slot />
+    </div>
+  </oc-card>
+</template>
+
+<script setup lang="ts">
+import { FillType } from '@opencloud-eu/design-system/helpers'
+// import ods components explicitly, ods is not initialized on all pages using this component
+import { OcCard, OcIcon } from '@opencloud-eu/design-system/components'
+
+const {
+  title,
+  description = undefined,
+  icon = undefined,
+  iconFillType = 'line'
+} = defineProps<{
+  title: string
+  description?: string
+  icon?: string
+  iconFillType?: FillType
+}>()
+
+defineSlots<{
+  default?: () => unknown
+}>()
+</script>

--- a/packages/web-runtime/src/components/PlainShell.vue
+++ b/packages/web-runtime/src/components/PlainShell.vue
@@ -1,0 +1,53 @@
+<template>
+  <div
+    class="min-h-screen overflow-y-auto flex flex-col bg-gradient-to-br from-role-surface-container to-role-surface-container-highest dark:to-role-surface-container-lowest"
+    :style="backgroundImgStyle"
+  >
+    <slot name="banner" />
+    <h1 class="sr-only" v-text="title" />
+    <div class="relative z-1 grow flex flex-col items-center justify-center gap-8 p-4">
+      <img
+        v-if="logoImg"
+        :src="logoImg"
+        alt=""
+        :aria-hidden="true"
+        class="h-8 sm:h-10 w-auto max-w-full"
+      />
+      <slot />
+      <p
+        v-if="footerSlogan"
+        class="my-0 text-sm text-role-on-surface-variant text-center"
+        v-text="footerSlogan"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { computed, unref } from 'vue'
+import { useThemeStore } from '@opencloud-eu/web-pkg'
+import { addVersionToAssetUrl } from '@opencloud-eu/design-system/helpers'
+
+defineProps<{
+  title: string
+}>()
+
+defineSlots<{
+  default?: () => unknown
+  banner?: () => unknown
+}>()
+
+const themeStore = useThemeStore()
+const { currentTheme } = storeToRefs(themeStore)
+
+const backgroundImg = computed(() => unref(currentTheme)?.background)
+const backgroundImgStyle = computed(() => {
+  return unref(backgroundImg) ? { backgroundImage: `url(${unref(backgroundImg)})` } : {}
+})
+const logoImg = computed(() => {
+  const logo = unref(currentTheme)?.logo
+  return logo ? addVersionToAssetUrl(logo) : null
+})
+const footerSlogan = computed(() => unref(currentTheme)?.slogan)
+</script>

--- a/packages/web-runtime/src/composables/layout/useLayout.ts
+++ b/packages/web-runtime/src/composables/layout/useLayout.ts
@@ -1,3 +1,4 @@
+import LayoutBare from '../../layouts/Bare.vue'
 import LayoutPlain from '../../layouts/Plain.vue'
 import LayoutApplication from '../../layouts/Application.vue'
 import { computed, unref } from 'vue'
@@ -9,24 +10,18 @@ export interface LayoutOptions {
   router?: Router
 }
 
-const layoutTypes = ['plain', 'application'] as const
-type LayoutType = (typeof layoutTypes)[number]
-
 export const useLayout = (options?: LayoutOptions) => {
   const router = options?.router || useRouter()
 
-  const layoutType = computed<LayoutType>(() => {
-    const plainLayoutRoutes = [
-      'login',
-      'logout',
-      'oidcCallback',
-      'resolvePublicLink',
-      'accessDenied'
-    ]
-    if (
-      !unref(router.currentRoute).name ||
-      plainLayoutRoutes.includes(unref(router.currentRoute).name as string)
-    ) {
+  const layoutType = computed<'bare' | 'plain' | 'application'>(() => {
+    const bareLayoutRoutes = ['login', 'oidcCallback']
+    const plainLayoutRoutes = ['logout', 'resolvePublicLink', 'accessDenied']
+
+    const routeName = unref(router.currentRoute).name as string
+    if (!routeName || bareLayoutRoutes.includes(routeName)) {
+      return 'bare'
+    }
+    if (plainLayoutRoutes.includes(routeName)) {
       return 'plain'
     }
 
@@ -38,8 +33,10 @@ export const useLayout = (options?: LayoutOptions) => {
       case 'application':
         return LayoutApplication
       case 'plain':
-      default:
         return LayoutPlain
+      case 'bare':
+      default:
+        return LayoutBare
     }
   })
 

--- a/packages/web-runtime/src/composables/layout/useLayout.ts
+++ b/packages/web-runtime/src/composables/layout/useLayout.ts
@@ -13,6 +13,15 @@ export interface LayoutOptions {
 export const useLayout = (options?: LayoutOptions) => {
   const router = options?.router || useRouter()
 
+  /**
+   * Determines the layout type based on the current route.
+   *
+   *  - bare: most minimal layout for pages that don't require any styling at all,
+   *    typically used for login and authentication pages, showing a loading spinner.
+   *  - plain: a simple layout with the OpenCloud logo and a card in the middle,
+   *    typically used for pages like access denied or public link password forms.
+   *  - application: the full application layout for the main content of the app.
+   */
   const layoutType = computed<'bare' | 'plain' | 'application'>(() => {
     const bareLayoutRoutes = ['login', 'oidcCallback']
     const plainLayoutRoutes = ['logout', 'resolvePublicLink', 'accessDenied']

--- a/packages/web-runtime/src/layouts/Bare.vue
+++ b/packages/web-runtime/src/layouts/Bare.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="min-h-screen overflow-y-auto flex flex-col bg-role-surface-container">
+    <announcement />
+    <h1 class="sr-only" v-text="pageTitle" />
+    <div class="flex grow items-center justify-center">
+      <oc-spinner v-if="pathIsRoot" size="large" :aria-label="$gettext('Loading')" />
+      <router-view v-else />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, unref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { useRoute } from 'vue-router'
+import { useRouteMeta } from '@opencloud-eu/web-pkg'
+import Announcement from '../components/Announcement.vue'
+
+const { $gettext } = useGettext()
+const route = useRoute()
+
+const title = useRouteMeta('title')
+
+const pageTitle = computed(() => $gettext(unref(title) || ''))
+const pathIsRoot = computed(() => unref(route)?.fullPath === '/')
+</script>

--- a/packages/web-runtime/src/layouts/Bare.vue
+++ b/packages/web-runtime/src/layouts/Bare.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen overflow-y-auto flex flex-col bg-role-surface-container">
+  <div class="min-h-screen overflow-y-auto flex flex-col bg-role-surface-container h-full">
     <announcement />
     <h1 class="sr-only" v-text="pageTitle" />
     <div class="flex grow items-center justify-center">

--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -1,5 +1,5 @@
 <template>
-  <plain-shell class="oc-login" :title="pageTitle">
+  <plain-shell class="oc-login h-full" :title="pageTitle">
     <template #banner>
       <announcement class="relative z-1" />
     </template>

--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -1,5 +1,5 @@
 <template>
-  <plain-shell class="oc-login h-full" :title="pageTitle">
+  <plain-shell class="h-full" :title="pageTitle">
     <template #banner>
       <announcement class="relative z-1" />
     </template>

--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -1,51 +1,24 @@
 <template>
-  <div class="oc-login h-screen" :style="backgroundImgStyle">
-    <div v-if="pathIsRoot" class="flex items-center justify-center h-full bg-role-surface">
-      <oc-spinner size="large" :aria-label="$gettext('Loading')" />
-    </div>
-    <template v-else>
+  <plain-shell class="oc-login" :title="pageTitle">
+    <template #banner>
       <announcement class="relative z-1" />
-      <h1 class="sr-only" v-text="pageTitle" />
-      <router-view class="relative z-1" />
-      <img
-        v-if="!backgroundImg && !pathIsRoot"
-        alt="OpenCloud emblem"
-        :src="emblemSrc"
-        class="hidden sm:block fixed w-3xs xs:w-xs md:w-md lg:w-lg bottom-[-40px] right-[-40px]"
-      />
     </template>
-  </div>
+    <router-view class="w-full max-w-md" />
+  </plain-shell>
 </template>
 
 <script setup lang="ts">
-import { storeToRefs } from 'pinia'
 import { computed, unref } from 'vue'
 import { useGettext } from 'vue3-gettext'
-import { useRouteMeta, useThemeStore } from '@opencloud-eu/web-pkg'
-import { useRoute } from 'vue-router'
-import { addVersionToAssetUrl } from '@opencloud-eu/design-system/helpers'
+import { useRouteMeta } from '@opencloud-eu/web-pkg'
 import Announcement from '../components/Announcement.vue'
+import PlainShell from '../components/PlainShell.vue'
 
 const { $gettext } = useGettext()
-const themeStore = useThemeStore()
-const { currentTheme } = storeToRefs(themeStore)
 
 const title = useRouteMeta('title')
-const route = useRoute()
 
 const pageTitle = computed(() => {
   return $gettext(unref(title) || '')
-})
-const backgroundImg = computed(() => unref(currentTheme).background)
-const backgroundImgStyle = computed(() => {
-  return unref(backgroundImg) ? { backgroundImage: `url(${unref(backgroundImg)})` } : {}
-})
-const emblemSrc = computed(() => {
-  const url = unref(currentTheme).isDark ? 'images/icon-lilac.svg' : 'images/icon-petrol.svg'
-  return addVersionToAssetUrl(url)
-})
-
-const pathIsRoot = computed(() => {
-  return unref(route)?.fullPath === '/'
 })
 </script>

--- a/packages/web-runtime/src/pages/accessDenied.vue
+++ b/packages/web-runtime/src/pages/accessDenied.vue
@@ -1,38 +1,28 @@
 <template>
-  <div class="h-screen flex flex-col justify-center items-center p-4">
-    <img v-if="logoImg" :src="logoImg" alt="" :aria-hidden="true" class="max-w-48 max-h-48 mb-4" />
-    <oc-card
-      :title="cardTitle"
-      body-class="text-center"
-      header-class="text-center"
-      class="w-full sm:w-sm rounded-lg"
-    >
-      <p v-text="cardHint" />
+  <plain-card :title="cardTitle" :description="cardHint" icon="user">
+    <div class="flex flex-col gap-4">
       <oc-button
         v-if="accessDeniedHelpUrl"
         type="a"
         appearance="raw"
+        justify-content="left"
         :href="accessDeniedHelpUrl"
         target="_blank"
         no-hover
       >
         <span v-text="$gettext('Read more')" />
       </oc-button>
-      <template #footer>
-        <p v-text="footerSlogan" />
-      </template>
-    </oc-card>
-    <oc-button
-      id="exitAnchor"
-      class="mt-4 w-full sm:w-sm"
-      size="large"
-      appearance="filled"
-      color-role="primary"
-      v-bind="logoutButtonsAttrs"
-    >
-      {{ navigateToLoginText }}
-    </oc-button>
-  </div>
+      <oc-button
+        id="exitAnchor"
+        class="w-full p-2"
+        size="large"
+        appearance="filled"
+        v-bind="logoutButtonsAttrs"
+      >
+        {{ navigateToLoginText }}
+      </oc-button>
+    </div>
+  </plain-card>
 </template>
 
 <script setup lang="ts">
@@ -45,6 +35,7 @@ import {
   useRouteQuery,
   useThemeStore
 } from '@opencloud-eu/web-pkg'
+import PlainCard from '../components/PlainCard.vue'
 
 const themeStore = useThemeStore()
 const { currentTheme } = storeToRefs(themeStore)
@@ -54,8 +45,6 @@ const redirectUrlQuery = useRouteQuery('redirectUrl')
 const { $gettext } = useGettext()
 
 const accessDeniedHelpUrl = computed(() => unref(currentTheme).urls?.accessDeniedHelp)
-const footerSlogan = computed(() => unref(currentTheme).slogan)
-const logoImg = computed(() => unref(currentTheme).logo)
 
 const cardTitle = computed(() => {
   return $gettext('Not logged in')

--- a/packages/web-runtime/src/pages/login.vue
+++ b/packages/web-runtime/src/pages/login.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="size-full">
-    <app-loading-spinner />
-  </div>
+  <app-loading-spinner />
 </template>
 
 <script setup lang="ts">

--- a/packages/web-runtime/src/pages/logout.vue
+++ b/packages/web-runtime/src/pages/logout.vue
@@ -1,38 +1,23 @@
 <template>
-  <div class="h-screen flex flex-col justify-center items-center p-4">
-    <img v-if="logoImg" :src="logoImg" alt="" :aria-hidden="true" class="max-w-48 max-h-48 mb-4" />
-    <oc-card
-      :title="cardTitle"
-      body-class="text-center"
-      header-class="text-center"
-      class="w-full sm:w-sm rounded-lg"
-    >
-      <p v-text="cardHint" />
-      <template #footer>
-        <p v-text="footerSlogan" />
-      </template>
-    </oc-card>
+  <plain-card :title="cardTitle" :description="cardHint" icon="logout-box-r">
     <oc-button
       id="exitAnchor"
-      class="mt-4 w-full sm:w-sm"
+      class="w-full p-2"
       size="large"
       appearance="filled"
-      color-role="primary"
       v-bind="loginButtonAttrs"
     >
       {{ loginButtonText }}
     </oc-button>
-  </div>
+  </plain-card>
 </template>
 <script setup lang="ts">
-import { computed, unref } from 'vue'
-import { useConfigStore, useThemeStore } from '@opencloud-eu/web-pkg'
+import { computed } from 'vue'
+import { useConfigStore } from '@opencloud-eu/web-pkg'
 import { useGettext } from 'vue3-gettext'
-import { storeToRefs } from 'pinia'
+import PlainCard from '../components/PlainCard.vue'
 
 const { $gettext } = useGettext()
-const themeStore = useThemeStore()
-const { currentTheme } = storeToRefs(themeStore)
 const configStore = useConfigStore()
 
 const cardTitle = computed(() => {
@@ -59,7 +44,4 @@ const loginButtonAttrs = computed(() => {
     }
   }
 })
-
-const footerSlogan = computed(() => unref(currentTheme).slogan)
-const logoImg = computed(() => unref(currentTheme).logo)
 </script>

--- a/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
+++ b/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
@@ -1,34 +1,20 @@
 <template>
-  <div
-    class="bg-role-chrome h-dvh max-h-dvh overflow-y-hidden flex flex-col justify-center items-center p-4"
-  >
-    <h1 class="sr-only" v-text="$gettext('Error')" />
-    <img v-if="logoImg" :src="logoImg" alt="" :aria-hidden="true" class="max-w-48 max-h-48 mb-4" />
-    <oc-card
+  <plain-shell :title="$gettext('Error')">
+    <plain-card
+      class="w-full max-w-md"
+      icon="error-warning"
       :title="$gettext('Missing or invalid config')"
-      body-class="text-center"
-      header-class="text-center"
-      class="rounded-lg"
+      :description="$gettext('Please check if the OpenCloud server is configured correctly.')"
     >
-      <p v-text="$gettext('Please check if the file config.json exists and is correct.')" />
-      <p v-text="$gettext('Also, make sure to check the browser console for more information.')" />
-      <template #footer>
-        <p v-if="footerSlogan" v-text="footerSlogan" />
-      </template>
-    </oc-card>
-  </div>
+      <p
+        class="my-0 text-role-on-surface-variant"
+        v-text="$gettext('Also, make sure to check the browser console for more information.')"
+      />
+    </plain-card>
+  </plain-shell>
 </template>
 
 <script setup lang="ts">
-import { computed, unref } from 'vue'
-import { useThemeStore } from '@opencloud-eu/web-pkg'
-import { storeToRefs } from 'pinia'
-// import ods component because ods is not initialized in case of a missing or invalid config
-import { OcCard } from '@opencloud-eu/design-system/components'
-
-const themeStore = useThemeStore()
-const { currentTheme } = storeToRefs(themeStore)
-
-const logoImg = computed(() => unref(currentTheme)?.logo)
-const footerSlogan = computed(() => unref(currentTheme)?.slogan)
+import PlainCard from '../components/PlainCard.vue'
+import PlainShell from '../components/PlainShell.vue'
 </script>

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -1,45 +1,27 @@
 <template>
-  <div class="h-screen flex flex-col justify-center items-center">
-    <img v-if="logoImg" :src="logoImg" alt="" :aria-hidden="true" class="max-w-48 max-h-48 mb-4" />
-    <oc-card :title="cardTitle" body-class="w-sm text-center" class="rounded-lg">
-      <p v-text="cardHint" />
-      <template #footer>
-        <p v-text="footerSlogan" />
-      </template>
-    </oc-card>
-  </div>
+  <plain-card
+    v-if="error"
+    class="w-full max-w-md"
+    :title="$gettext('Authentication failed')"
+    :description="$gettext('Please contact the administrator if this error persists.')"
+    icon="error-warning"
+  />
+  <app-loading-spinner v-else />
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, unref } from 'vue'
-import { useEmbedMode, useRoute, useThemeStore } from '@opencloud-eu/web-pkg'
+import { onBeforeUnmount, onMounted, ref, unref } from 'vue'
+import { useEmbedMode, useRoute, AppLoadingSpinner } from '@opencloud-eu/web-pkg'
 import { authService } from '../services/auth'
-import { storeToRefs } from 'pinia'
 import { useGettext } from 'vue3-gettext'
+import PlainCard from '../components/PlainCard.vue'
 
 const { $gettext } = useGettext()
-const themeStore = useThemeStore()
-const { currentTheme } = storeToRefs(themeStore)
 
 const { isDelegatingAuthentication, postMessage, verifyDelegatedAuthenticationOrigin } =
   useEmbedMode()
 
 const error = ref(false)
-
-const logoImg = computed(() => unref(currentTheme)?.logo)
-const cardTitle = computed(() => {
-  if (unref(error)) {
-    return $gettext('Authentication failed')
-  }
-  return $gettext('Logging you in')
-})
-const cardHint = computed(() => {
-  if (unref(error)) {
-    return $gettext('Please contact the administrator if this error persists.')
-  }
-  return $gettext('Please wait, you are being redirected.')
-})
-const footerSlogan = computed(() => unref(currentTheme)?.slogan)
 
 const route = useRoute()
 

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -1,13 +1,14 @@
 <template>
   <div class="oc-link-resolve h-full flex flex-col justify-center items-center p-4">
+    <app-loading-spinner v-if="loading" data-testid="loading-spinner" />
     <oc-card
-      :title="headerTitle"
+      v-else-if="errorMessage"
+      :title="$gettext('An error occurred while resolving the link')"
       body-class="text-center"
       header-class="text-center"
       class="w-auto md:w-lg rounded-lg"
     >
-      <oc-spinner v-if="loading" data-testid="loading-spinner" :aria-hidden="true" />
-      <p v-else-if="errorMessage" data-testid="error-message" class="text-xl">{{ errorMessage }}</p>
+      <p data-testid="error-message" class="text-xl">{{ errorMessage }}</p>
     </oc-card>
   </div>
 </template>
@@ -23,7 +24,8 @@ import {
   getSharedDriveItem,
   useSpacesStore,
   useGetResourceContext,
-  useLinkTargetRoute
+  useLinkTargetRoute,
+  AppLoadingSpinner
 } from '@opencloud-eu/web-pkg'
 import { unref, computed, onMounted } from 'vue'
 import { useTask } from 'vue-concurrency'
@@ -124,16 +126,6 @@ const getTargetRoute = async ({
 
 const loading = computed(() => {
   return !resolvePrivateLinkTask.last || resolvePrivateLinkTask.isRunning
-})
-
-const headerTitle = computed(() => {
-  if (unref(loading)) {
-    return $gettext('Resolving link…')
-  }
-  if (unref(errorMessage)) {
-    return $gettext('An error occurred while resolving the link')
-  }
-  return ''
 })
 
 const errorMessage = computed(() => {

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -1,39 +1,37 @@
 <template>
-  <div class="oc-link-resolve h-screen flex flex-col justify-center items-center p-4">
-    <img v-if="logoImg" :src="logoImg" alt="" :aria-hidden="true" class="max-w-48 max-h-48 mb-4" />
-    <oc-card
-      :title="headerTitle"
-      body-class="text-center"
-      header-class="text-center"
-      class="w-auto md:w-lg rounded-lg"
+  <plain-card
+    class="oc-link-resolve"
+    :title="cardTitle"
+    :description="cardDescription"
+    :icon="cardIcon"
+  >
+    <p v-if="errorMessage" data-testid="error-message" class="my-0">
+      {{ errorMessage }}
+    </p>
+    <form
+      v-else-if="isPasswordRequired"
+      class="flex flex-col gap-4"
+      @submit.prevent="resolvePublicLinkTask.perform(true)"
     >
-      <p v-if="errorMessage" data-testid="error-message" class="text-xl">
-        {{ errorMessage }}
-      </p>
-      <form v-else-if="isPasswordRequired" @submit.prevent="resolvePublicLinkTask.perform(true)">
-        <oc-text-input
-          ref="passwordInput"
-          v-model="password"
-          :error-message="wrongPasswordMessage"
-          :label="passwordFieldLabel"
-          type="password"
-          class="mb-2 [&_.oc-text-input-message]:justify-center"
-        />
-        <oc-button
-          appearance="filled"
-          class="oc-login-authorize-button"
-          :disabled="!password"
-          submit="submit"
-        >
-          <span v-text="$gettext('Continue')" />
-        </oc-button>
-      </form>
-      <oc-spinner v-else :aria-hidden="true" />
-      <template #footer>
-        <p v-text="footerSlogan" />
-      </template>
-    </oc-card>
-  </div>
+      <oc-text-input
+        ref="passwordInput"
+        v-model="password"
+        :error-message="wrongPasswordMessage"
+        :label="passwordFieldLabel"
+        type="password"
+      />
+      <oc-button
+        appearance="filled"
+        size="large"
+        class="oc-login-authorize-button w-full p-2"
+        :disabled="!password"
+        submit="submit"
+      >
+        <span v-text="$gettext('Continue')" />
+      </oc-button>
+    </form>
+    <oc-spinner v-else :aria-hidden="true" />
+  </plain-card>
 </template>
 
 <script setup lang="ts">
@@ -50,8 +48,7 @@ import {
   useRouteParam,
   useRouteQuery,
   useRouter,
-  useSpacesStore,
-  useThemeStore
+  useSpacesStore
 } from '@opencloud-eu/web-pkg'
 import { useTask } from 'vue-concurrency'
 import { ref, unref, computed, onMounted, useTemplateRef } from 'vue'
@@ -63,7 +60,7 @@ import {
   Resource
 } from '@opencloud-eu/web-client'
 import { useGettext } from 'vue3-gettext'
-import { storeToRefs } from 'pinia'
+import PlainCard from '../components/PlainCard.vue'
 
 const clientService = useClientService()
 const router = useRouter()
@@ -72,11 +69,7 @@ const authStore = useAuthStore()
 const { $gettext } = useGettext()
 const token = useRouteParam('token')
 const redirectUrl = useRouteQuery('redirectUrl')
-const themeStore = useThemeStore()
 const spacesStore = useSpacesStore()
-
-const { currentTheme } = storeToRefs(themeStore)
-const logoImg = computed(() => unref(currentTheme).logo)
 
 const passwordInputRef = useTemplateRef<HTMLInputElement>('passwordInput')
 const password = ref('')
@@ -288,18 +281,32 @@ onMounted(async () => {
   }
 })
 
-const headerTitle = computed(() => {
+const cardTitle = computed(() => {
   if (unref(errorMessage)) {
     return $gettext('An error occurred while loading the public link')
   }
   if (unref(isPasswordRequired)) {
-    return $gettext('This resource is password-protected')
+    return $gettext('This link is password-protected')
   }
   return $gettext('Loading public link…')
 })
-const footerSlogan = computed(() => unref(currentTheme).slogan)
+const cardDescription = computed(() => {
+  if (!unref(errorMessage) && unref(isPasswordRequired)) {
+    return $gettext('Enter the password you received to open this link.')
+  }
+  return undefined
+})
+const cardIcon = computed(() => {
+  if (unref(errorMessage)) {
+    return 'error-warning'
+  }
+  if (unref(isPasswordRequired)) {
+    return 'lock'
+  }
+  return undefined
+})
 const passwordFieldLabel = computed(() => {
-  return $gettext('Enter password for public link')
+  return $gettext('Password')
 })
 const wrongPasswordMessage = computed(() => {
   if (unref(wrongPassword)) {

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/accessDenied.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/accessDenied.spec.ts.snap
@@ -1,18 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`access denied page > renders component 1`] = `
-"<div class="h-screen flex flex-col justify-center items-center p-4"><img src="themes/opencloud/assets/logo.svg" alt="" aria-hidden="true" class="max-w-48 max-h-48 mb-4">
-  <div class="oc-card w-full sm:w-sm rounded-lg">
-    <div class="oc-card-header text-center">
-      <h2 class="mt-0">Not logged in</h2>
+"<div class="oc-card w-full rounded-xl shadow-md dark:border">
+  <!--v-if-->
+  <div class="oc-card-body p-6 sm:p-8">
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-4"><span class="flex size-11 shrink-0 items-center justify-center rounded-lg bg-role-secondary-container"><span class="oc-icon box-content inline-block align-baseline [&amp;_svg]:block size-5"><svg data-testid="inline-svg-stub" src="icons/user-line.svg" unique-ids="false" transform-source="(svg) => {
+			if (__props.accessibleLabel !== &quot;&quot;) {
+				const title = document.createElement(&quot;title&quot;);
+				title.setAttribute(&quot;id&quot;, svgTitleId.value);
+				title.appendChild(document.createTextNode(__props.accessibleLabel));
+				svg.insertBefore(title, svg.firstChild);
+			};
+			return svg;
+		}" aria-hidden="true" focusable="false" style="fill: var(--oc-role-on-secondary-container);" class="size-5"></svg></span></span>
+        <div class="flex flex-col gap-1">
+          <h2 class="my-0 text-2xl font-bold">Not logged in</h2>
+          <p class="my-0 text-role-on-surface-variant">This could be because of a routine safety log out, or because your account is either inactive or not yet authorized for use. Please try logging in after a while or seek help from your Administrator.</p>
+        </div>
+      </div>
+      <div class="flex flex-col gap-4">
+        <!--v-if--> <a attrs="[object Object]" class="oc-button-secondary oc-button-filled oc-button-secondary-filled gap-2 justify-center text-lg min-h-7 oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default w-full p-2" id="exitAnchor"></a>
+      </div>
     </div>
-    <div class="oc-card-body text-center">
-      <p>This could be because of a routine safety log out, or because your account is either inactive or not yet authorized for use. Please try logging in after a while or seek help from your Administrator.</p>
-      <!--v-if-->
-    </div>
-    <div class="oc-card-footer">
-      <p></p>
-    </div>
-  </div> <a attrs="[object Object]" class="oc-button-primary oc-button-filled oc-button-primary-filled gap-2 justify-center text-lg min-h-7 oc-button cursor-pointer disabled:opacity-60 disabled:cursor-default mt-4 w-full sm:w-sm" id="exitAnchor"></a>
+  </div>
+  <!--v-if-->
 </div>"
 `;

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/resolvePublicLink.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/resolvePublicLink.spec.ts.snap
@@ -1,13 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`resolvePublicLink > password required form > should display if password is required 1`] = `
-"<form><input modelvalue="" label="Enter password for public link" type="password" class="mb-2 [&amp;_.oc-text-input-message]:justify-center">
-  <oc-button-stub appearance="filled" colorrole="secondary" disabled="true" gapsize="medium" justifycontent="center" showspinner="false" size="medium" submit="submit" type="button" nohover="false" class="oc-login-authorize-button"></oc-button-stub>
+"<form class="flex flex-col gap-4"><input modelvalue="" label="Password" type="password">
+  <oc-button-stub appearance="filled" colorrole="secondary" disabled="true" gapsize="medium" justifycontent="center" showspinner="false" size="large" submit="submit" type="button" nohover="false" class="oc-login-authorize-button w-full p-2"></oc-button-stub>
 </form>"
-`;
-
-exports[`resolvePublicLink > should display the configuration theme general slogan as the login card footer 1`] = `
-"<div class="oc-card-footer">
-  <p></p>
-</div>"
 `;

--- a/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
@@ -15,7 +15,7 @@ vi.mock('@opencloud-eu/web-pkg', async (importOriginal) => ({
 }))
 
 const selectors = {
-  ocSpinnerStub: 'oc-spinner-stub',
+  loadingSpinner: '[data-testid="loading-spinner"]',
   errorMessage: '[data-testid="error-message"]'
 }
 
@@ -37,7 +37,7 @@ describe('resolvePrivateLink', () => {
 
   it('is in a loading state initially', () => {
     const { wrapper } = getWrapper()
-    expect(wrapper.find(selectors.ocSpinnerStub).exists()).toBeTruthy()
+    expect(wrapper.find(selectors.loadingSpinner).exists()).toBeTruthy()
   })
   it('resolves to "files-spaces-generic" and passes the scrollTo query', async () => {
     const fileId = '1'

--- a/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
@@ -28,18 +28,12 @@ const OcTextInputStub = defineComponent({
 })
 
 const selectors = {
-  cardFooter: '.oc-card-footer',
   ocSpinnerStub: 'oc-spinner-stub',
   submitButton: '.oc-login-authorize-button',
   errorMessage: '[data-testid="error-message"]'
 }
 
 describe('resolvePublicLink', () => {
-  it('should display the configuration theme general slogan as the login card footer', () => {
-    const { wrapper } = getWrapper()
-    const slogan = wrapper.find(selectors.cardFooter)
-    expect(slogan.html()).toMatchSnapshot()
-  })
   it('should display the loading spinner', () => {
     const { wrapper } = getWrapper({ passwordRequired: true })
     const loading = wrapper.find(selectors.ocSpinnerStub)
@@ -208,6 +202,7 @@ function getWrapper({
         provide: mocks,
         stubs: {
           OcCard: false,
+          PlainCard: false,
           OcTextInput: OcTextInputStub
         }
       }


### PR DESCRIPTION
Redesign the plain layout pages and reduce the flicker after logging in and out and when resolving private links by:

- matching the initial loading spinner and the `AppLoadingSpinner`.
- matching the background colors of the initial page render and the loaded theme.
- introducing a new bare layout that only renders the `AppLoadingSpinner` to avoid rendering some text like `You are being logged in` for a split second.

Also, make using `dark:` prefixes on Tailwind classes work by correctly setting `document.documentElement.dataset.colorScheme`.

<img width="475" height="560" alt="image" src="https://github.com/user-attachments/assets/9a6671e1-fac1-447c-8fa8-d72d8539ce6d" />
