### PR TITLE
Disable collaboration for vault files

### DIFF
--- a/packages/web-pkg/src/composables/yjs/useYjsSession.ts
+++ b/packages/web-pkg/src/composables/yjs/useYjsSession.ts
@@ -218,11 +218,13 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
   // Awareness still spin up so the editor binding stays on one codepath, but
   // nothing connects. Public-link visitors stay local too: the Yjs server
   // authenticates user bearer tokens against Graph `/me` and knows nothing
-  // about public-link tokens.
+  // about public-link tokens. Vault resources are always local as well: even
+  // with a configured server URL, encrypted files must never go collaborative.
   const yjsServerUrl = computed<string | null>(() => {
     if (!configStore.options.yjsServerUrl) return null
     if (!authStore.accessToken) return null
     if (authStore.publicLinkContextReady) return null
+    if (toValue(resource)?.isInVault) return null
     return configStore.options.yjsServerUrl
   })
 

--- a/packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts
@@ -303,6 +303,21 @@ describe('useYjsSession — local mode (no yjsServerUrl)', () => {
   })
 })
 
+describe('useYjsSession — vault resources', () => {
+  it('stays local and does not construct a HocuspocusProvider even when yjsServerUrl is set', async () => {
+    const s = setupSession({
+      yjsServerUrl: 'wss://example.test/yjs',
+      resource: makeResource({ isInVault: true }),
+      currentContent: 'vault content'
+    })
+    await flushPromises()
+
+    expect(providerInstances).toHaveLength(0)
+    expect(unref(s.session.status)).toBe('local')
+    expect(unref(s.session.provider)).toBeNull()
+  })
+})
+
 describe('useYjsSession — failed hydration', () => {
   const META_KEY = '_oc_meta'
   const throwingAdapter: YjsAdapter = {


### PR DESCRIPTION
## Description

- Disable remote Yjs collaboration for vault resources by forcing local session mode when `resource.isInVault` is true.
- Make the behavior independent of global server config (`yjsServerUrl`): vault files always behave like "no Yjs server configured".
- Add a regression test that asserts no provider/websocket is created for a vault file.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3100

## How Has This Been Tested?

- test environment: local development workspace (macOS, Node 24, pnpm)
- test case 1: `pnpm test:unit --run packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts`
- test case 2: new unit test `useYjsSession — vault resources` verifies `provider === null` and `status === 'local'` with `yjsServerUrl` configured

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
