### PR TITLE
test(e2e): add test to search using keyboard shortcuts

### DIFF
--- a/tests/e2e/features/search/search.feature
+++ b/tests/e2e/features/search/search.feature
@@ -246,3 +246,35 @@ Feature: Search
       | mainFolder/mediaTest.txt |
     And "Alice" clears lastModified filter
     And "Alice" logs out
+
+
+  Scenario: Search using keyboard shortcuts
+    Given "Admin" creates following user using API
+      | id    |
+      | Alice |
+    And "Alice" creates the following folder in personal space using API
+      | name           |
+      | mainFolder     |
+      | mainFolder/sub |
+    And "Alice" creates the following files with mtime into personal space using API
+      | pathToFile              | content |
+      | mainFolder/sub/lorem.md | lorem   |
+      | mainFolder/epsum.txt    | epsum   |
+    And "Alice" logs in
+    When "Alice" searches "lorem" globally using "s" keyboard shortcut
+    Then following resources should be displayed in the search list for user "Alice"
+      | resource       |
+      | …/sub/lorem.md |
+    But following resources should not be displayed in the search list for user "Alice"
+      | resource             |
+      | mainFolder/epsum.txt |
+    When "Alice" clears the search using keyboard shortcut
+    And "Alice" navigates to the personal space page
+    And "Alice" searches "epsum" globally using "/" keyboard shortcut
+    Then following resources should be displayed in the search list for user "Alice"
+      | resource             |
+      | mainFolder/epsum.txt |
+    But following resources should not be displayed in the search list for user "Alice"
+      | resource       |
+      | …/sub/lorem.md |
+    And "Alice" logs out

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -14,7 +14,7 @@ import {
 import { Public } from '../../support/objects/app-files/page/public'
 import { Resource } from '../../support/objects/app-files'
 import * as runtimeFs from '../../support/utils/runtimeFs'
-import { searchFilter } from '../../support/objects/app-files/resource/actions'
+import { searchFilter, SearchShortcutType } from '../../support/objects/app-files/resource/actions'
 import { File } from '../../support/types'
 import { waitProcessingToFinish } from '../../support/objects/app-files/fileEvents'
 import { editor } from '../../support/objects/app-files/utils'
@@ -404,6 +404,32 @@ When(
       filter: filter as searchFilter,
       pressEnter
     })
+  }
+)
+
+When(
+  /^"([^"]*)" searches "([^"]*)" globally using "(s|\/)" keyboard shortcut$/,
+  async (
+    { world }: { world: World },
+    stepUser: string,
+    keyword: string,
+    shortcut: string
+  ): Promise<void> => {
+    const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    await resourceObject.searchResource({
+      keyword,
+      keyboardShortcut: shortcut as SearchShortcutType
+    })
+  }
+)
+
+When(
+  '{string} clears the search using keyboard shortcut',
+  async ({ world }: { world: World }, stepUser: string): Promise<void> => {
+    const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    await resourceObject.clearSearchUsingKeyboardShortcut()
   }
 )
 

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1901,19 +1901,22 @@ export const getTagsForResourceVisibilityInDetailsPanel = async (
 
   return true
 }
-export type searchFilter = 'all files' | 'current folder'
 
+export type searchFilter = 'all files' | 'current folder'
+export type SearchShortcutType = 's' | '/'
 export interface searchResourceGlobalSearchArgs {
+  page: Page
   keyword: string
   filter?: searchFilter
   pressEnter?: boolean
-  page: Page
+  keyboardShortcut?: SearchShortcutType
 }
 
 export const searchResourceGlobalSearch = async (
   args: searchResourceGlobalSearchArgs
 ): Promise<void> => {
-  const { page, keyword, filter, pressEnter } = args
+  const { page, keyword, filter, pressEnter, keyboardShortcut } = args
+  const searchInputLocator = page.locator(globalSearchInput)
 
   // .reload() waits nicely for search indexing to be finished
   await page.reload()
@@ -1928,22 +1931,31 @@ export const searchResourceGlobalSearch = async (
       .click()
   }
 
-  await page.locator(globalSearchBarFilter).click()
-  await page.locator(appLoadingSpinner).waitFor({ state: 'detached' })
+  if (!keyboardShortcut) {
+    await page.locator(globalSearchBarFilter).click()
+    await page.locator(appLoadingSpinner).waitFor({ state: 'detached' })
+  }
 
   if (!keyword) {
-    await page.locator(globalSearchInput).click()
+    await searchInputLocator.click()
     await page.keyboard.press('Enter')
     return
   }
 
   // wait for tika indexing
   await new Promise((resolve) => setTimeout(resolve, 500))
+  const waitResponse = page.waitForResponse(
+    (resp) => resp.status() === 207 && resp.request().method() === 'REPORT'
+  )
 
-  await Promise.all([
-    page.waitForResponse((resp) => resp.status() === 207 && resp.request().method() === 'REPORT'),
-    page.locator(globalSearchInput).fill(keyword)
-  ])
+  if (keyboardShortcut) {
+    await expect(searchInputLocator).not.toBeFocused()
+    await page.keyboard.press(keyboardShortcut)
+    await expect(searchInputLocator).toBeFocused()
+    await Promise.all([waitResponse, page.keyboard.type(keyword)])
+  } else {
+    await Promise.all([waitResponse, searchInputLocator.fill(keyword)])
+  }
 
   await expect(page.locator(globalSearchOptions)).toBeVisible()
   await expect(page.locator(loadingSpinner)).not.toBeVisible()
@@ -1951,6 +1963,13 @@ export const searchResourceGlobalSearch = async (
   if (pressEnter) {
     await page.keyboard.press('Enter')
   }
+}
+
+export const clearSearchUsingKeyboardShortcut = async (page: Page): Promise<void> => {
+  await page.keyboard.press('Escape')
+  const searchInputLocator = page.locator(globalSearchInput)
+  await expect(searchInputLocator).toBeFocused()
+  await expect(searchInputLocator).toHaveValue('')
 }
 
 export type displayedResourceType = 'search list' | 'files list' | 'Shares' | 'trashbin'

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -230,6 +230,10 @@ export class Resource {
     await po.searchResourceGlobalSearch({ ...args, page: this.#page })
   }
 
+  clearSearchUsingKeyboardShortcut(): Promise<void> {
+    return po.clearSearchUsingKeyboardShortcut(this.#page)
+  }
+
   getResourceLocator(resource: string) {
     return po.getResourceLocator({ page: this.#page, resource })
   }


### PR DESCRIPTION
## Description
Added e2e to search globally using the keyboard shortcuts:
- `s` and `/` to search
- `esc` to clear the search input

## Related Issue
- Fixes https://github.com/opencloud-eu/qa/issues/86

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
