### PR TITLE
Isolate Yjs rooms by web version

### DIFF
--- a/dev/docs/yjs.md
+++ b/dev/docs/yjs.md
@@ -1,8 +1,13 @@
 # Yjs
 
-This doc explains the architecture and implementation of collaborative editing in OpenCloud Web. It is intended for developers who want to understand how it works, or who want to implement their own collaborative app on top of the same infrastructure.
+This doc explains the architecture and implementation of collaborative editing in OpenCloud Web. It is intended for
+developers who want to understand how it works, or who want to implement their own collaborative app on top of the same
+infrastructure.
 
-It is all built on [Yjs](https://yjs.dev/), a CRDT framework for building collaborative applications. Yjs provides the data structures and algorithms for merging concurrent edits from multiple clients, ensuring that all clients eventually converge to the same state. `yjs` is the term used throughout the code for everything belonging to it, most of all the external server.
+It is all built on [Yjs](https://yjs.dev/), a CRDT framework for building collaborative applications. Yjs provides the
+data structures and algorithms for merging concurrent edits from multiple clients, ensuring that all clients eventually
+converge to the same state. `yjs` is the term used throughout the code for everything belonging to it, most of all the
+external server.
 
 ## System view
 
@@ -39,19 +44,23 @@ flowchart TB
 
 ### The Yjs server
 
-The [OpenCloud Yjs server](https://github.com/opencloud-eu/web/tree/main/services/yjs) runs a [Hocuspocus](https://tiptap.dev/docs/hocuspocus) server that relays Yjs updates between clients editing the same file.
+The [OpenCloud Yjs server](https://github.com/opencloud-eu/web/tree/main/services/yjs) runs
+a [Hocuspocus](https://tiptap.dev/docs/hocuspocus) server that relays Yjs updates between clients editing the same file.
 
-It is reachable at whatever URL the deployment configures. In the Web dev setup that is `/yjs` on the OpenCloud host, forwarded by OC's own proxy, but it could equally be a separate domain behind its own ingress. The server URL needs to be defined via the `WEB_OPTION_YJS_SERVER_URL` environment variable.
+It is reachable at whatever URL the deployment configures. In the Web dev setup that is `/yjs` on the OpenCloud host,
+forwarded by OC's own proxy, but it could equally be a separate domain behind its own ingress. The server URL needs to
+be defined via the `WEB_OPTION_YJS_SERVER_URL` environment variable.
 
-| It does                                           | It does not                                      |
-| ------------------------------------------------- | ------------------------------------------------ |
-| Hold an in-memory replica and sync it with peers  | Persist anything (no storage extension is wired) |
-| Authenticate the bearer token against Graph `/me` | Read or write the file                           |
-| Enforce read/write access per file, per user      | Decide when to save                              |
-| Stamp the authenticated identity onto awareness   | Serialize the CRDT back to text                  |
-| Reject peers running a mismatched app version     | Survive a restart, or an empty room              |
+| It does                                              | It does not                                      |
+|------------------------------------------------------|--------------------------------------------------|
+| Hold an in-memory replica and sync it with peers     | Persist anything (no storage extension is wired) |
+| Authenticate the bearer token against Graph `/me`    | Read or write the file                           |
+| Enforce read/write access per file, per user         | Decide when to save                              |
+| Stamp the authenticated identity onto awareness      | Serialize the CRDT back to text                  |
+| Relay versioned room names without interpreting them | Survive a restart, or an empty room              |
 
-Notably it never converts the CRDT back into file content. That only happens in a browser, through the app's adapter - which is why saving needs a client to be online.
+Notably it never converts the CRDT back into file content. That only happens in a browser, through the app's adapter -
+which is why saving needs a client to be online.
 
 ### Access control
 
@@ -63,7 +72,7 @@ sequenceDiagram
     participant HP as Yjs server
     participant G as Graph API
 
-    C->>HP: connect(room, token, appVersion)
+    C->>HP: connect(room, token)
     HP->>G: GET /graph/v1.0/me
     G-->>HP: user identity
     HP->>G: GET drives/{driveId}/items/{itemId}/permissions
@@ -71,11 +80,7 @@ sequenceDiagram
     alt 401 / 403 / 404
         HP-->>C: reject - access denied
     else
-        HP->>HP: appVersion matches the room's baseline?
-        Note over HP: first client into a room sets the baseline
-        alt mismatch
-            HP-->>C: reject - please reload
-        else write action present
+        alt write action present
             HP-->>C: accept (read-write)
         else read only
             HP-->>C: accept (readOnly)
@@ -83,11 +88,22 @@ sequenceDiagram
     end
 ```
 
-The version baseline is recorded only once identity and access are settled. Doing it any earlier let an unauthenticated caller name any room, claim a version nobody else runs, and lock every legitimate client out of that file until the process restarted - the entry is cleared by `onDisconnect`, which never fires for a connection that was rejected.
+The room name is `<prefix>::<storageid>$<spaceid>!<opaqueid>:<webVersion>`. The prefix is `yjs.documentPrefix`,
+defaulting to the app's `applicationId`. The file id is `resource.fileId ?? resource.id`, which is the real composite id
+for everyone: plain WebDAV resources set `fileId` to `id`, and the recipient of a share gets it from `remoteItem.id`.
+Neither of the other two candidates works. `resource.remoteItemId` is the _share space_ id, so every file inside a
+shared folder would collapse into one room. `resource.id` alone breaks the recipient of a _directly_ shared file, where
+the resource is the share root and `id` is that recipient's private share-jail mount point - each recipient would get
+their own room, so live edits would not merge and saves would collide as ordinary WebDAV conflicts.
 
-The room name is `<prefix>::<storageid>$<spaceid>!<opaqueid>`. The prefix is `yjs.documentPrefix`, defaulting to the app's `applicationId`. The file id is `resource.fileId ?? resource.id`, which is the real composite id for everyone: plain WebDAV resources set `fileId` to `id`, and the recipient of a share gets it from `remoteItem.id`. Neither of the other two candidates works. `resource.remoteItemId` is the _share space_ id, so every file inside a shared folder would collapse into one room. `resource.id` alone breaks the recipient of a _directly_ shared file, where the resource is the share root and `id` is that recipient's private share-jail mount point - each recipient would get their own room, and since both sides still report `connected`, a save conflict would be silently retried over the other side's write rather than raising a dialog. The server strips the `<prefix>::` part before parsing, so the ACL probe targets the real file. The prefix exists so two editors with incompatible Y.Doc layouts (Tiptap's `Y.XmlFragment` vs CodeMirror's `Y.Text`) never share a room for the same file.
+`webVersion` comes from `process.env.PACKAGE_VERSION` (fallback `0.0.0`). Room membership is versioned by name: equal
+versions share one room, different versions do not. `_oc_meta` is not used for version negotiation. The server strips
+both `<prefix>::` and the optional `:<webVersion>` suffix before parsing, so the ACL probe always targets the real file
+id. The prefix still exists so two editors with incompatible Y.Doc layouts (Tiptap's
+`Y.XmlFragment` vs CodeMirror's `Y.Text`) never share a room for the same file.
 
-Awareness is anti-spoofed: `beforeHandleAwareness` overwrites the `user` field on every inbound awareness state with the identity from the authenticated connection, so a client cannot present itself as someone else.
+Awareness is anti-spoofed: `beforeHandleAwareness` overwrites the `user` field on every inbound awareness state with the
+identity from the authenticated connection, so a client cannot present itself as someone else.
 
 ## Inside `web`
 
@@ -111,7 +127,7 @@ flowchart TB
     HP["Yjs server"]
     DAV["WebDAV"]
 
-    IDX -->|"yjs: { appVersion, makeAdapter }"| AW
+    IDX -->|"yjs: { makeAdapter, documentPrefix? }"| AW
     AW -->|"makeAdapter(), once in setup"| ADP
     ADP -->|"YjsAdapter"| UCD
     AW --> UCD
@@ -139,11 +155,10 @@ An app turns on collaboration with one route option.
 ```ts
 // packages/web-app-text-editor/src/index.ts
 AppWrapperRoute(TextEditor, {
-  applicationId: 'text-editor',
-  yjs: {
-    appVersion: pkg.version,
-    makeAdapter: makeTextEditorAdapter
-  }
+    applicationId: 'text-editor',
+    yjs: {
+        makeAdapter: makeTextEditorAdapter
+    }
 })
 ```
 
@@ -156,13 +171,16 @@ AppWrapperRoute(TextEditor, {
 From there on, first client:
 
 1. `hasContent(ydoc)` is `false` → this client wins the election → `adapter.hydrate` (`yjsAdapter.ts`)
-2. `deserialize` (md/html pass through, json `JSON.parse`, plain-text builds the ProseMirror JSON itself) (`yjsAdapter.ts`)
-3. Headless editor is constructed with the strategy's extensions + Collaboration bound to the existing Y.Doc - `ySyncPlugin` attaches here (`yjsAdapter.ts`)
+2. `deserialize` (md/html pass through, json `JSON.parse`, plain-text builds the ProseMirror JSON itself) (
+   `yjsAdapter.ts`)
+3. Headless editor is constructed with the strategy's extensions + Collaboration bound to the existing Y.Doc -
+   `ySyncPlugin` attaches here (`yjsAdapter.ts`)
 4. `setContent` builds the ProseMirror tree, guided by `contentType` and the schema (`yjsAdapter.ts`)
 5. `ySyncPlugin` sees that transaction and writes the tree into the Y.XmlFragment
 6. Y.Doc lives locally, and syncs to the Yjs server if a provider exists
 
-Both lists run _after_ the version handshake and the etag drift check, which can short-circuit into a reload lock or into stale recovery before hydration is ever considered.
+Both lists run _after_ the etag drift check, which can short-circuit into stale recovery before hydration is ever
+considered.
 
 Client joining afterwards:
 
@@ -171,7 +189,9 @@ Client joining afterwards:
 
 ### Y.Doc
 
-Y.Doc is the CRDT that holds the shared state. It is a tree of shared types, and the editor content lives in a `Y.XmlFragment` named `"default"`. The session also maintains a `Y.Map` named `"_oc_meta"` for coordination and metadata.
+Y.Doc is the CRDT that holds the shared state. It is a tree of shared types, and the editor content lives in a
+`Y.XmlFragment` named `"default"`. The session also maintains a `Y.Map` named `"_oc_meta"` for coordination and
+metadata.
 
 There is no single global document. Every participant holds its own `Y.Doc`, and the server holds one too:
 
@@ -197,26 +217,38 @@ flowchart LR
     class F file
 ```
 
-All three are convergent replicas of the same CRDT. None is authoritative - that is the point of a CRDT: updates applied in any order end up at the same state. The server's copy is not a coordinator, it is a participant that happens to always be present.
+All three are convergent replicas of the same CRDT. None is authoritative - that is the point of a CRDT: updates applied
+in any order end up at the same state. The server's copy is not a coordinator, it is a participant that happens to
+always be present.
 
-It exists for two reasons. It gives a late joiner the room's current state in one initial sync, without any peer having to notice and re-send. And because it is a real `Y.Doc`, server-side hooks could read `_oc_meta` if a future stale probe ever needed to run server-side. Nothing does today.
+It exists for two reasons. It gives a late joiner the room's current state in one initial sync, without any peer having
+to notice and re-send. And because it is a real `Y.Doc`, server-side hooks could read `_oc_meta` if a future stale probe
+ever needed to run server-side. Nothing does today.
 
-The server's replica is memory-only - no storage extension is wired up. When the last client disconnects, the room empties and that copy is gone. Reconnecting later starts from a blank server doc, which is why hydration runs again. That is a deliberate trade - see [Known limits](#known-limits).
+The server's replica is memory-only - no storage extension is wired up. When the last client disconnects, the room
+empties and that copy is gone. Reconnecting later starts from a blank server doc, which is why hydration runs again.
+That is a deliberate trade - see [Known limits](#known-limits).
 
 ### The YjsAdapter
 
-The app provides a `YjsAdapter` to the session, which is how the session reads and writes the Y.Doc. The adapter is responsible for converting between the native file format and the Y.Doc's shared types.
+The app provides a `YjsAdapter` to the session, which is how the session reads and writes the Y.Doc. The adapter is
+responsible for converting between the native file format and the Y.Doc's shared types.
 
 ```ts
 interface YjsAdapter {
-  hydrate(ydoc: Y.Doc, content: string): void | Promise<void>
-  serialize(ydoc: Y.Doc): string | Promise<string>
-  hasContent(ydoc: Y.Doc): boolean
-  reset?(ydoc: Y.Doc): void
+    hydrate(ydoc: Y.Doc, content: string): void | Promise<void>
+
+    serialize(ydoc: Y.Doc): string | Promise<string>
+
+    hasContent(ydoc: Y.Doc): boolean
+
+    reset?(ydoc: Y.Doc): void
 }
 ```
 
-`makeAdapter` runs during `AppWrapper`'s setup - before the file is loaded - so it receives a reactive context (`{ resource: Ref<Resource> }`) and reads it lazily. It must run in setup because content strategies call `useGettext()`, which is why `makeTextEditorAdapter` resolves its strategies eagerly and only picks between them per call.
+`makeAdapter` runs during `AppWrapper`'s setup - before the file is loaded - so it receives a reactive context (
+`{ resource: Ref<Resource> }`) and reads it lazily. It must run in setup because content strategies call `useGettext()`,
+which is why `makeTextEditorAdapter` resolves its strategies eagerly and only picks between them per call.
 
 ### Startup order
 
@@ -235,11 +267,11 @@ sequenceDiagram
     DAV-->>AW: currentContent + OC-ETag
     Note over AW,S: only now is the session enabled -<br/>hydration seeds from currentContent
     AW->>S: enabled = true
-    S->>HP: connect(room, token, appVersion)
+    S->>HP: connect(room, token)
     HP-->>S: authenticated
     S->>HP: initial sync
     HP-->>S: onSynced
-    S->>S: version handshake · etag drift check · hydration election
+    S->>S: etag drift check · hydration election
     Note over S: winner runs adapter.hydrate(ydoc, currentContent)
     S-->>AW: isReady = true
     Note over AW: loading screen drops, slot renders
@@ -247,34 +279,55 @@ sequenceDiagram
     APP->>APP: useTextEditor binds Tiptap to the Y.Doc
 ```
 
-`AppWrapper` keeps its loading screen up until the session reports ready, so `App.vue` mounts against a Y.Doc that is already synced and hydrated. That is what lets the app declare `ydoc` and `awareness` as required props and call `useTextEditor` directly, with no placeholder of its own.
+`AppWrapper` keeps its loading screen up until the session reports ready, so `App.vue` mounts against a Y.Doc that is
+already synced and hydrated. That is what lets the app declare `ydoc` and `awareness` as required props and call
+`useTextEditor` directly, with no placeholder of its own.
 
 ### Hydration
 
-Hydration is the process of taking the file content and seeding it into the Y.Doc. It usually only happens once per room, and only if the room is empty. The first client to arrive into an empty room runs `adapter.hydrate(ydoc, currentContent)`. All other clients skip hydration and wait for the Yjs server to sync them up. A state recovery may re-run hydration if the room turns out to be stale, i.e. `_oc_meta.etag` no longer matches the etag the joining client just fetched.
+Hydration is the process of taking the file content and seeding it into the Y.Doc. It usually only happens once per
+room, and only if the room is empty. The first client to arrive into an empty room runs
+`adapter.hydrate(ydoc, currentContent)`. All other clients skip hydration and wait for the Yjs server to sync them up. A
+state recovery may re-run hydration if the room turns out to be stale, i.e. `_oc_meta.etag` no longer matches the etag
+the joining client just fetched.
 
-Two clients can arrive into an empty room at the same moment, and only one may seed it - otherwise the content lands twice. The elected client is the one with the lowest Yjs `clientID`, after a 150 ms pause to let peers announce themselves. The winner sets `_oc_meta.hydrated` before it seeds, so peers can react to the incoming content rather than merge with it.
+Two clients can arrive into an empty room at the same moment, and only one may seed it - otherwise the content lands
+twice. The elected client is the one with the lowest Yjs `clientID`, after a 150 ms pause to let peers announce
+themselves. The winner sets `_oc_meta.hydrated` before it seeds, so peers can react to the incoming content rather than
+merge with it.
 
 ### Stale recovery
 
-When a joining client finds that `_oc_meta.etag` no longer matches the etag it just fetched, the file changed outside the room. It stamps `nativeEtag`, claims the job via `recoveryClientId` and raises `isStale`. Every peer's meta observer fires, but only the elected one gets through: recovery wipes the room and re-seeds it, and the only peer holding the body behind `nativeEtag` is the one that just fetched the file. Any other peer would publish the copy it opened with - or its own last serialization - and then stamp the fresh etag onto it, so the next save would overwrite the external writer with a matching `If-Match` and no conflict.
+When a joining client finds that `_oc_meta.etag` no longer matches the etag it just fetched, the file changed outside
+the room. It stamps `nativeEtag`, claims the job via `recoveryClientId` and raises `isStale`. Every peer's meta observer
+fires, but only the elected one gets through: recovery wipes the room and re-seeds it, and the only peer holding the
+body behind `nativeEtag` is the one that just fetched the file. Any other peer would publish the copy it opened with -
+or its own last serialization - and then stamp the fresh etag onto it, so the next save would overwrite the external
+writer with a matching `If-Match` and no conflict.
 
-The elected peer captures that body at detection time rather than reading `currentContent` when recovery runs. By then the room has synced its own state into the Y.Doc and the debounced serialize has reported it straight back into `currentContent`.
+The elected peer captures that body at detection time rather than reading `currentContent` when recovery runs. By then
+the room has synced its own state into the Y.Doc and the debounced serialize has reported it straight back into
+`currentContent`.
 
-`recoveryClientId` is last-write-wins, so if several clients detect the same drift at once, exactly one of them survives convergence. A peer that joins while `isStale` is already up offers itself the same way, provided its etag matches `nativeEtag` - the observer only fires on change, so without that the room would stay stuck if the elected peer navigated away mid-recovery.
+`recoveryClientId` is last-write-wins, so if several clients detect the same drift at once, exactly one of them survives
+convergence. A peer that joins while `isStale` is already up offers itself the same way, provided its etag matches
+`nativeEtag` - the observer only fires on change, so without that the room would stay stuck if the elected peer
+navigated away mid-recovery.
 
-Reset lands before hydrate, so a throw in between leaves every peer looking at an empty document. That path keeps `isStale` up for the next joiner to retry, and locks the session so the editor freezes. Note that the lock does _not_ block saving - `isDirty` deliberately ignores it so a lock cannot silently discard unsaved work (see Known limits). What actually stops an empty document reaching disk is `serializeDoc` returning `null` when the adapter reports no content.
+Reset lands before hydrate, so a throw in between leaves every peer looking at an empty document. That path keeps
+`isStale` up for the next joiner to retry, and locks the session so the editor freezes. Note that the lock does _not_
+block saving - `isDirty` deliberately ignores it so a lock cannot silently discard unsaved work (see Known limits). What
+actually stops an empty document reaching disk is `serializeDoc` returning `null` when the adapter reports no content.
 
 ### `_oc_meta`
 
 A `Y.Map` alongside the editor content, used for coordination the editor never sees:
 
 | Key                | Written by          | Meaning                                       |
-| ------------------ | ------------------- | --------------------------------------------- |
+|--------------------|---------------------|-----------------------------------------------|
 | `etag`             | whoever saved last  | the etag the room believes is on disk         |
 | `lastSavedAt`      | whoever saved last  | fan-out trigger for a peer save               |
 | `savedStateVector` | whoever saved last  | what that peer's doc held when it wrote       |
-| `appVersion`       | first peer in       | schema version the room is running            |
 | `isStale`          | any writer          | the file changed outside this room; rehydrate |
 | `nativeEtag`       | writer that noticed | the etag recovery should settle on            |
 | `recoveryClientId` | writer that noticed | which peer is elected to re-seed the room     |
@@ -286,7 +339,8 @@ read-only peer alone therefore never reaches the room.
 
 ### Saving
 
-Saving is unchanged from single-user editing: `AppWrapper` PUTs over WebDAV with `If-Match`. Collaboration only changes where the content comes from and how conflicts resolve.
+Saving is unchanged from single-user editing: `AppWrapper` PUTs over WebDAV with `If-Match`. Collaboration only changes
+where the content comes from and how conflicts resolve.
 
 ```mermaid
 sequenceDiagram
@@ -316,30 +370,56 @@ sequenceDiagram
     Note over AWB: isDirty drops to false,<br/>next If-Match is already correct
 ```
 
-A peer's save only makes B clean if it actually contains B's work. What A wrote is what _A's_ doc serialized to, so `savedStateVector` carries A's Yjs state vector at write time and B compares its own client clock against it. Covered means B contributed nothing A was missing, so B has nothing left to save. Not covered means B typed something A's PUT never saw, and B stays dirty - dropping the flag there would also unregister `beforeunload` and wave the route-leave guard through, losing the edit with the tab. The etag is mirrored either way: it is factual, and it keeps B's next `If-Match` correct.
+A peer's save only makes B clean if it actually contains B's work. What A wrote is what _A's_ doc serialized to, so
+`savedStateVector` carries A's Yjs state vector at write time and B compares its own client clock against it. Covered
+means B contributed nothing A was missing, so B has nothing left to save. Not covered means B typed something A's PUT
+never saw, and B stays dirty - dropping the flag there would also unregister `beforeunload` and wave the route-leave
+guard through, losing the edit with the tab. The etag is mirrored either way: it is factual, and it keeps B's next
+`If-Match` correct.
 
 Only B's own client id is compared. A third peer's unsaved operations are that peer's dirty state to track.
 
-The 300 ms debounce only refreshes `currentContent`, which is what drives `isDirty`. It never triggers a PUT on its own. The actual write comes from a manual save (Ctrl+S) or the autosave timer (default 120 s), and both go through the same path. If a PUT comes back 409/412, what happens depends on whether a Yjs session is actually connected. With one, `AppWrapper` refetches, compares, and retries once with the fresh etag before falling back to a conflict message - the local Y.Doc already contains the peer's edits, so the retry publishes the merged state. Without one - a plain editor, or a deployment with no `yjsServerUrl` - there is nothing to merge, so the conflict dialog comes up straight away, exactly as it did before collaboration existed. Retrying there would silently overwrite whoever else wrote the file.
+The 300 ms debounce only refreshes `currentContent`, which is what drives `isDirty`. It never triggers a PUT on its own.
+The actual write comes from a manual save (Ctrl+S) or the autosave timer (default 120 s), and both go through the same
+path. If a PUT comes back 409/412, `AppWrapper` only tries reconciliation when a Yjs session exists _and_ is
+`connected`. It refetches the file, then:
+
+1. if body matches `newContent`, only etag tracking was stale, so it silently updates the baseline;
+2. if body differs, retry is allowed only when `wasWrittenByRoom(freshEtag)` proves the conflicting write came from this
+   room (with a short grace for in-flight etag stamps);
+3. otherwise it shows the conflict dialog.
+
+Without a connected session - plain editor, local mode, or unreachable Yjs server - the conflict dialog is immediate,
+exactly as in non-collaborative editing.
 
 ### Local mode
 
-When `options.yjsServerUrl` is unset the session still creates a `Y.Doc` and a standalone `Awareness`, skips the provider, and hydrates immediately. The Y.Doc binding is the same in both modes, so adapters and editor extensions need no branch. Two things do differ: no peers ever appear, and `useTextEditor` re-reads `yjsServerUrl` itself to decide whether to drop the source-mode action. That is what "collaboration disabled" means here - the editor works as it always did, it just never syncs.
+When `options.yjsServerUrl` is unset the session still creates a `Y.Doc` and a standalone `Awareness`, skips the
+provider, and hydrates immediately. The Y.Doc binding is the same in both modes, so adapters and editor extensions need
+no branch. Two things do differ: no peers ever appear, and `useTextEditor` re-reads `yjsServerUrl` itself to decide
+whether to drop the source-mode action. That is what "collaboration disabled" means here - the editor works as it always
+did, it just never syncs.
 
-A session configured for collaboration ends up here too when the server does not answer. A provider that cannot reach its server emits neither `onSynced` nor `onAuthenticationFailed` - it just keeps retrying - so nothing would ever release the loading gate. After `CONNECT_TIMEOUT_MS` the session gives up, disconnects the provider, hydrates locally and surfaces an error saying changes will not be shared. The file stays editable and saveable; only syncing is gone, and a reload is what retries. The provider is disconnected rather than destroyed, because the editor binds to its awareness; and it is not left retrying, because a late connect would merge the locally hydrated copy into a room that may already hold the same content and duplicate the document for everyone.
+A session configured for collaboration ends up here too when the server does not answer. A provider that cannot reach
+its server emits neither `onSynced` nor `onAuthenticationFailed` - it just keeps retrying - so nothing would ever
+release the loading gate. After `CONNECT_TIMEOUT_MS` the session gives up, disconnects the provider, hydrates locally
+and surfaces an error saying changes will not be shared. The file stays editable and saveable; only syncing is gone, and
+a reload is what retries. The provider is disconnected rather than destroyed, because the editor binds to its awareness;
+and it is not left retrying, because a late connect would merge the locally hydrated copy into a room that may already
+hold the same content and duplicate the document for everyone.
 
 ### File map
 
-| Path                                                          | Role                                                                          |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `packages/web-pkg/src/composables/yjs/useYjsSession.ts`       | the session: Y.Doc, provider, hydration, staleness, version gate, etag mirror |
-| `packages/web-pkg/src/composables/yjs/types.ts`               | `YjsAdapter`                                                                  |
-| `packages/web-pkg/src/components/AppTemplates/AppWrapper.vue` | owns the session, the save loop and the loading gate                          |
-| `packages/web-pkg/src/components/AppTemplates/types.ts`       | `YjsOptions`, `YjsAdapterContext`, slot args                                  |
-| `packages/web-pkg/src/editor/yjsAdapter.ts`                   | `makeTiptapYjsAdapter` - any strategy to a Y.Doc                              |
-| `packages/web-pkg/src/editor/composables/useTextEditor.ts`    | binds Tiptap to a Y.Doc and renders peer carets                               |
-| `packages/web-app-text-editor/src/yjs.ts`                     | the text editor's adapter and content-type detection                          |
-| `services/yjs/src/server.ts`                                  | the Yjs server (Hocuspocus)                                                   |
+| Path                                                          | Role                                                            |
+|---------------------------------------------------------------|-----------------------------------------------------------------|
+| `packages/web-pkg/src/composables/yjs/useYjsSession.ts`       | the session: Y.Doc, provider, hydration, staleness, etag mirror |
+| `packages/web-pkg/src/composables/yjs/types.ts`               | `YjsAdapter`                                                    |
+| `packages/web-pkg/src/components/AppTemplates/AppWrapper.vue` | owns the session, the save loop and the loading gate            |
+| `packages/web-pkg/src/components/AppTemplates/types.ts`       | `YjsOptions`, `YjsAdapterContext`, slot args                    |
+| `packages/web-pkg/src/editor/yjsAdapter.ts`                   | `makeTiptapYjsAdapter` - any strategy to a Y.Doc                |
+| `packages/web-pkg/src/editor/composables/useTextEditor.ts`    | binds Tiptap to a Y.Doc and renders peer carets                 |
+| `packages/web-app-text-editor/src/yjs.ts`                     | the text editor's adapter and content-type detection            |
+| `services/yjs/src/server.ts`                                  | the Yjs server (Hocuspocus)                                     |
 
 ---
 
@@ -347,30 +427,60 @@ A session configured for collaboration ends up here too when the server does not
 
 These are open items, not bugs to be surprised by.
 
-**Durability depends on an open browser.** The Yjs server holds no state and does not save. If every client closes between autosaves, edits made since the last save are lost with the room. A server-side flush would require `serialize` to run in Node, which the Tiptap-based adapter cannot do today.
+**Durability depends on an open browser.** The Yjs server holds no state and does not save. If every client closes
+between autosaves, edits made since the last save are lost with the room. A server-side flush would require `serialize`
+to run in Node, which the Tiptap-based adapter cannot do today.
 
-**Every peer autosaves.** A remote edit marks _your_ `AppWrapper` dirty, so with N clients open the same document gets saved N times per autosave interval. There is election for hydration but none for saving.
+**Every peer autosaves.** A remote edit marks _your_ `AppWrapper` dirty, so with N clients open the same document gets
+saved N times per autosave interval. There is election for hydration but none for saving.
 
-**Peer edits arm your unsaved-changes guard.** Same root cause: remote CRDT updates flow into `currentContent`, so `beforeunload` and the unsaved-changes modal fire for edits you did not make. Writers only - `isDirty` is hard-wired to `false` for a read-only client, which has nothing to save.
+**Peer edits arm your unsaved-changes guard.** Same root cause: remote CRDT updates flow into `currentContent`, so
+`beforeunload` and the unsaved-changes modal fire for edits you did not make. Writers only - `isDirty` is hard-wired to
+`false` for a read-only client, which has nothing to save.
 
-**Hydration election can race.** The 150 ms awareness-settle window is heuristic. If awareness has not propagated in time, two peers can both elect themselves and hydrate, duplicating content. Server-side hydration would remove the whole class.
+**Hydration election can race.** The 150 ms awareness-settle window is heuristic. If awareness has not propagated in
+time, two peers can both elect themselves and hydrate, duplicating content. Server-side hydration would remove the whole
+class.
 
-**`_oc_meta` is writable by any client with write access.** A buggy or hostile client can set `appVersion` or `isStale` and lock or reset every peer in the room. The room's control plane has no server authority beyond the read-only gate.
+**`_oc_meta` is writable by any client with write access.** A buggy or hostile client can set `isStale` and reset every
+peer in the room. The room's control plane has no server authority beyond the read-only gate.
 
-**`appVersion` is `0.0.0`.** `web-app-text-editor` is a private package with a placeholder version, so the version gate never actually fires for it.
+**Different web versions do not collaborate in one room.** Room names include `:<webVersion>`, so rolling upgrades split
+active editors by release. That avoids cross-version Y.Doc schema collisions, but those users now interact through
+WebDAV conflicts instead of live Yjs merges until they are on the same version again.
 
-**Source mode is disabled while collaborating.** It swaps the ProseMirror view for a plain textarea, which has no Y.Doc binding, so `useTextEditor` drops the `source-mode` action whenever a Yjs session is active. Marked as a `FIXME`.
+**Source mode is disabled while collaborating.** It swaps the ProseMirror view for a plain textarea, which has no Y.Doc
+binding, so `useTextEditor` drops the `source-mode` action whenever a Yjs session is active. Marked as a `FIXME`.
 
-**A locked session can still be saved.** `isLockedForReload` freezes the editor but deliberately leaves `isDirty` alone, so the user can still persist work they typed before the lock. The gap is an adapter that throws _partway_ through `hydrate`, or a mid-session `appVersion` bump: in both cases a manual save would write content the room considers wrong. Unreachable while `appVersion` is `0.0.0` - whoever makes the version gate real must split the lock into "freeze the editor" and "content is untrustworthy, block autosave" in the same change.
+**A locked session can still be saved.** `isLockedForReload` freezes the editor but deliberately leaves `isDirty` alone,
+so the user can still persist work they typed before the lock. The gap is an adapter that throws _partway_ through
+`hydrate`: a manual save could write content the room considers wrong. If locking is ever used for "content is
+untrustworthy", the lock needs to split into "freeze editor" and "block saves".
 
-**Yjs needs a user token.** The Yjs server authenticates a bearer token against Graph `/me` and knows nothing about public-link tokens, so any context without a user access token - a public link, OCM - runs in local mode regardless of `yjsServerUrl`. Editing works, it just does not sync. A signed-in visitor opening someone else's public link is treated the same way, since their token carries no grant on the shared file.
+**Yjs needs a user token.** The Yjs server authenticates a bearer token against Graph `/me` and knows nothing about
+public-link tokens, so any context without a user access token - a public link, OCM - runs in local mode regardless of
+`yjsServerUrl`. Editing works, it just does not sync. A signed-in visitor opening someone else's public link is treated
+the same way, since their token carries no grant on the shared file.
 
-**Connection state is invisible.** The session exposes a `status` ref (`connecting` / `connected` / `disconnected` / `local`). `AppWrapper` reads it to decide whether a save conflict can be reconciled, but never shows it. A websocket that drops _after_ a successful sync produces no indicator: the user keeps typing into a Y.Doc that no longer reaches anyone. Only a connect that never succeeds in the first place is caught, by the timeout above.
+**Connection state is invisible.** The session exposes a `status` ref (`connecting` / `connected` / `disconnected` /
+`local`). `AppWrapper` reads it to decide whether a save conflict can be reconciled, but never shows it. A websocket
+that drops _after_ a successful sync produces no indicator: the user keeps typing into a Y.Doc that no longer reaches
+anyone. Only a connect that never succeeds in the first place is caught, by the timeout above.
 
-**Conflict reconciliation depends on a timely etag stamp.** While connected, a 409/412 is only retried when the room can account for the write: the fresh etag must match `_oc_meta.etag`, with a short grace period (`ROOM_ETAG_GRACE_MS`) for a peer's stamp that is still in flight. An external writer - a desktop sync client, say - fails that check and raises the conflict dialog instead of being overwritten. The residual gap is timing: a peer save whose stamp arrives after the grace period turns into a spurious conflict dialog.
+**Conflict reconciliation depends on a timely etag stamp.** While connected, a 409/412 is only retried when the room can
+account for the write: the fresh etag must match `_oc_meta.etag`, with a short grace period (`ROOM_ETAG_GRACE_MS`) for a
+peer's stamp that is still in flight. An external writer - a desktop sync client, say - fails that check and raises the
+conflict dialog instead of being overwritten. The residual gap is timing: a peer save whose stamp arrives after the
+grace period turns into a spurious conflict dialog.
 
-**`_oc_meta.hydrated` is never cleared.** Stale recovery deletes `isStale`, `nativeEtag` and `recoveryClientId` but leaves `hydrated` set. Harmless today, since the recovered room really is seeded, but it means the flag tracks "this room was ever seeded" rather than "a peer is seeding right now".
+**`_oc_meta.hydrated` is never cleared.** Stale recovery deletes `isStale`, `nativeEtag` and `recoveryClientId` but
+leaves `hydrated` set. Harmless today, since the recovered room really is seeded, but it means the flag tracks "this
+room was ever seeded" rather than "a peer is seeding right now".
 
-**Stale recovery needs someone who holds the fresh body.** Only a peer whose fetched etag matches `nativeEtag` may re-seed the room. If that peer leaves before finishing, the room stays flagged until another client opens the file and picks the job up. Peers already in the room keep editing a document that no longer matches disk in the meantime.
+**Stale recovery needs someone who holds the fresh body.** Only a peer whose fetched etag matches `nativeEtag` may
+re-seed the room. If that peer leaves before finishing, the room stays flagged until another client opens the file and
+picks the job up. Peers already in the room keep editing a document that no longer matches disk in the meantime.
 
-**Bundle weight.** `AppWrapper` imports the session directly, so `yjs`, `y-protocols` and `@hocuspocus/provider` land in web-pkg's main entry - loaded even by users who never open an editor. Moving the session behind a `defineAsyncComponent` would fix it at the cost of some indirection.
+**Bundle weight.** `AppWrapper` imports the session directly, so `yjs`, `y-protocols` and `@hocuspocus/provider` land in
+web-pkg's main entry - loaded even by users who never open an editor. Moving the session behind a `defineAsyncComponent`
+would fix it at the cost of some indirection.

--- a/dev/docs/yjs.md
+++ b/dev/docs/yjs.md
@@ -52,7 +52,7 @@ forwarded by OC's own proxy, but it could equally be a separate domain behind it
 be defined via the `WEB_OPTION_YJS_SERVER_URL` environment variable.
 
 | It does                                              | It does not                                      |
-|------------------------------------------------------|--------------------------------------------------|
+| ---------------------------------------------------- | ------------------------------------------------ |
 | Hold an in-memory replica and sync it with peers     | Persist anything (no storage extension is wired) |
 | Authenticate the bearer token against Graph `/me`    | Read or write the file                           |
 | Enforce read/write access per file, per user         | Decide when to save                              |
@@ -155,10 +155,10 @@ An app turns on collaboration with one route option.
 ```ts
 // packages/web-app-text-editor/src/index.ts
 AppWrapperRoute(TextEditor, {
-    applicationId: 'text-editor',
-    yjs: {
-        makeAdapter: makeTextEditorAdapter
-    }
+  applicationId: 'text-editor',
+  yjs: {
+    makeAdapter: makeTextEditorAdapter
+  }
 })
 ```
 
@@ -236,13 +236,13 @@ responsible for converting between the native file format and the Y.Doc's shared
 
 ```ts
 interface YjsAdapter {
-    hydrate(ydoc: Y.Doc, content: string): void | Promise<void>
+  hydrate(ydoc: Y.Doc, content: string): void | Promise<void>
 
-    serialize(ydoc: Y.Doc): string | Promise<string>
+  serialize(ydoc: Y.Doc): string | Promise<string>
 
-    hasContent(ydoc: Y.Doc): boolean
+  hasContent(ydoc: Y.Doc): boolean
 
-    reset?(ydoc: Y.Doc): void
+  reset?(ydoc: Y.Doc): void
 }
 ```
 
@@ -324,7 +324,7 @@ actually stops an empty document reaching disk is `serializeDoc` returning `null
 A `Y.Map` alongside the editor content, used for coordination the editor never sees:
 
 | Key                | Written by          | Meaning                                       |
-|--------------------|---------------------|-----------------------------------------------|
+| ------------------ | ------------------- | --------------------------------------------- |
 | `etag`             | whoever saved last  | the etag the room believes is on disk         |
 | `lastSavedAt`      | whoever saved last  | fan-out trigger for a peer save               |
 | `savedStateVector` | whoever saved last  | what that peer's doc held when it wrote       |
@@ -411,7 +411,7 @@ hold the same content and duplicate the document for everyone.
 ### File map
 
 | Path                                                          | Role                                                            |
-|---------------------------------------------------------------|-----------------------------------------------------------------|
+| ------------------------------------------------------------- | --------------------------------------------------------------- |
 | `packages/web-pkg/src/composables/yjs/useYjsSession.ts`       | the session: Y.Doc, provider, hydration, staleness, etag mirror |
 | `packages/web-pkg/src/composables/yjs/types.ts`               | `YjsAdapter`                                                    |
 | `packages/web-pkg/src/components/AppTemplates/AppWrapper.vue` | owns the session, the save loop and the loading gate            |

--- a/packages/web-app-text-editor/src/index.ts
+++ b/packages/web-app-text-editor/src/index.ts
@@ -8,7 +8,6 @@ import {
   defineWebApplication
 } from '@opencloud-eu/web-pkg'
 import { makeTextEditorAdapter } from './yjs'
-import pkg from '../package.json'
 
 export default defineWebApplication({
   setup({ applicationConfig }) {
@@ -196,7 +195,6 @@ export default defineWebApplication({
         component: AppWrapperRoute(TextEditor, {
           applicationId: appId,
           yjs: {
-            appVersion: pkg.version,
             makeAdapter: makeTextEditorAdapter
           }
         }),

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -107,7 +107,6 @@
     "pinia": "^4.0.0",
     "prosemirror-transform": "^1.12.0",
     "qs": "^6.15.0",
-    "semver": "^7.8.0",
     "uuid": "^14.0.0",
     "vue-concurrency": "^5.0.3",
     "vue-inline-svg": "^4.0.1",
@@ -121,7 +120,6 @@
     "@opencloud-eu/web-test-helpers": "workspace:^",
     "@types/lodash-es": "4.17.12",
     "@types/node": "^25.5.0",
-    "@types/semver": "^7.7.0",
     "@vitest/web-worker": "^4.1.2",
     "vite-plugin-node-polyfills": "0.28.0"
   }

--- a/packages/web-pkg/src/components/AppTemplates/types.ts
+++ b/packages/web-pkg/src/components/AppTemplates/types.ts
@@ -22,12 +22,6 @@ export interface YjsAdapterContext {
 
 export interface YjsOptions {
   /**
-   * App version owned by the consuming app, typically `pkg.version` from its
-   * own package.json. Peers in the same room must agree on it, otherwise the
-   * older client is locked out and asked to reload.
-   */
-  appVersion: string
-  /**
    * Builds the bridge between the native file format and the shared Y.Doc.
    * Called once during the wrapper's setup, so it may use composables.
    */

--- a/packages/web-pkg/src/components/AppTemplates/useAppWrapperYjs.ts
+++ b/packages/web-pkg/src/components/AppTemplates/useAppWrapperYjs.ts
@@ -66,7 +66,6 @@ export function useAppWrapperYjs(options: AppWrapperYjsOptions) {
           unref(contentResourceId) === unref(resource)?.id,
         isReadOnly,
         adapter: yjs.makeAdapter({ resource }),
-        appVersion: yjs.appVersion,
         documentPrefix: yjs.documentPrefix ?? applicationId,
         onContentChange: (value) => {
           currentContent.value = value
@@ -100,8 +99,7 @@ export function useAppWrapperYjs(options: AppWrapperYjsOptions) {
   /** True once the session is synced and hydrated; always true without one. */
   const isSessionReady = computed(() => !session || unref(session.isReady))
 
-  // A Yjs session can force read-only on top of the WebDAV permissions, e.g.
-  // after locking on an app-version mismatch.
+  // A Yjs session can force read-only on top of the WebDAV permissions.
   const effectiveReadOnly = computed(
     () => unref(isReadOnly) || Boolean(unref(session?.isLockedForReload))
   )

--- a/packages/web-pkg/src/composables/yjs/useYjsSession.ts
+++ b/packages/web-pkg/src/composables/yjs/useYjsSession.ts
@@ -3,8 +3,6 @@ import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
 import * as Y from 'yjs'
 import { Awareness } from 'y-protocols/awareness'
 import { HocuspocusProvider } from '@hocuspocus/provider'
-import semverCompare from 'semver/functions/compare'
-import semverValid from 'semver/functions/valid'
 import type { Resource } from '@opencloud-eu/web-client'
 import { useGettext } from 'vue3-gettext'
 import { useAuthStore, useConfigStore } from '../piniaStores'
@@ -38,11 +36,6 @@ export interface YjsSessionOptions {
   /** Translates between the native file format and the doc's shared types. */
   adapter: MaybeRefOrGetter<YjsAdapter>
   /**
-   * App version owned by the consuming app (typically `pkg.version`). Used to
-   * detect schema mismatch between peers in the same Y.Doc room.
-   */
-  appVersion: MaybeRefOrGetter<string>
-  /**
    * Namespace for the Yjs room. Editor apps with incompatible Y.Doc schemas
    * can open the same file, so they MUST land in separate rooms.
    */
@@ -67,7 +60,7 @@ export interface YjsSession {
    */
   isReady: ShallowRef<boolean>
   /**
-   * True after a forced disconnect (e.g. app-version mismatch). The editor
+   * True after a forced disconnect. The editor
    * should stay mounted with the last-known content but flip read-only, and
    * the user should be asked to reload.
    */
@@ -125,9 +118,29 @@ const SEED_CAPABLE_KEY = '_oc_canSeed'
  * write while peers are present.
  */
 const ROOM_ETAG_GRACE_MS = 1_000
+const FALLBACK_WEB_VERSION = '0.0.0'
 
 /** The awareness fields this composable sets or reads. */
 type AwarenessState = Record<string, unknown> & { [SEED_CAPABLE_KEY]?: boolean }
+
+function resolveWebVersion(): string {
+  const version = process.env.PACKAGE_VERSION?.trim()
+  return version || FALLBACK_WEB_VERSION
+}
+
+export function buildYjsRoomName({
+  documentPrefix,
+  fileId,
+  webVersion
+}: {
+  documentPrefix?: string
+  fileId: string
+  webVersion?: string
+}): string {
+  const version = webVersion?.trim() || FALLBACK_WEB_VERSION
+  const versionedFileId = `${fileId}:${version}`
+  return documentPrefix ? `${documentPrefix}::${versionedFileId}` : versionedFileId
+}
 
 /**
  * The coordination fields this session keeps in the doc's `_oc_meta` map,
@@ -136,8 +149,6 @@ type AwarenessState = Record<string, unknown> & { [SEED_CAPABLE_KEY]?: boolean }
 interface SessionMeta {
   /** Etag of the file on disk, stamped by whichever peer last wrote it. */
   etag: string
-  /** App version the room's current state was built with. */
-  appVersion: string
   /** The room's state no longer matches the file on disk; triggers recovery. */
   isStale: boolean
   /** Etag of the fresh file body recovery must settle on. */
@@ -175,18 +186,8 @@ function sessionMeta(doc: Y.Doc) {
 type SessionMetaMap = ReturnType<typeof sessionMeta>
 
 /**
- * Semver comparison (negative / zero / positive). Non-semver strings (e.g.
- * raw git SHAs in dev builds) fall back to strict equality: `0` for equal,
- * `NaN` otherwise, which callers treat as "incomparable, force reload".
- */
-function compareVersion(a: string, b: string): number {
-  if (semverValid(a) && semverValid(b)) return semverCompare(a, b)
-  return a === b ? 0 : Number.NaN
-}
-
-/**
  * Owns a Yjs session for a single file: the Y.Doc, the optional Hocuspocus
- * provider, hydration, stale-state recovery and the app-version gate.
+ * provider, hydration and stale-state recovery.
  *
  * It knows nothing about editors. The caller mounts whatever editor it likes
  * against the returned `ydoc` / `awareness`, and supplies a {@link YjsAdapter}
@@ -199,7 +200,6 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
     enabled,
     isReadOnly,
     adapter,
-    appVersion,
     documentPrefix,
     onContentChange,
     onServerContentChange,
@@ -242,8 +242,11 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
     const r = toValue(resource)
     const fileId = r?.fileId ?? r?.id
     if (!fileId) return null
-    const prefix = toValue(documentPrefix)
-    return prefix ? `${prefix}::${fileId}` : `${fileId}`
+    return buildYjsRoomName({
+      documentPrefix: toValue(documentPrefix),
+      fileId,
+      webVersion: resolveWebVersion()
+    })
   })
 
   // Explicit session key instead of a watchEffect: the caller mutates
@@ -452,7 +455,6 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
   ) {
     const current = toValue(adapter)
     const meta = sessionMeta(doc)
-    const version = toValue(appVersion)
 
     // Already flagged stale: let the meta observer run the recovery, and skip
     // the checks below so we don't race-lock a doc that is about to be
@@ -465,35 +467,6 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
         void recoverFromStaleState(doc, prov)
       }
       return
-    }
-
-    // App-version handshake:
-    // - empty: first client into the room, seed our version
-    // - equal: no-op
-    // - doc OLDER than us: persisted state pre-dates our schema, recover
-    // - doc NEWER than us or incomparable: we are out of date, force reload
-    const docVersion = meta.get('appVersion')
-    if (!docVersion) {
-      doc.transact(() => {
-        if (!meta.get('appVersion')) meta.set('appVersion', version)
-      })
-    } else {
-      const cmp = compareVersion(version, docVersion)
-      if (Number.isNaN(cmp) || cmp < 0) {
-        lockForReload(
-          prov,
-          $gettext(
-            'This file is being edited with app version %{docVersion} (yours is %{version}). Please reload.',
-            { docVersion, version }
-          )
-        )
-        return
-      }
-      if (cmp > 0) {
-        // Same recovery as an etag drift, and it needs the same claim to run.
-        flagStale(doc, meta)
-        return
-      }
     }
 
     // Etag drift check. The Yjs server is relay-only and persists nothing, so
@@ -613,9 +586,6 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
         meta.delete('nativeEtag')
         meta.delete('recoveryClientId')
         if (freshEtag) meta.set('etag', freshEtag)
-        // The recovered content is in our current layout now; late joiners
-        // with the same version pass the handshake, older clients bounce.
-        meta.set('appVersion', toValue(appVersion))
       }, STALE_RECOVERY_COMMIT_ORIGIN)
 
       staleRecoveryContent = null
@@ -705,13 +675,8 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
       connectTimer = undefined
     }
 
-    // HocuspocusProvider has no `parameters` option, so query params for the
-    // Yjs server go into the URL.
-    const version = toValue(appVersion)
-    const separator = serverUrl.includes('?') ? '&' : '?'
-    const wsUrlWithParams = `${serverUrl}${separator}appVersion=${encodeURIComponent(version)}`
     const prov: HocuspocusProvider = new HocuspocusProvider({
-      url: wsUrlWithParams,
+      url: serverUrl,
       name,
       document: doc,
       token: () => authStore.accessToken,
@@ -721,8 +686,7 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
       onAuthenticationFailed({ reason }) {
         console.error('[yjs] auth failed:', reason)
         // Surfaced as an error so the user sees the reason rather than a
-        // silent disconnect. The server uses this for app-version rejection
-        // too.
+        // silent disconnect.
         error.value = new Error(reason || $gettext('authentication failed'))
         isLockedForReload.value = true
         clearConnectTimer()
@@ -779,7 +743,7 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
   }
 
   /**
-   * `_oc_meta` is the side channel for save/stale/version coordination.
+   * `_oc_meta` is the side channel for save/stale coordination.
    * Adapters bind to their own shared types and never see it.
    */
   function createMetaObserver(doc: Y.Doc, prov: HocuspocusProvider | null) {
@@ -813,28 +777,6 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
                 onServerContentChange(value)
               })
               .catch((e) => console.error('[yjs] serialize for peer-save sync failed:', e))
-          }
-        }
-      }
-
-      // Version drift mid-session (e.g. a newer peer joined and bumped the
-      // stamp): lock and prompt reload. Strictly mid-session - the stored
-      // version arriving with the initial sync is `runInitialHydration`'s
-      // job, and locking on it here would keep a newer client from ever
-      // rebuilding the room.
-      if (event.keysChanged.has('appVersion') && isMidSession) {
-        const docVersion = meta.get('appVersion')
-        const version = toValue(appVersion)
-        if (docVersion) {
-          const cmp = compareVersion(version, docVersion)
-          if (Number.isNaN(cmp) || cmp !== 0) {
-            lockForReload(
-              prov,
-              $gettext(
-                'This file is now being edited with app version %{docVersion} (yours is %{version}). Please reload.',
-                { docVersion, version }
-              )
-            )
           }
         }
       }

--- a/packages/web-pkg/src/editor/types.ts
+++ b/packages/web-pkg/src/editor/types.ts
@@ -21,8 +21,8 @@ export interface TextEditorOptions {
   currentResource?: Ref<Resource>
   /**
    * Accepts a ref or getter, not just a snapshot: a Yjs session can
-   * flip the editor read-only mid-edit (locking the room on an app-version
-   * mismatch, say), and the ProseMirror view has to follow.
+   * flip the editor read-only mid-edit, and the ProseMirror view has to
+   * follow.
    */
   readonly?: MaybeRefOrGetter<boolean>
   slashCommands?: boolean

--- a/packages/web-pkg/tests/unit/components/AppTemplates/AppWrapper.spec.ts
+++ b/packages/web-pkg/tests/unit/components/AppTemplates/AppWrapper.spec.ts
@@ -137,7 +137,7 @@ function setup({
     props: {
       applicationId: 'test-app',
       wrappedComponent,
-      ...(yjsEnabled ? { yjs: { appVersion: '1.0.0', makeAdapter: () => mock<any>() } } : {})
+      ...(yjsEnabled ? { yjs: { makeAdapter: () => mock<any>() } } : {})
     },
     global: {
       plugins: [

--- a/packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts
@@ -15,7 +15,12 @@ import * as Y from 'yjs'
 import { Awareness } from 'y-protocols/awareness'
 import type { Resource } from '@opencloud-eu/web-client'
 
-import { useYjsSession, type YjsAdapter, type YjsSession } from '../../../../src/composables/yjs'
+import {
+  buildYjsRoomName,
+  useYjsSession,
+  type YjsAdapter,
+  type YjsSession
+} from '../../../../src/composables/yjs'
 import { getComposableWrapper } from '@opencloud-eu/web-test-helpers'
 
 // vi.hoisted is required so providerInstances is reachable from the hoisted
@@ -118,7 +123,6 @@ function makeResource(overrides: Partial<Resource> = {}): Resource {
 function setupSession({
   currentContent = '',
   yjsServerUrl = undefined as string | undefined,
-  appVersion = '1.2.3',
   resource = makeResource(),
   adapter = testAdapter as YjsAdapter,
   enabled = true,
@@ -150,7 +154,6 @@ function setupSession({
         enabled: enabledRef,
         isReadOnly: isReadOnlyRef,
         adapter: adapterRef,
-        appVersion,
         documentPrefix: 'test-app',
         onContentChange,
         onServerContentChange,
@@ -223,10 +226,49 @@ describe('useYjsSession — enabled gate', () => {
 describe('useYjsSession — room name', () => {
   const yjsServerUrl = 'wss://example.test/yjs'
 
-  it('keys the room on the prefix and the resource id', async () => {
+  it('keys the room on the prefix, resource id and web version', async () => {
     setupSession({ yjsServerUrl, resource: makeResource({ id: 'storage$space!item-1' }) })
     await flushPromises()
-    expect(providerInstances[0].name).toBe('test-app::storage$space!item-1')
+    const webVersion = process.env.PACKAGE_VERSION || '0.0.0'
+    expect(providerInstances[0].name).toBe(`test-app::storage$space!item-1:${webVersion}`)
+  })
+
+  it('falls back to 0.0.0 when no web version is available', () => {
+    expect(
+      buildYjsRoomName({
+        documentPrefix: 'test-app',
+        fileId: 'storage$space!item-1',
+        webVersion: ''
+      })
+    ).toBe('test-app::storage$space!item-1:0.0.0')
+  })
+
+  it('builds the same room name for equal versions', () => {
+    const roomA = buildYjsRoomName({
+      documentPrefix: 'test-app',
+      fileId: 'storage$space!item-1',
+      webVersion: '7.4.0'
+    })
+    const roomB = buildYjsRoomName({
+      documentPrefix: 'test-app',
+      fileId: 'storage$space!item-1',
+      webVersion: '7.4.0'
+    })
+    expect(roomA).toBe(roomB)
+  })
+
+  it('builds different room names for different versions', () => {
+    const roomA = buildYjsRoomName({
+      documentPrefix: 'test-app',
+      fileId: 'storage$space!item-1',
+      webVersion: '7.4.0'
+    })
+    const roomB = buildYjsRoomName({
+      documentPrefix: 'test-app',
+      fileId: 'storage$space!item-1',
+      webVersion: '7.5.0'
+    })
+    expect(roomA).not.toBe(roomB)
   })
 
   // `fileId` is the real composite id for everyone: plain WebDAV resources set
@@ -268,7 +310,8 @@ describe('useYjsSession — room name', () => {
     })
     await flushPromises()
 
-    expect(providerInstances[1].name).toBe('test-app::storage$space!item-1')
+    const webVersion = process.env.PACKAGE_VERSION || '0.0.0'
+    expect(providerInstances[1].name).toBe(`test-app::storage$space!item-1:${webVersion}`)
     expect(providerInstances[0].name).toBe(providerInstances[1].name)
   })
 })
@@ -373,11 +416,11 @@ describe('useYjsSession — failed hydration', () => {
 })
 
 describe('useYjsSession — remote mode (yjsServerUrl set)', () => {
-  it('constructs a HocuspocusProvider with the appVersion query param appended', async () => {
-    setupSession({ yjsServerUrl: 'wss://example.test/yjs', appVersion: '2.3.4' })
+  it('constructs a HocuspocusProvider with the configured URL', async () => {
+    setupSession({ yjsServerUrl: 'wss://example.test/yjs' })
     await flushPromises()
     expect(providerInstances).toHaveLength(1)
-    expect(providerInstances[0].url).toBe('wss://example.test/yjs?appVersion=2.3.4')
+    expect(providerInstances[0].url).toBe('wss://example.test/yjs')
     expect(providerInstances[0].setAwarenessField).toHaveBeenCalledWith('user', {})
   })
 
@@ -998,93 +1041,6 @@ describe('useYjsSession — stale-state recovery', () => {
   })
 })
 
-// The room's persisted state was written by an older app version, so its shared
-// types may not match the schema this client builds. It has to be rebuilt from
-// the native file, which is the same recovery an etag drift triggers.
-describe('useYjsSession — app version upgrade', () => {
-  const yjsServerUrl = 'wss://example.test/yjs'
-  const META_KEY = '_oc_meta'
-
-  /**
-   * Brings a session up against a room last touched by another version. The
-   * room state arrives as a genuine remote update, the way the initial sync
-   * delivers it - a local write would not reach the observer the same way.
-   */
-  async function syncIntoRoomAtVersion({ isReadOnly = false, docVersion = '1.0.0' } = {}) {
-    const s = setupSession({
-      yjsServerUrl,
-      appVersion: '2.0.0',
-      currentContent: 'fresh body',
-      resource: makeResource({ etag: 'etag-current' }),
-      isReadOnly
-    })
-    await flushPromises()
-
-    const room = new Y.Doc()
-    room.transact(() => {
-      room.getText(SHARED_TEXT_KEY).insert(0, 'body in the old schema')
-      room.getMap(META_KEY).set('appVersion', docVersion)
-      room.getMap(META_KEY).set('etag', 'etag-current')
-    })
-    Y.applyUpdate(s.ydoc!, Y.encodeStateAsUpdate(room))
-
-    providerInstances[0].triggerSynced()
-    await flushPromises()
-    return s
-  }
-
-  beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-  })
-
-  // Regression: this path raised `isStale` and nothing else - no `nativeEtag`,
-  // no `recoveryClientId`, no captured body. Recovery bailed on the missing
-  // body, and every later joiner took the `isStale` early return, which runs
-  // neither the handshake nor the drift check nor hydration. The room was
-  // stuck for good, with no way left to clear the flag.
-  it('claims the recovery instead of only raising the flag', async () => {
-    const s = await syncIntoRoomAtVersion()
-    const meta = s.ydoc!.getMap(META_KEY)
-
-    expect(meta.get('nativeEtag')).toBe('etag-current')
-    expect(meta.get('recoveryClientId')).toBe(s.ydoc!.clientID)
-  })
-
-  it('rebuilds the room from the native file and bumps the version stamp', async () => {
-    const s = await syncIntoRoomAtVersion()
-    vi.advanceTimersByTime(200)
-    await flushPromises()
-
-    const meta = s.ydoc!.getMap(META_KEY)
-    expect(s.ydoc!.getText(SHARED_TEXT_KEY).toString()).toBe('fresh body')
-    expect(meta.get('isStale')).toBeUndefined()
-    expect(meta.get('appVersion')).toBe('2.0.0')
-  })
-
-  // The flag has to be recoverable by somebody, so a client that cannot run
-  // the recovery must still leave the etag a later writer can claim against.
-  it('leaves a claimable flag behind on a read-only client', async () => {
-    const s = await syncIntoRoomAtVersion({ isReadOnly: true })
-    vi.advanceTimersByTime(200)
-    await flushPromises()
-
-    const meta = s.ydoc!.getMap(META_KEY)
-    expect(meta.get('isStale')).toBe(true)
-    expect(meta.get('nativeEtag')).toBe('etag-current')
-    expect(meta.get('recoveryClientId')).toBeUndefined()
-  })
-
-  // The other direction is unchanged: an out-of-date client must not rewrite a
-  // room that newer peers are already using.
-  it('still locks a client older than the room', async () => {
-    const s = await syncIntoRoomAtVersion({ docVersion: '3.0.0' })
-
-    const meta = s.ydoc!.getMap(META_KEY)
-    expect(unref(s.session.isLockedForReload)).toBe(true)
-    expect(meta.get('isStale')).toBeUndefined()
-  })
-})
-
 describe('useYjsSession — etag mirror', () => {
   it('writes a new resource etag into _oc_meta.etag', async () => {
     const s = setupSession({ currentContent: 'x', resource: makeResource({ etag: 'a' }) })
@@ -1324,7 +1280,6 @@ describe('useYjsSession — initial sync is not a peer save', () => {
     room.transact(() => {
       room.getText(SHARED_TEXT_KEY).insert(0, content)
       const meta = room.getMap(META_KEY)
-      meta.set('appVersion', '1.2.3')
       meta.set('etag', etag)
       meta.set('savedStateVector', Y.encodeStateVector(room))
       meta.set('lastSavedAt', 1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,9 +1131,6 @@ importers:
       qs:
         specifier: ^6.15.0
         version: 6.15.3
-      semver:
-        specifier: ^7.8.0
-        version: 7.8.5
       uuid:
         specifier: ^14.0.0
         version: 14.0.2
@@ -1168,9 +1165,6 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.9.5
-      '@types/semver':
-        specifier: ^7.7.0
-        version: 7.8.0
       '@vitest/web-worker':
         specifier: ^4.1.2
         version: 4.1.11(vitest@4.1.11)
@@ -2348,9 +2342,6 @@ packages:
 
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
-
-  '@types/semver@7.8.0':
-    resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -6369,8 +6360,6 @@ snapshots:
   '@types/qs@6.15.1': {}
 
   '@types/retry@0.12.2': {}
-
-  '@types/semver@7.8.0': {}
 
   '@types/trusted-types@2.0.7':
     optional: true

--- a/services/yjs/src/server.ts
+++ b/services/yjs/src/server.ts
@@ -20,52 +20,14 @@ type FileAccess = {
   canWrite: boolean
 }
 
-// Per-document first-seen app version. Acts as the authoritative gate for
-// "everybody in this room must run the same client version". First connect
-// for a documentName sets the baseline; subsequent connects with a different
-// appVersion are rejected at authenticate-time. In-memory only; on restart
-// the next connecter becomes the new baseline (acceptable for a stateless
-// yjs server). Empty appVersion is tolerated for legacy/test clients.
-const appVersionByDocument = new Map<string, string>()
-
-// A room name is `<prefix>::<storageid>$<spaceid>!<opaqueid>` - a few hundred
-// characters at the very most. Anything longer is not a file we could serve, so
-// refuse it before it becomes a Graph URL.
+// A room name is `<prefix>::<storageid>$<spaceid>!<opaqueid>:<webVersion>` -
+// a few hundred characters at the very most. Anything longer is not a file we
+// could serve, so refuse it before it becomes a Graph URL.
 const MAX_DOCUMENT_NAME_LENGTH = 512
 
 // Bounds each Graph call so a stalled OpenCloud cannot keep WebSocket
 // handshakes hanging in `onAuthenticate` indefinitely.
 const GRAPH_TIMEOUT_MS = 10_000
-
-/**
- * App-version gate: everybody in a room must run the same client version, or
- * two incompatible Y.Doc layouts end up in one document. The first connect for
- * a documentName sets the baseline and later connects with a different version
- * are rejected. An empty client version is tolerated (back-compat for a raw
- * provider in a test harness).
- *
- * MUST run only after the connection is both authenticated and authorized.
- * Recording a baseline any earlier let an unauthenticated caller name any room,
- * claim a version nobody else runs and lock every legitimate client out of that
- * file until the process restarted - the entry is only cleared by
- * `onDisconnect`, which never fires for a rejected connection. The same path
- * grew the map without bound under attacker-chosen keys.
- */
-function enforceAppVersion(documentName: string, clientAppVersion: string): void {
-  if (!clientAppVersion) return
-
-  const baseline = appVersionByDocument.get(documentName)
-  if (!baseline) {
-    appVersionByDocument.set(documentName, clientAppVersion)
-    return
-  }
-  if (clientAppVersion !== baseline) {
-    throw new Error(
-      `app version mismatch for document=${JSON.stringify(documentName)}: ` +
-        `client=${clientAppVersion} room=${baseline}, please reload`
-    )
-  }
-}
 
 function hslToHex(h: number, s: number, l: number): string {
   const a = s * Math.min(l, 1 - l)
@@ -116,12 +78,15 @@ const WRITE_ACTION = 'libre.graph/driveItem/upload/create'
 //
 // The wrapper namespaces room names by app id to avoid schema collisions
 // between different editors opening the same file (e.g.
-// `text-editor::<composite>` vs `codemirror::<composite>`). Strip any
-// `<scope>::` prefix before parsing so the Graph probe targets the raw
-// file id.
+// `text-editor::<composite>:<webVersion>` vs
+// `codemirror::<composite>:<webVersion>`). Strip any `<scope>::` prefix and
+// optional `:<webVersion>` suffix before parsing so the Graph probe targets
+// the raw file id.
 function parseDocumentId(documentName: string): { driveId: string; itemId: string } {
   const scopeSep = documentName.indexOf('::')
-  const fileId = scopeSep >= 0 ? documentName.slice(scopeSep + 2) : documentName
+  const scopedFileId = scopeSep >= 0 ? documentName.slice(scopeSep + 2) : documentName
+  const versionSep = scopedFileId.lastIndexOf(':')
+  const fileId = versionSep >= 0 ? scopedFileId.slice(0, versionSep) : scopedFileId
   const sep = fileId.indexOf('!')
   if (sep <= 0 || sep === fileId.length - 1) {
     throw new Error(`malformed documentName=${JSON.stringify(documentName)}`)
@@ -177,15 +142,13 @@ const server = new Server({
   // here is "mostly ceremony" per the migration plan. Stale detection
   // moved to the client (see useYjsSession.onProviderSynced).
 
-  async onAuthenticate({ token, documentName, requestParameters, connectionConfig }) {
+  async onAuthenticate({ token, documentName, connectionConfig }) {
     if (!token) {
       throw new Error('missing token')
     }
     if (documentName.length > MAX_DOCUMENT_NAME_LENGTH) {
       throw new Error(`documentName too long (${documentName.length})`)
     }
-
-    const clientAppVersion = requestParameters.get('appVersion') ?? ''
 
     const me = await validateTokenAgainstOpenCloud(token)
     const id = me.id ?? me.userPrincipalName ?? me.mail ?? 'unknown'
@@ -195,10 +158,6 @@ const server = new Server({
     if (access === null) {
       throw new Error(`access denied for document=${JSON.stringify(documentName)}`)
     }
-
-    // Identity and access are settled, so this caller is entitled to influence
-    // the room's version baseline.
-    enforceAppVersion(documentName, clientAppVersion)
 
     const readOnly = !access.canWrite
 
@@ -213,7 +172,6 @@ const server = new Server({
     )
     return {
       readOnly,
-      clientAppVersion,
       user: {
         id,
         displayName: me.displayName ?? me.userPrincipalName ?? id,
@@ -229,11 +187,6 @@ const server = new Server({
 
   async onDisconnect({ documentName, clientsCount }) {
     console.log(`[onDisconnect] document=${JSON.stringify(documentName)} remaining=${clientsCount}`)
-    if (clientsCount === 0) {
-      // Forget the version baseline once the room empties out so a new
-      // deploy can start fresh without manual restart.
-      appVersionByDocument.delete(documentName)
-    }
   },
 
   // Anti-spoof identity stamp: before each inbound awareness update is


### PR DESCRIPTION
## Description

- Include the web version in the Yjs room name (fileId:webVersion), with a 0.0.0 fallback for environments without a version.
- Remove app-version gating via _oc_meta.appVersion and remove the server-side appVersion handshake/query handling.
- Keep stale-state and etag coordination in _oc_meta, and adapt parsing on the Yjs service to strip the optional :webVersion suffix before Graph ACL checks.
- Update app-wrapper/text-editor Yjs option wiring and adjust unit tests for room-name generation and version-based room separation.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3101

## How Has This Been Tested?

- test environment: local dev workspace on macOS
- test case 1: pnpm test:unit --run packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts packages/web-pkg/tests/unit/components/AppTemplates/AppWrapper.spec.ts packages/web-app-text-editor/tests/unit/app.spec.ts packages/web-app-text-editor/tests/unit/yjs.spec.ts
- test case 2: pnpm exec tsc --noEmit -p services/yjs/tsconfig.json
- test case 3: verify room name composition unit tests cover equal and differing versions, including 0.0.0 fallback

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
