### PR TITLE
Harden yjs container readiness and shutdown behavior

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,12 @@ services:
     depends_on:
       collabora:
         condition: service_healthy
+      yjs:
+        condition: service_healthy
+      traefik:
+        condition: service_started
+      tika-service:
+        condition: service_started
 
   opencloud-federated:
     <<: *opencloud-service
@@ -176,6 +182,13 @@ services:
       - ./dev/docker/opencloud/app-registry.yaml:/etc/opencloud/app-registry.yaml
       - opencloud-federated-config:/etc/opencloud
       - ${OC_WEB_CONFIG:-./dev/docker/opencloud.web-federated.config.json}:/web/config.json:ro
+    depends_on:
+      yjs:
+        condition: service_healthy
+      traefik:
+        condition: service_started
+      tika-service:
+        condition: service_started
 
   collabora:
     image: collabora/code:26.04.2.4.1
@@ -451,6 +464,7 @@ services:
       # model identical to what CI uses (CI has no Traefik).
       - traefik
     restart: unless-stopped
+    stop_grace_period: 20s
 
 volumes:
   uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 x-opencloud-server: &opencloud-service
   image: ${OC_IMAGE:-opencloudeu/opencloud-rolling:daily}
   entrypoint: /bin/sh
-  command: [ '-c', 'opencloud init || true && opencloud server' ]
+  command: ['-c', 'opencloud init || true && opencloud server']
   environment: &opencloud-environment
     OC_INSECURE: '${OC_INSECURE:-true}'
     OC_LOG_LEVEL: '${OC_LOG_LEVEL:-error}'
@@ -98,8 +98,8 @@ services:
   opencloud:
     <<: *opencloud-service
     container_name: web_oc
-    entrypoint: [ '/bin/sh', '-c' ]
-    command: [ 'mkdir -p /var/lib/opencloud/idm && (opencloud init || true) && opencloud server' ]
+    entrypoint: ['/bin/sh', '-c']
+    command: ['mkdir -p /var/lib/opencloud/idm && (opencloud init || true) && opencloud server']
     environment:
       <<: *opencloud-environment
       OC_URL: ${OC_URL:-https://host.docker.internal:9200}
@@ -217,7 +217,7 @@ services:
   # generates the WOPI proof key on first start and keeps it in a named volume
   collabora-proof-key:
     image: alpine/openssl:3.5.7
-    entrypoint: [ '/bin/sh' ]
+    entrypoint: ['/bin/sh']
     command:
       - -ec
       - |
@@ -370,7 +370,7 @@ services:
       traefik.http.services.stalwart.loadbalancer.server.port: 8180
     logging:
       driver: ${LOG_DRIVER:-local}
-    entrypoint: [ '/bin/sh', '-c' ]
+    entrypoint: ['/bin/sh', '-c']
     command:
       - |
         if [ ! -f /var/lib/stalwart/.initialized ]; then
@@ -411,7 +411,7 @@ services:
       STALWART_URL: 'http://stalwart:8180'
       STALWART_USER: 'admin'
       STALWART_PASSWORD: 'secret'
-    entrypoint: [ '/bin/sh', '-c' ]
+    entrypoint: ['/bin/sh', '-c']
     command:
       - |
         if [ -f /var/lib/stalwart/.initialized ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 x-opencloud-server: &opencloud-service
   image: ${OC_IMAGE:-opencloudeu/opencloud-rolling:daily}
   entrypoint: /bin/sh
-  command: ['-c', 'opencloud init || true && opencloud server']
+  command: [ '-c', 'opencloud init || true && opencloud server' ]
   environment: &opencloud-environment
     OC_INSECURE: '${OC_INSECURE:-true}'
     OC_LOG_LEVEL: '${OC_LOG_LEVEL:-error}'
@@ -98,8 +98,8 @@ services:
   opencloud:
     <<: *opencloud-service
     container_name: web_oc
-    entrypoint: ['/bin/sh', '-c']
-    command: ['mkdir -p /var/lib/opencloud/idm && (opencloud init || true) && opencloud server']
+    entrypoint: [ '/bin/sh', '-c' ]
+    command: [ 'mkdir -p /var/lib/opencloud/idm && (opencloud init || true) && opencloud server' ]
     environment:
       <<: *opencloud-environment
       OC_URL: ${OC_URL:-https://host.docker.internal:9200}
@@ -147,12 +147,6 @@ services:
     depends_on:
       collabora:
         condition: service_healthy
-      yjs:
-        condition: service_healthy
-      traefik:
-        condition: service_started
-      tika-service:
-        condition: service_started
 
   opencloud-federated:
     <<: *opencloud-service
@@ -182,13 +176,6 @@ services:
       - ./dev/docker/opencloud/app-registry.yaml:/etc/opencloud/app-registry.yaml
       - opencloud-federated-config:/etc/opencloud
       - ${OC_WEB_CONFIG:-./dev/docker/opencloud.web-federated.config.json}:/web/config.json:ro
-    depends_on:
-      yjs:
-        condition: service_healthy
-      traefik:
-        condition: service_started
-      tika-service:
-        condition: service_started
 
   collabora:
     image: collabora/code:26.04.2.4.1
@@ -230,7 +217,7 @@ services:
   # generates the WOPI proof key on first start and keeps it in a named volume
   collabora-proof-key:
     image: alpine/openssl:3.5.7
-    entrypoint: ['/bin/sh']
+    entrypoint: [ '/bin/sh' ]
     command:
       - -ec
       - |
@@ -383,7 +370,7 @@ services:
       traefik.http.services.stalwart.loadbalancer.server.port: 8180
     logging:
       driver: ${LOG_DRIVER:-local}
-    entrypoint: ['/bin/sh', '-c']
+    entrypoint: [ '/bin/sh', '-c' ]
     command:
       - |
         if [ ! -f /var/lib/stalwart/.initialized ]; then
@@ -424,7 +411,7 @@ services:
       STALWART_URL: 'http://stalwart:8180'
       STALWART_USER: 'admin'
       STALWART_PASSWORD: 'secret'
-    entrypoint: ['/bin/sh', '-c']
+    entrypoint: [ '/bin/sh', '-c' ]
     command:
       - |
         if [ -f /var/lib/stalwart/.initialized ]; then

--- a/services/yjs/Dockerfile
+++ b/services/yjs/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder /app ./
 USER node
 EXPOSE 1234
 
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=15s --start-period=15s --timeout=12s --retries=3 \
   CMD ["node", "src/healthcheck.ts"]
 
 CMD ["node", "src/server.ts"]

--- a/services/yjs/Dockerfile
+++ b/services/yjs/Dockerfile
@@ -31,4 +31,7 @@ COPY --from=builder /app ./
 USER node
 EXPOSE 1234
 
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["node", "src/healthcheck.ts"]
+
 CMD ["node", "src/server.ts"]

--- a/services/yjs/README.md
+++ b/services/yjs/README.md
@@ -17,10 +17,14 @@ Every connection is authenticated and authorized against OpenCloud:
 
 ## Configuration
 
-| Variable        | Default | Description                                                                  |
-| --------------- | ------- | ---------------------------------------------------------------------------- |
-| `OPENCLOUD_URL` | -       | Required. Base URL of the OpenCloud server, e.g. `https://cloud.example.com` |
-| `PORT`          | `1234`  | Port to listen on                                                            |
+| Variable                   | Default          | Description                                                                  |
+| -------------------------- | ---------------- | ---------------------------------------------------------------------------- |
+| `OPENCLOUD_URL`            | -                | Required. Base URL of the OpenCloud server, e.g. `https://cloud.example.com` |
+| `PORT`                     | `1234`           | Port to listen on                                                            |
+| `SHUTDOWN_GRACE_PERIOD_MS` | `15000`          | Grace period for graceful shutdown before the process exits with code `1`    |
+| `HEALTHCHECK_TIMEOUT_MS`   | `5000`           | Timeout used by the container healthcheck probe                              |
+| `HEALTHCHECK_READY_PATH`   | `/healthz/ready` | Internal readiness endpoint path                                             |
+| `HEALTHCHECK_HOST`         | `127.0.0.1`      | Host used by the container healthcheck probe                                 |
 
 ## Routing
 
@@ -61,3 +65,40 @@ As a container, built from the repository root:
 ```sh
 docker build -f services/yjs/Dockerfile -t opencloud-yjs-server .
 ```
+
+## Healthchecks and readiness
+
+The image defines a Docker `HEALTHCHECK` that verifies:
+
+1. the readiness endpoint (`GET /healthz/ready`) returns HTTP `200`
+2. a WebSocket handshake to `ws://127.0.0.1:$PORT` succeeds
+
+During normal operation `/healthz/ready` returns `200 ok`. Once shutdown starts, it flips to `503`
+immediately.
+
+## Graceful shutdown
+
+The service installs a SIGTERM/SIGINT/SIGQUIT handler and performs graceful shutdown:
+
+1. mark the instance as shutting down (readiness becomes `503`)
+2. stop accepting new upgrade/authentication attempts
+3. close existing WebSocket connections and let Hocuspocus unload/flush open documents
+4. exit successfully when done
+
+If shutdown does not complete within `SHUTDOWN_GRACE_PERIOD_MS`, the process exits with code `1`.
+
+## Docker Compose defaults
+
+In the repository `docker-compose.yml`:
+
+- `yjs` uses `restart: unless-stopped`
+- `yjs` uses `stop_grace_period: 20s` (5s buffer beyond the default 15s shutdown grace period)
+- OpenCloud services declare `depends_on: yjs` with `condition: service_healthy`
+
+Keep `stop_grace_period` higher than `SHUTDOWN_GRACE_PERIOD_MS` to allow the service time to
+flush and close cleanly before Docker sends SIGKILL.
+
+## Logging
+
+The service writes operational logs to standard output/error (`stdout`/`stderr`) via Node's
+`console` methods. No file logger is used.

--- a/services/yjs/README.md
+++ b/services/yjs/README.md
@@ -22,9 +22,6 @@ Every connection is authenticated and authorized against OpenCloud:
 | `OPENCLOUD_URL`            | -                | Required. Base URL of the OpenCloud server, e.g. `https://cloud.example.com` |
 | `PORT`                     | `1234`           | Port to listen on                                                            |
 | `SHUTDOWN_GRACE_PERIOD_MS` | `15000`          | Grace period for graceful shutdown before the process exits with code `1`    |
-| `HEALTHCHECK_TIMEOUT_MS`   | `5000`           | Timeout used by the container healthcheck probe                              |
-| `HEALTHCHECK_READY_PATH`   | `/healthz/ready` | Internal readiness endpoint path                                             |
-| `HEALTHCHECK_HOST`         | `127.0.0.1`      | Host used by the container healthcheck probe                                 |
 
 ## Routing
 
@@ -93,7 +90,6 @@ In the repository `docker-compose.yml`:
 
 - `yjs` uses `restart: unless-stopped`
 - `yjs` uses `stop_grace_period: 20s` (5s buffer beyond the default 15s shutdown grace period)
-- OpenCloud services declare `depends_on: yjs` with `condition: service_healthy`
 
 Keep `stop_grace_period` higher than `SHUTDOWN_GRACE_PERIOD_MS` to allow the service time to
 flush and close cleanly before Docker sends SIGKILL.

--- a/services/yjs/README.md
+++ b/services/yjs/README.md
@@ -17,11 +17,11 @@ Every connection is authenticated and authorized against OpenCloud:
 
 ## Configuration
 
-| Variable                   | Default          | Description                                                                  |
-| -------------------------- | ---------------- | ---------------------------------------------------------------------------- |
-| `OPENCLOUD_URL`            | -                | Required. Base URL of the OpenCloud server, e.g. `https://cloud.example.com` |
-| `PORT`                     | `1234`           | Port to listen on                                                            |
-| `SHUTDOWN_GRACE_PERIOD_MS` | `15000`          | Grace period for graceful shutdown before the process exits with code `1`    |
+| Variable                   | Default | Description                                                                  |
+| -------------------------- | ------- | ---------------------------------------------------------------------------- |
+| `OPENCLOUD_URL`            | -       | Required. Base URL of the OpenCloud server, e.g. `https://cloud.example.com` |
+| `PORT`                     | `1234`  | Port to listen on                                                            |
+| `SHUTDOWN_GRACE_PERIOD_MS` | `15000` | Grace period for graceful shutdown before the process exits with code `1`    |
 
 ## Routing
 
@@ -78,7 +78,7 @@ immediately.
 The service installs a SIGTERM/SIGINT/SIGQUIT handler and performs graceful shutdown:
 
 1. mark the instance as shutting down (readiness becomes `503`)
-2. stop accepting new upgrade/authentication attempts
+2. stop accepting new upgrade attempts
 3. close existing WebSocket connections and let Hocuspocus unload/flush open documents
 4. exit successfully when done
 

--- a/services/yjs/src/healthcheck.ts
+++ b/services/yjs/src/healthcheck.ts
@@ -1,24 +1,17 @@
 const port = parseInt(process.env.PORT ?? '1234', 10)
-const host = process.env.HEALTHCHECK_HOST ?? '127.0.0.1'
-const readyPath = process.env.HEALTHCHECK_READY_PATH ?? '/healthz/ready'
-const timeoutMs = parseInt(process.env.HEALTHCHECK_TIMEOUT_MS ?? '5000', 10)
+const READY_PATH = '/healthz/ready'
+const LOCALHOST = '127.0.0.1'
+const TIMEOUT_MS = 5000
 
 if (!Number.isInteger(port) || port <= 0) {
   console.error(`invalid PORT=${JSON.stringify(process.env.PORT)}`)
   process.exit(1)
 }
 
-if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
-  console.error(
-    `invalid HEALTHCHECK_TIMEOUT_MS=${JSON.stringify(process.env.HEALTHCHECK_TIMEOUT_MS)}`
-  )
-  process.exit(1)
-}
-
 async function checkReadinessEndpoint(): Promise<void> {
-  const url = `http://${host}:${port}${readyPath}`
+  const url = `http://${LOCALHOST}:${port}${READY_PATH}`
   const res = await fetch(url, {
-    signal: AbortSignal.timeout(timeoutMs)
+    signal: AbortSignal.timeout(TIMEOUT_MS)
   })
 
   if (!res.ok) {
@@ -27,7 +20,7 @@ async function checkReadinessEndpoint(): Promise<void> {
 }
 
 async function checkWebSocketEndpoint(): Promise<void> {
-  const url = `ws://${host}:${port}`
+  const url = `ws://${LOCALHOST}:${port}`
   await new Promise<void>((resolve, reject) => {
     const ws = new WebSocket(url)
     let opened = false
@@ -36,7 +29,7 @@ async function checkWebSocketEndpoint(): Promise<void> {
       cleanup()
       ws.close()
       reject(new Error('websocket handshake timed out'))
-    }, timeoutMs)
+    }, TIMEOUT_MS)
 
     function cleanup(): void {
       clearTimeout(timer)

--- a/services/yjs/src/healthcheck.ts
+++ b/services/yjs/src/healthcheck.ts
@@ -1,0 +1,82 @@
+const port = parseInt(process.env.PORT ?? '1234', 10)
+const host = process.env.HEALTHCHECK_HOST ?? '127.0.0.1'
+const readyPath = process.env.HEALTHCHECK_READY_PATH ?? '/healthz/ready'
+const timeoutMs = parseInt(process.env.HEALTHCHECK_TIMEOUT_MS ?? '5000', 10)
+
+if (!Number.isInteger(port) || port <= 0) {
+  console.error(`invalid PORT=${JSON.stringify(process.env.PORT)}`)
+  process.exit(1)
+}
+
+if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+  console.error(
+    `invalid HEALTHCHECK_TIMEOUT_MS=${JSON.stringify(process.env.HEALTHCHECK_TIMEOUT_MS)}`
+  )
+  process.exit(1)
+}
+
+async function checkReadinessEndpoint(): Promise<void> {
+  const url = `http://${host}:${port}${readyPath}`
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(timeoutMs)
+  })
+
+  if (!res.ok) {
+    throw new Error(`readiness endpoint returned ${res.status}`)
+  }
+}
+
+async function checkWebSocketEndpoint(): Promise<void> {
+  const url = `ws://${host}:${port}`
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(url)
+    let opened = false
+
+    const timer = setTimeout(() => {
+      cleanup()
+      ws.close()
+      reject(new Error('websocket handshake timed out'))
+    }, timeoutMs)
+
+    function cleanup(): void {
+      clearTimeout(timer)
+      ws.removeEventListener('open', onOpen)
+      ws.removeEventListener('error', onError)
+      ws.removeEventListener('close', onClose)
+    }
+
+    function onOpen(): void {
+      opened = true
+      cleanup()
+      ws.close(1000, 'healthcheck')
+      resolve()
+    }
+
+    function onError(): void {
+      cleanup()
+      reject(new Error('websocket endpoint is not reachable'))
+    }
+
+    function onClose(): void {
+      if (opened) {
+        return
+      }
+      cleanup()
+      reject(new Error('websocket closed before handshake completed'))
+    }
+
+    ws.addEventListener('open', onOpen)
+    ws.addEventListener('error', onError)
+    ws.addEventListener('close', onClose)
+  })
+}
+
+async function main(): Promise<void> {
+  await checkReadinessEndpoint()
+  await checkWebSocketEndpoint()
+}
+
+main().catch((error: unknown) => {
+  console.error('[healthcheck] failed:', error)
+  process.exit(1)
+})

--- a/services/yjs/src/server.ts
+++ b/services/yjs/src/server.ts
@@ -149,7 +149,7 @@ const server = new Server({
   // here is "mostly ceremony" per the migration plan. Stale detection
   // moved to the client (see useYjsSession.onProviderSynced).
 
-  onRequest({ request, response }) {
+  async onRequest({ request, response }) {
     const requestPath = request.url?.split('?')[0] ?? '/'
     if (requestPath !== HEALTH_ENDPOINT_PATH) {
       return
@@ -164,7 +164,7 @@ const server = new Server({
     throw undefined
   },
 
-  onUpgrade({ socket }) {
+  async onUpgrade({ socket }) {
     if (!isShuttingDown) {
       return
     }
@@ -214,12 +214,12 @@ const server = new Server({
     }
   },
 
-  onConnect({ documentName, requestHeaders }) {
+  async onConnect({ documentName, requestHeaders }) {
     const origin = requestHeaders.get('origin') ?? '-'
     console.log(`[onConnect] document=${JSON.stringify(documentName)} origin=${origin}`)
   },
 
-  onDisconnect({ documentName, clientsCount }) {
+  async onDisconnect({ documentName, clientsCount }) {
     console.log(`[onDisconnect] document=${JSON.stringify(documentName)} remaining=${clientsCount}`)
   },
 
@@ -232,7 +232,7 @@ const server = new Server({
   // document-level callback the lib wires up internally (see
   // hocuspocus-server.cjs ~line 1299). Using positional args here would
   // silently no-op (states=undefined -> no user found -> return).
-  beforeHandleAwareness({ states, context, connection }) {
+  async beforeHandleAwareness({ states, context, connection }) {
     const user = context?.user ?? connection?.context?.user
     if (!user) {
       return

--- a/services/yjs/src/server.ts
+++ b/services/yjs/src/server.ts
@@ -174,9 +174,6 @@ const server = new Server({
   },
 
   async onAuthenticate({ token, documentName, connectionConfig }) {
-    if (isShuttingDown) {
-      throw new Error('server is shutting down')
-    }
     if (!token) {
       throw new Error('missing token')
     }

--- a/services/yjs/src/server.ts
+++ b/services/yjs/src/server.ts
@@ -2,6 +2,12 @@ import { Server } from '@hocuspocus/server'
 
 const port = parseInt(process.env.PORT ?? '1234', 10)
 const opencloudUrl = (process.env.OPENCLOUD_URL ?? '').replace(/\/$/, '')
+const HEALTH_ENDPOINT_PATH = '/healthz/ready'
+const SHUTDOWN_GRACE_PERIOD_MS = parseInt(process.env.SHUTDOWN_GRACE_PERIOD_MS ?? '15000', 10)
+
+let isServerReady = false
+let isShuttingDown = false
+let shutdownPromise: Promise<void> | null = null
 
 if (!opencloudUrl) {
   console.error('OPENCLOUD_URL is required, e.g. https://cloud.example.com')
@@ -135,6 +141,7 @@ async function probeFileAccess(token: string, documentName: string): Promise<Fil
 const server = new Server({
   port,
   address: '0.0.0.0',
+  stopOnSignals: false,
   // No server-side persistence: every doc is file-backed via WebDAV.
   // Cold-start for a fresh peer = hydrate from `currentContent` in the
   // wrapper. The persisted SQLite snapshot would get discarded on stale-
@@ -142,7 +149,34 @@ const server = new Server({
   // here is "mostly ceremony" per the migration plan. Stale detection
   // moved to the client (see useYjsSession.onProviderSynced).
 
+  onRequest({ request, response }) {
+    const requestPath = request.url?.split('?')[0] ?? '/'
+    if (requestPath !== HEALTH_ENDPOINT_PATH) {
+      return
+    }
+
+    const isReady = isServerReady && !isShuttingDown
+    response.writeHead(isReady ? 200 : 503, { 'Content-Type': 'text/plain' })
+    response.end(isReady ? 'ok' : 'shutting down')
+    // Hocuspocus convention: throwing (any value) signals that the request/upgrade
+    // has been fully handled and should not be processed further by the framework.
+    // Void/undefined return allows fallthrough to default handlers.
+    throw undefined
+  },
+
+  onUpgrade({ socket }) {
+    if (!isShuttingDown) {
+      return
+    }
+    socket.destroy()
+    // Reject upgrade during shutdown by throwing (see onRequest comment above)
+    throw undefined
+  },
+
   async onAuthenticate({ token, documentName, connectionConfig }) {
+    if (isShuttingDown) {
+      throw new Error('server is shutting down')
+    }
     if (!token) {
       throw new Error('missing token')
     }
@@ -180,12 +214,12 @@ const server = new Server({
     }
   },
 
-  async onConnect({ documentName, requestHeaders }) {
+  onConnect({ documentName, requestHeaders }) {
     const origin = requestHeaders.get('origin') ?? '-'
     console.log(`[onConnect] document=${JSON.stringify(documentName)} origin=${origin}`)
   },
 
-  async onDisconnect({ documentName, clientsCount }) {
+  onDisconnect({ documentName, clientsCount }) {
     console.log(`[onDisconnect] document=${JSON.stringify(documentName)} remaining=${clientsCount}`)
   },
 
@@ -198,9 +232,11 @@ const server = new Server({
   // document-level callback the lib wires up internally (see
   // hocuspocus-server.cjs ~line 1299). Using positional args here would
   // silently no-op (states=undefined -> no user found -> return).
-  async beforeHandleAwareness({ states, context, connection }) {
+  beforeHandleAwareness({ states, context, connection }) {
     const user = context?.user ?? connection?.context?.user
-    if (!user) return
+    if (!user) {
+      return
+    }
     const canonical = {
       id: user.id,
       name: user.displayName,
@@ -219,11 +255,70 @@ const server = new Server({
   }
 })
 
+function forceExitAfterGracePeriod(): NodeJS.Timeout {
+  const timeout = setTimeout(() => {
+    console.error(
+      `[shutdown] did not complete within ${SHUTDOWN_GRACE_PERIOD_MS}ms; forcing process exit`
+    )
+    process.exit(1)
+  }, SHUTDOWN_GRACE_PERIOD_MS)
+  timeout.unref()
+  return timeout
+}
+
+function gracefulShutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shutdownPromise) {
+    return shutdownPromise
+  }
+
+  isShuttingDown = true
+  isServerReady = false
+  console.log(
+    `[shutdown] received ${signal}; draining connections (grace=${SHUTDOWN_GRACE_PERIOD_MS}ms)`
+  )
+
+  shutdownPromise = (async () => {
+    const forceExitTimer = forceExitAfterGracePeriod()
+    try {
+      await server.destroy()
+      clearTimeout(forceExitTimer)
+      console.log('[shutdown] graceful shutdown completed')
+    } catch (error) {
+      clearTimeout(forceExitTimer)
+      throw error
+    }
+  })()
+
+  return shutdownPromise
+}
+
+function installSignalHandlers(): void {
+  const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGQUIT']
+
+  signals.forEach((signal) => {
+    process.on(signal, () => {
+      void gracefulShutdown(signal).then(
+        () => {
+          process.exit(0)
+        },
+        (error: unknown) => {
+          console.error('[shutdown] graceful shutdown failed:', error)
+          process.exit(1)
+        }
+      )
+    })
+  })
+}
+
+installSignalHandlers()
+
 server.listen().then(
   () => {
+    isServerReady = true
     console.log(`yjs server listening on :${port}, oc=${opencloudUrl}`)
   },
   (err: unknown) => {
+    isServerReady = false
     // Most often the port is already taken. Without this the process died on an
     // unhandled rejection and a stack trace instead of saying what went wrong.
     console.error(`yjs server failed to listen on :${port}:`, err)


### PR DESCRIPTION
## Description

This change upgrades the `services/yjs` container behavior for production-style operation.

It adds:
- container image `HEALTHCHECK` based on actual readiness (`/healthz/ready`) and WebSocket reachability
- graceful signal handling (`SIGTERM`/`SIGINT`/`SIGQUIT`) with a documented grace period
- shutdown draining behavior: readiness flips to unhealthy, new upgrades are rejected, then active connections are closed and document unload/flush paths run
- compose-level `stop_grace_period` for `yjs`, aligned with graceful shutdown behavior
- administrator documentation for restart policy, grace period, health semantics, and logging

## Related Issue

- https://github.com/opencloud-eu/web/issues/3105

## How Has This Been Tested?

- test environment: local development on macOS
- test case 1: `pnpm --filter opencloud-yjs-server check:types`
- test case 2: `pnpm exec eslint services/yjs/src/server.ts services/yjs/src/healthcheck.ts`
- test case 3: `pnpm exec prettier --check services/yjs/src/server.ts services/yjs/src/healthcheck.ts services/yjs/README.md docker-compose.yml`
- test case 4: `docker compose config >/tmp/docker-compose.resolved.yml`

## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that does not break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [x] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
