### PR TITLE
fix: share the tooltip escape listener

### DIFF
--- a/packages/design-system/src/directives/OcTooltip.spec.ts
+++ b/packages/design-system/src/directives/OcTooltip.spec.ts
@@ -1,0 +1,22 @@
+import OcTooltip from './OcTooltip'
+import type { DirectiveBinding } from 'vue'
+
+describe('OcTooltip', () => {
+  it('shares one document escape listener between tooltip instances', () => {
+    const addEventListener = vi.spyOn(document, 'addEventListener')
+    const removeEventListener = vi.spyOn(document, 'removeEventListener')
+    const first = document.createElement('button')
+    const second = document.createElement('button')
+
+    OcTooltip.beforeMount(first, { value: 'first' } as DirectiveBinding<string>)
+    OcTooltip.beforeMount(second, { value: 'second' } as DirectiveBinding<string>)
+
+    expect(addEventListener).toHaveBeenCalledTimes(1)
+
+    OcTooltip.unmounted(first)
+    expect(removeEventListener).not.toHaveBeenCalled()
+
+    OcTooltip.unmounted(second)
+    expect(removeEventListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/design-system/src/directives/OcTooltip.spec.ts
+++ b/packages/design-system/src/directives/OcTooltip.spec.ts
@@ -2,7 +2,7 @@ import OcTooltip from './OcTooltip'
 import type { DirectiveBinding } from 'vue'
 
 describe('OcTooltip', () => {
-  it('shares one document escape listener between tooltip instances', () => {
+  it('shares one document escape listener between visible tooltip instances', async () => {
     const addEventListener = vi.spyOn(document, 'addEventListener')
     const removeEventListener = vi.spyOn(document, 'removeEventListener')
     const first = document.createElement('button')
@@ -11,7 +11,11 @@ describe('OcTooltip', () => {
     OcTooltip.beforeMount(first, { value: 'first' } as DirectiveBinding<string>)
     OcTooltip.beforeMount(second, { value: 'second' } as DirectiveBinding<string>)
 
-    expect(addEventListener).toHaveBeenCalledTimes(1)
+    expect(addEventListener).not.toHaveBeenCalled()
+
+    first.dispatchEvent(new Event('mouseenter'))
+    second.dispatchEvent(new Event('mouseenter'))
+    await vi.waitFor(() => expect(addEventListener).toHaveBeenCalledTimes(1))
 
     OcTooltip.unmounted(first)
     expect(removeEventListener).not.toHaveBeenCalled()

--- a/packages/design-system/src/directives/OcTooltip.ts
+++ b/packages/design-system/src/directives/OcTooltip.ts
@@ -40,6 +40,10 @@ const showTooltip = async (el: HTMLElement) => {
 
   document.body.appendChild(tooltipEl)
   data.tooltipEl = tooltipEl
+  tooltipElements.add(el)
+  if (tooltipElements.size === 1) {
+    document.addEventListener('keydown', documentEscapeHandler)
+  }
 
   const { x, y, placement, middlewareData } = await computePosition(el, tooltipEl, {
     placement: 'top',
@@ -80,6 +84,10 @@ const hideTooltip = (el: HTMLElement) => {
 
   data.tooltipEl.remove()
   data.tooltipEl = null
+  tooltipElements.delete(el)
+  if (tooltipElements.size === 0) {
+    document.removeEventListener('keydown', documentEscapeHandler)
+  }
 }
 
 const destroy = (el: HTMLElement) => {
@@ -95,11 +103,6 @@ const destroy = (el: HTMLElement) => {
   el.removeEventListener('mouseleave', data.hideHandler)
   el.removeEventListener('blur', data.hideHandler)
   el.removeEventListener('click', data.clickHandler)
-  tooltipElements.delete(el)
-  if (tooltipElements.size === 0) {
-    document.removeEventListener('keydown', documentEscapeHandler)
-  }
-
   tooltipMap.delete(el)
 }
 
@@ -131,11 +134,6 @@ const initOrUpdate = (el: HTMLElement, { value }: DirectiveBinding) => {
     hideHandler,
     clickHandler
   })
-  if (tooltipElements.size === 0) {
-    document.addEventListener('keydown', documentEscapeHandler)
-  }
-  tooltipElements.add(el)
-
   el.addEventListener('mouseenter', showHandler)
   el.addEventListener('mouseleave', hideHandler)
   el.addEventListener('focus', showHandler)

--- a/packages/design-system/src/directives/OcTooltip.ts
+++ b/packages/design-system/src/directives/OcTooltip.ts
@@ -7,10 +7,18 @@ interface TooltipData {
   showHandler: () => void
   hideHandler: () => void
   clickHandler: () => void
-  escapeHandler: (e: KeyboardEvent) => void
 }
 
 const tooltipMap = new WeakMap<HTMLElement, TooltipData>()
+const tooltipElements = new Set<HTMLElement>()
+
+const documentEscapeHandler = (event: KeyboardEvent) => {
+  if (event.code !== 'Escape') {
+    return
+  }
+
+  tooltipElements.forEach((el) => hideTooltip(el))
+}
 
 const showTooltip = async (el: HTMLElement) => {
   const data = tooltipMap.get(el)
@@ -87,7 +95,10 @@ const destroy = (el: HTMLElement) => {
   el.removeEventListener('mouseleave', data.hideHandler)
   el.removeEventListener('blur', data.hideHandler)
   el.removeEventListener('click', data.clickHandler)
-  document.removeEventListener('keydown', data.escapeHandler)
+  tooltipElements.delete(el)
+  if (tooltipElements.size === 0) {
+    document.removeEventListener('keydown', documentEscapeHandler)
+  }
 
   tooltipMap.delete(el)
 }
@@ -113,27 +124,23 @@ const initOrUpdate = (el: HTMLElement, { value }: DirectiveBinding) => {
   const showHandler = () => showTooltip(el)
   const hideHandler = () => hideTooltip(el)
   const clickHandler = () => hideTooltip(el)
-  const escapeHandler = (e: KeyboardEvent) => {
-    if (e.code === 'Escape') {
-      hideTooltip(el)
-    }
-  }
-
   tooltipMap.set(el, {
     content: value,
     tooltipEl: null,
     showHandler,
     hideHandler,
-    clickHandler,
-    escapeHandler
+    clickHandler
   })
+  if (tooltipElements.size === 0) {
+    document.addEventListener('keydown', documentEscapeHandler)
+  }
+  tooltipElements.add(el)
 
   el.addEventListener('mouseenter', showHandler)
   el.addEventListener('mouseleave', hideHandler)
   el.addEventListener('focus', showHandler)
   el.addEventListener('blur', hideHandler)
   el.addEventListener('click', clickHandler)
-  document.addEventListener('keydown', escapeHandler)
 }
 
 export default {


### PR DESCRIPTION
## Description

Each tooltip instance currently registers its own document-level Escape key listener. This adds one global listener per mounted tooltip and removes it only with that instance.

This change shares one Escape listener across all mounted tooltips and removes it after the last tooltip is unmounted. Tooltip behavior is unchanged.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3171

## How Has This Been Tested?

- test environment: Node.js 26.7.0, pnpm 11.22.0
- test case 1: `pnpm test:unit --run packages/design-system/src/directives/OcTooltip.spec.ts`
- test case 2: `pnpm check:types`
- test case 3: `pnpm lint`
- test case 4: `pnpm format:check`

## Types of changes

- [x] Bugfix
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt (improving code quality without changing functionality)
- [x] Tests (adding or updating tests)
- [ ] Documentation (updates to the documentation, readme, or changelog)
- [ ] Maintenance (updates to the build process or auxiliary tools and libraries)
