### PR TITLE
fix: define the shimmer animation start frame

### DIFF
--- a/packages/design-system/src/styles/tailwind.css
+++ b/packages/design-system/src/styles/tailwind.css
@@ -85,6 +85,10 @@
   }
 
   @keyframes shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+
     100% {
       transform: translateX(100%);
     }


### PR DESCRIPTION
## Description

The shared shimmer animation only declares its ending transform and relies on a utility class to provide the initial state. That implicit starting frame is not consistently retained by browsers, and the loading indicator can fail to animate correctly.

Define the `0%` transform in the keyframes so the shimmer has an explicit, portable start state.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3169

## How Has This Been Tested?

- test environment: Node.js 26.7.0, pnpm 11.24.0
- test case 1: `pnpm lint`
- test case 2: `pnpm format:check`

## Types of changes

- [x] Bugfix
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt (improving code quality without changing functionality)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (updates to the documentation, readme, or changelog)
- [ ] Maintenance (updates to the build process or auxiliary tools and libraries)
