### PR TITLE
fix: preserve lazy tile height

### DIFF
--- a/packages/design-system/src/styles/tailwind.css
+++ b/packages/design-system/src/styles/tailwind.css
@@ -85,6 +85,10 @@
   }
 
   @keyframes shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+
     100% {
       transform: translateX(100%);
     }

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -21,7 +21,7 @@
     >
       <div class="w-full aspect-[16/9]" />
       <div class="p-2">
-        <div class="h-6" />
+        <div class="h-7" />
       </div>
     </div>
     <template v-else>
@@ -243,10 +243,6 @@ if (!lazy) {
 
   .oc-tile-card-lazy-shimmer::after {
     background-image: linear-gradient(90deg, #4c5f7900 0, #4c5f7933 20%, #4c5f7980 60%, #4c5f7900);
-  }
-
-  .oc-tile-card-lazy-shimmer {
-    min-height: calc(var(--oc-size-tiles-actual) * 0.5625 + 44px);
   }
 }
 </style>

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -244,5 +244,9 @@ if (!lazy) {
   .oc-tile-card-lazy-shimmer::after {
     background-image: linear-gradient(90deg, #4c5f7900 0, #4c5f7933 20%, #4c5f7980 60%, #4c5f7900);
   }
+
+  .oc-tile-card-lazy-shimmer {
+    min-height: calc(var(--oc-size-tiles-actual) * 0.5625 + 44px);
+  }
 }
 </style>


### PR DESCRIPTION
## Description

Lazy tile placeholders are shorter than hydrated tiles by the height of the tile content's line box. Revealing a tile therefore expands its grid row and shifts the items below it while scrolling.

Give the placeholder a minimum height based on the configured tile width, the 16:9 preview ratio, and the 44px content area used by hydrated tiles.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3170

## How Has This Been Tested?

- test environment: Node.js 26.7.0, pnpm 11.24.0
- test case 1: `pnpm test:unit --run packages/web-pkg/tests/unit/components/FilesList/ResourceTile.spec.ts`
- test case 2: `pnpm check:types`
- test case 3: `pnpm lint`
- test case 4: `pnpm format:check`

## Types of changes

- [x] Bugfix
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt (improving code quality without changing functionality)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (updates to the documentation, readme, or changelog)
- [ ] Maintenance (updates to the build process or auxiliary tools and libraries)
