### PR TITLE
Fix default Open action for .url files and add Text Editor support

### DIFF
--- a/packages/web-app-text-editor/src/index.ts
+++ b/packages/web-app-text-editor/src/index.ts
@@ -51,6 +51,7 @@ export default defineWebApplication({
         { extension: 'asm', label: () => $gettext('Assembler source file') },
         { extension: 'log', label: () => $gettext('Log file') },
         { extension: 'ics', label: () => $gettext('Calendar file') },
+        { extension: 'url', label: () => $gettext('Internet shortcut file') },
         { extension: 'rtf', label: () => $gettext('Rich Text Format file') },
         { extension: 'dockerfile', label: () => $gettext('Dockerfile') },
         { extension: 'makefile', label: () => $gettext('Makefile') },

--- a/packages/web-pkg/src/components/ContextActions/ActionMenuItem.vue
+++ b/packages/web-pkg/src/components/ContextActions/ActionMenuItem.vue
@@ -78,11 +78,25 @@ const {
 const configStore = useConfigStore()
 const { options } = storeToRefs(configStore)
 
+const resolvedRoute = computed(() => {
+  if (!Object.hasOwn(action, 'route')) {
+    return undefined
+  }
+  return action.route(actionOptions)
+})
+
+const resolvedHref = computed(() => {
+  if (!Object.hasOwn(action, 'href')) {
+    return undefined
+  }
+  return action.href(actionOptions)
+})
+
 const componentType = computed<'a' | 'button' | 'router-link'>(() => {
-  if (Object.hasOwn(action, 'route')) {
+  if (unref(resolvedRoute)) {
     return 'router-link'
   }
-  if (Object.hasOwn(action, 'href')) {
+  if (unref(resolvedHref)) {
     return 'a'
   }
   if (Object.hasOwn(action, 'handler')) {
@@ -104,10 +118,10 @@ const componentProps = computed(() => {
   return {
     ...properties,
     ...(unref(componentType) === 'router-link' && {
-      to: action.route(actionOptions)
+      to: unref(resolvedRoute)
     }),
     ...(unref(componentType) === 'a' && {
-      href: action.href(actionOptions)
+      href: unref(resolvedHref)
     }),
     ...(['router-link', 'a'].includes(unref(componentType)) && {
       target: options.value.openFilesInNewTab ? ('_blank' as const) : ('_self' as const)

--- a/packages/web-pkg/tests/unit/components/ContextActions/ActionMenuItem.spec.ts
+++ b/packages/web-pkg/tests/unit/components/ContextActions/ActionMenuItem.spec.ts
@@ -88,6 +88,22 @@ describe('ActionMenuItem component', () => {
       // expect(link.attributes().href).toBe(action.route)
     })
   })
+  describe('route fallback', () => {
+    it('falls back to button handler when route callback resolves to undefined', async () => {
+      const spyHandler = vi.fn()
+      const action = {
+        ...fileActions.navigate,
+        route: (): undefined => undefined,
+        handler: spyHandler
+      } as unknown as FileAction
+      const { wrapper } = getWrapper(action, mount)
+      const button = wrapper.find(selectors.handler)
+      expect(button.exists()).toBeTruthy()
+      expect(button.element.tagName).toBe('BUTTON')
+      await button.trigger('click')
+      expect(spyHandler).toHaveBeenCalled()
+    })
+  })
   describe('component is of type a', () => {
     it('has a href', () => {
       const action = fileActions.redirect


### PR DESCRIPTION
## Description

Before this fix, clicking "Open" on a `.url` file in the file-list context menu could result in no action at all.

Root cause: the rendered action was treated as a route link as soon as a `route` callback existed, even when that callback returned no target. In that case, the handler-backed action ("Open shortcut") was never executed.

What changed:
- In `ActionMenuItem`, route/href targets are resolved first.
- A route link is rendered only when `route(...)` returns a concrete target.
- If no route target exists, the action falls back to button behavior and executes the handler.
- `.url` is now also registered for the Text Editor, so shortcut files can be opened as plain text via "Open with".

## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local dev environment (macOS, Node/pnpm workspace)
- test case 1: `pnpm --filter @opencloud-eu/web-pkg check:types`
- test case 2: `pnpm test:unit --run packages/web-pkg/tests/unit/components/ContextActions/ActionMenuItem.spec.ts`
- test case 3: `pnpm test:unit --run packages/web-app-text-editor/tests/unit/yjs.spec.ts packages/web-app-text-editor/tests/unit/app.spec.ts`

## Types of changes

- [x] Bugfix
- [x] Enhancement (a change that does not break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
