### PR TITLE
Fix chapter updates for fast EPUB slider seeks

### DIFF
--- a/packages/web-app-epub-reader/src/App.vue
+++ b/packages/web-app-epub-reader/src/App.vue
@@ -526,9 +526,10 @@ watch(
       }
     })
 
-    unref(rendition).on('relocated', () => {
+    unref(rendition).on('relocated', (relocatedLocation: Location | undefined) => {
       isReaderLoading.value = false
-      const currentLocation = unref(rendition).currentLocation() as unknown as Location
+      const currentLocation =
+        relocatedLocation ?? (unref(rendition).currentLocation() as unknown as Location)
       if (!currentLocation) {
         return
       }

--- a/packages/web-app-epub-reader/src/App.vue
+++ b/packages/web-app-epub-reader/src/App.vue
@@ -526,10 +526,8 @@ watch(
       }
     })
 
-    unref(rendition).on('relocated', (relocatedLocation: Location | undefined) => {
+    unref(rendition).on('relocated', (currentLocation: Location | undefined) => {
       isReaderLoading.value = false
-      const currentLocation =
-        relocatedLocation ?? (unref(rendition).currentLocation() as unknown as Location)
       if (!currentLocation) {
         return
       }

--- a/packages/web-app-epub-reader/src/helpers/chapterResolving.ts
+++ b/packages/web-app-epub-reader/src/helpers/chapterResolving.ts
@@ -12,6 +12,19 @@ type RenditionDom = {
   getRange?: (cfi: string) => Range | null
 }
 
+function findChapterFromNavigationItem(
+  chapterList: NavItem[],
+  navigationItem?: Pick<NavItem, 'id' | 'href'> | null
+): NavItem | undefined {
+  if (!navigationItem) {
+    return undefined
+  }
+  return (
+    chapterList.find((chapter) => chapter.id === navigationItem.id) ||
+    findChapterByHref(chapterList, navigationItem.href)
+  )
+}
+
 /**
  * Finds a chapter by href from the chapter list.
  * Supports both exact matches and normalized matches (strips hash fragments).
@@ -85,14 +98,14 @@ export function findChapterByDomPosition(
 
 /**
  * Resolves the current chapter based on the current location in the book.
- * Uses multiple fallback strategies to handle various EPUB structures:
+ * Uses multiple resolution strategies to handle various EPUB structures:
  *
  * Strategy 1: Exact/normalized match directly against loaded TOC using relocated href
  * Strategy 2: Resolve via navigation.get(locationHref) but only if it maps to loaded TOC
  * Strategy 3: Match via navigation.get(spineHref), but only if it maps to loaded TOC
  * Strategy 4: Match by normalized spine href (without hash fragment)
  * Strategy 4b: Multiple chapters in same file - find by DOM element position
- * Strategy 5: Find containing chapter by spine index (for chapters spanning multiple files)
+ * Strategy 5: Resolve by nearest TOC chapter in spine order
  *
  * Returns undefined when no strategy resolves a chapter, so that callers can keep the
  * previously resolved chapter instead of highlighting an unrelated one.
@@ -122,7 +135,10 @@ export function resolveCurrentChapter(
   // Strategy 2: Resolve via navigation.get(locationHref) but only if it maps to loaded TOC
   if (locationHref) {
     const byLocationHref = navigation.get(locationHref)
-    const byNavigationLocationHrefFromToc = findChapterByHref(chapterList, byLocationHref?.href)
+    const byNavigationLocationHrefFromToc = findChapterFromNavigationItem(
+      chapterList,
+      byLocationHref
+    )
     if (byNavigationLocationHrefFromToc) {
       return byNavigationLocationHrefFromToc
     }
@@ -140,7 +156,7 @@ export function resolveCurrentChapter(
 
   // Strategy 3: Match via navigation.get(spineHref), but only if it maps to loaded TOC
   const bySpineHref = navigation.get(spineHref)
-  const bySpineHrefFromToc = findChapterByHref(chapterList, bySpineHref?.href)
+  const bySpineHrefFromToc = findChapterFromNavigationItem(chapterList, bySpineHref)
   if (bySpineHrefFromToc) {
     return bySpineHrefFromToc
   }
@@ -167,23 +183,40 @@ export function resolveCurrentChapter(
     return matchingChapters[0]
   }
 
-  // Strategy 5: Find containing chapter by spine index (for chapters spanning multiple files)
+  // Strategy 5: Resolve by nearest TOC chapter in spine order
   const currentSpineIndex = spineItem?.index
   if (typeof currentSpineIndex === 'number') {
-    const chaptersWithSpineIndex = chapterList
-      .map((chapter) => {
-        const chapterSpineItem = book?.spine.get(chapter.href.split('#')[0])
-        return {
-          chapter,
-          spineIndex: chapterSpineItem?.index ?? -1
-        }
-      })
-      .filter((item) => item.spineIndex >= 0 && item.spineIndex <= currentSpineIndex)
-      .sort((a, b) => b.spineIndex - a.spineIndex)
+    let nearestChapter: { chapter: NavItem; spineIndex: number; tocOrder: number } | undefined
+    let firstChapterInSpine: { chapter: NavItem; spineIndex: number; tocOrder: number } | undefined
 
-    if (chaptersWithSpineIndex.length > 0) {
-      return chaptersWithSpineIndex[0].chapter
+    for (const [tocOrder, chapter] of chapterList.entries()) {
+      const chapterSpineItem = book?.spine.get(chapter.href.split('#')[0])
+      const chapterSpineIndex = chapterSpineItem?.index
+      if (typeof chapterSpineIndex !== 'number') {
+        continue
+      }
+
+      const chapterAtIndex = { chapter, spineIndex: chapterSpineIndex, tocOrder }
+      if (
+        !firstChapterInSpine ||
+        chapterSpineIndex < firstChapterInSpine.spineIndex ||
+        (chapterSpineIndex === firstChapterInSpine.spineIndex &&
+          tocOrder < firstChapterInSpine.tocOrder)
+      ) {
+        firstChapterInSpine = chapterAtIndex
+      }
+
+      if (
+        chapterSpineIndex <= currentSpineIndex &&
+        (!nearestChapter ||
+          chapterSpineIndex > nearestChapter.spineIndex ||
+          (chapterSpineIndex === nearestChapter.spineIndex && tocOrder < nearestChapter.tocOrder))
+      ) {
+        nearestChapter = chapterAtIndex
+      }
     }
+
+    return nearestChapter?.chapter ?? firstChapterInSpine?.chapter
   }
 
   return undefined

--- a/packages/web-app-epub-reader/tests/unit/app.spec.ts
+++ b/packages/web-app-epub-reader/tests/unit/app.spec.ts
@@ -336,7 +336,7 @@ describe('Epub reader app', () => {
       const relocatedHandler = (wrapper.vm as any).rendition.on.mock.calls.find(
         ([eventName]: [string]) => eventName === 'relocated'
       )?.[1]
-      relocatedHandler()
+      relocatedHandler((wrapper.vm as any).rendition.currentLocation())
       await nextTicks(1)
 
       expect((wrapper.vm as any).currentChapter.id).toBe('ch-130')
@@ -369,7 +369,7 @@ describe('Epub reader app', () => {
       const relocatedHandler = (wrapper.vm as any).rendition.on.mock.calls.find(
         ([eventName]: [string]) => eventName === 'relocated'
       )?.[1]
-      relocatedHandler()
+      relocatedHandler((wrapper.vm as any).rendition.currentLocation())
       await nextTicks(1)
 
       expect((wrapper.vm as any).currentChapter.id).toBe('ch-1')
@@ -448,7 +448,7 @@ describe('Epub reader app', () => {
       const relocatedHandler = (wrapper.vm as any).rendition.on.mock.calls.find(
         ([eventName]: [string]) => eventName === 'relocated'
       )?.[1]
-      relocatedHandler()
+      relocatedHandler((wrapper.vm as any).rendition.currentLocation())
       await nextTicks(1)
 
       expect((wrapper.vm as any).currentChapter.id).toBe('ch-2')
@@ -472,7 +472,7 @@ describe('Epub reader app', () => {
       const relocatedHandler = (wrapper.vm as any).rendition.on.mock.calls.find(
         ([eventName]: [string]) => eventName === 'relocated'
       )?.[1]
-      relocatedHandler()
+      relocatedHandler((wrapper.vm as any).rendition.currentLocation())
       await nextTicks(1)
 
       expect((wrapper.vm as any).readingProgressPercent).toBe(0)

--- a/packages/web-app-epub-reader/tests/unit/app.spec.ts
+++ b/packages/web-app-epub-reader/tests/unit/app.spec.ts
@@ -375,6 +375,47 @@ describe('Epub reader app', () => {
       expect((wrapper.vm as any).currentChapter.id).toBe('ch-1')
     })
 
+    it('uses relocated payload when rendition.currentLocation is stale after seek', async () => {
+      const { wrapper } = getWrapper()
+      await nextTicks(3)
+
+      ;(wrapper.vm as any).chapters = [
+        { id: 'ch-1', label: 'Chapter 1', href: 'text/ch1.xhtml' },
+        { id: 'ch-2', label: 'Chapter 2', href: 'text/ch2.xhtml' }
+      ]
+      ;(wrapper.vm as any).currentChapter = {
+        id: 'ch-1',
+        label: 'Chapter 1',
+        href: 'text/ch1.xhtml'
+      }
+
+      ;(wrapper.vm as any).rendition.currentLocation.mockReturnValue({
+        start: {
+          cfi: 'epubcfi(/6/2)',
+          href: 'text/ch1.xhtml',
+          displayed: { page: 1, total: 12 }
+        },
+        atStart: false,
+        atEnd: false
+      })
+
+      const relocatedHandler = (wrapper.vm as any).rendition.on.mock.calls.find(
+        ([eventName]: [string]) => eventName === 'relocated'
+      )?.[1]
+      relocatedHandler({
+        start: {
+          cfi: 'epubcfi(/6/4)',
+          href: 'text/ch2.xhtml',
+          displayed: { page: 3, total: 12 }
+        },
+        atStart: false,
+        atEnd: false
+      })
+      await nextTicks(1)
+
+      expect((wrapper.vm as any).currentChapter.id).toBe('ch-2')
+    })
+
     it('keeps the current chapter when the location cannot be resolved', async () => {
       const { wrapper } = getWrapper()
       await nextTicks(6)

--- a/packages/web-app-epub-reader/tests/unit/helpers/chapterResolving.spec.ts
+++ b/packages/web-app-epub-reader/tests/unit/helpers/chapterResolving.spec.ts
@@ -216,6 +216,32 @@ describe('chapterResolving', () => {
         const result = resolveCurrentChapter(location, mockBook, chapters, mockRendition)
         expect(result?.id).toBe('ch-2')
       })
+
+      it('resolves chapter via navigation.get item id when href is ambiguous', () => {
+        const chapters: NavItem[] = [
+          { id: 'ch-1', label: 'Chapter 1', href: 'text/book.xhtml#ch1' },
+          { id: 'ch-2', label: 'Chapter 2', href: 'text/book.xhtml#ch2' }
+        ]
+
+        const location = mock<Location>({
+          start: {
+            href: 'text/book.xhtml',
+            cfi: 'epubcfi(/6/2)',
+            displayed: { page: 1, total: 12 }
+          }
+        })
+
+        mockBook.navigation.get.mockImplementation((href: string) => {
+          if (href === 'text/book.xhtml') {
+            return { id: 'ch-2', label: 'Chapter 2', href: 'text/book.xhtml' }
+          }
+          return null
+        })
+        mockBook.spine.get.mockReturnValue({ href: 'text/book.xhtml', index: 1 })
+
+        const result = resolveCurrentChapter(location, mockBook, chapters, mockRendition)
+        expect(result?.id).toBe('ch-2')
+      })
     })
 
     describe('Strategy 3: navigation.get(spineHref)', () => {
@@ -366,6 +392,64 @@ describe('chapterResolving', () => {
 
         const result = resolveCurrentChapter(location, mockBook, chapters, mockRendition)
         expect(result?.id).toBe('ch-2')
+      })
+
+      it('keeps TOC order when multiple chapters share the same spine index', () => {
+        const chapters: NavItem[] = [
+          { id: 'ch-1', label: 'Chapter 1', href: 'text/ch1-a.xhtml' },
+          { id: 'ch-1b', label: 'Chapter 1b', href: 'text/ch1-b.xhtml' },
+          { id: 'ch-2', label: 'Chapter 2', href: 'text/ch2.xhtml' }
+        ]
+
+        const location = mock<Location>({
+          start: {
+            href: 'text/interstitial.xhtml',
+            cfi: 'epubcfi(/6/8)',
+            displayed: { page: 1, total: 12 }
+          }
+        })
+
+        mockBook.spine.get.mockImplementation((target: string) => {
+          if (target === 'epubcfi(/6/8)' || target === 'text/interstitial.xhtml') {
+            return { href: 'text/interstitial.xhtml', index: 3 }
+          }
+          if (target === 'text/ch1-a.xhtml') return { index: 2 }
+          if (target === 'text/ch1-b.xhtml') return { index: 2 }
+          if (target === 'text/ch2.xhtml') return { index: 10 }
+          return null
+        })
+        mockBook.navigation.get.mockReturnValue(null)
+
+        const result = resolveCurrentChapter(location, mockBook, chapters, mockRendition)
+        expect(result?.id).toBe('ch-1')
+      })
+
+      it('resolves to the first chapter when current position is before first chapter spine index', () => {
+        const chapters: NavItem[] = [
+          { id: 'ch-1', label: 'Chapter 1', href: 'text/ch1.xhtml' },
+          { id: 'ch-2', label: 'Chapter 2', href: 'text/ch2.xhtml' }
+        ]
+
+        const location = mock<Location>({
+          start: {
+            href: 'text/index.xhtml',
+            cfi: 'epubcfi(/6/4)',
+            displayed: { page: 1, total: 12 }
+          }
+        })
+
+        mockBook.spine.get.mockImplementation((target: string) => {
+          if (target === 'epubcfi(/6/4)' || target === 'text/index.xhtml') {
+            return { href: 'text/index.xhtml', index: 1 }
+          }
+          if (target === 'text/ch1.xhtml') return { index: 5 }
+          if (target === 'text/ch2.xhtml') return { index: 10 }
+          return null
+        })
+        mockBook.navigation.get.mockReturnValue(null)
+
+        const result = resolveCurrentChapter(location, mockBook, chapters, mockRendition)
+        expect(result?.id).toBe('ch-1')
       })
     })
 


### PR DESCRIPTION
## Description

Fixes chapter selection desync in the EPUB reader when users drag the reading progress slider quickly (especially to the left).

Changes:
- use relocated event payload as the primary location source in App.vue
- improve chapter resolution to match navigation items by id as well as href
- make spine-order chapter resolution deterministic when direct TOC matches are unavailable
- add unit tests for stale relocated/currentLocation mismatch and ambiguous/frontmatter chapter resolution

## Related Issue

- Fixes <issue_link>

## How Has This Been Tested?

- test environment: local dev environment (macOS), Vitest
- test case 1: pnpm test:unit --run packages/web-app-epub-reader/tests/unit/app.spec.ts
- test case 2: pnpm test:unit --run packages/web-app-epub-reader/tests/unit/helpers/chapterResolving.spec.ts
- test case 3: fast slider seek scenario covered by new unit tests in app.spec.ts and chapterResolving.spec.ts

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
