### PR TITLE
fix: show trash breadcrumb with one space

### DIFF
--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -92,7 +92,6 @@
 import last from 'lodash-es/last'
 import { computed, onBeforeUnmount, onMounted, ref, unref, useSlots, useTemplateRef } from 'vue'
 import {
-  isPersonalSpaceResource,
   isProjectSpaceResource,
   isShareSpaceResource,
   Resource,
@@ -101,7 +100,6 @@ import {
 import BatchActions from '../BatchActions.vue'
 import ContextActions from '../FilesList/ContextActions.vue'
 import ViewOptions from '../ViewOptions.vue'
-import { isLocationTrashActive } from '../../router'
 import { FolderView } from '../../ui/types'
 import {
   useFileActionsDelete,
@@ -113,13 +111,11 @@ import {
   FileAction,
   FolderViewModeConstants,
   useAbility,
-  useActiveLocation,
   useExtensionRegistry,
   useIsTopBarSticky,
   useResourcesStore,
   useRouteMeta,
-  useSideBar,
-  useSpacesStore
+  useSideBar
 } from '../../composables'
 import { BreadcrumbItem, EVENT_ITEM_DROPPED } from '@opencloud-eu/design-system/helpers'
 import { useGettext } from 'vue3-gettext'
@@ -159,7 +155,6 @@ const emit = defineEmits<{
   (e: typeof EVENT_ITEM_DROPPED, data: RouteLocationRaw): void
 }>()
 
-const spacesStore = useSpacesStore()
 const { $gettext, $ngettext } = useGettext()
 const { can } = useAbility()
 const { requestExtensions } = useExtensionRegistry()
@@ -216,17 +211,7 @@ const batchActions = computed(() => {
     })
 })
 
-const spaces = computed(() =>
-  spacesStore.spaces.filter((s) => isPersonalSpaceResource(s) || isProjectSpaceResource(s))
-)
-
-const isTrashLocation = useActiveLocation(isLocationTrashActive, 'files-trash-generic')
-const showBreadcrumb = computed(() => {
-  if (unref(isTrashLocation) && unref(spaces).length === 1) {
-    return false
-  }
-  return breadcrumbs.length
-})
+const showBreadcrumb = computed(() => breadcrumbs.length)
 
 const breadcrumbTruncationOffset = computed(() => {
   if (!unref(space)) {

--- a/packages/web-pkg/tests/unit/components/AppBar/AppBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/AppBar/AppBar.spec.ts
@@ -74,6 +74,18 @@ describe('AppBar component', () => {
         const { wrapper } = getShallowWrapper([], {}, { breadcrumbs: [] })
         expect(wrapper.find(selectors.ocBreadcrumbStub).exists()).toBeFalsy()
       })
+      it('shows the trash breadcrumb when the personal space is the only space', () => {
+        const { wrapper } = getShallowWrapper(
+          [],
+          {},
+          { breadcrumbs: [{ text: 'Deleted files' }] },
+          mock<RouteLocation>({ name: 'files-trash-generic' }),
+          false,
+          false,
+          [mock<SpaceResource>({ driveType: 'personal' })]
+        )
+        expect(wrapper.find(selectors.ocBreadcrumbStub).exists()).toBeTruthy()
+      })
     })
     describe('bulkActions', () => {
       it('if enabled and batch actions available', () => {
@@ -134,7 +146,8 @@ function getShallowWrapper(
     path: '/files/spaces/personal/admin'
   }),
   isMobile = false,
-  hasBatchActions = false
+  hasBatchActions = false,
+  spaces: SpaceResource[] = []
 ) {
   vi.mocked(useIsMobile).mockReturnValue({
     isMobile: computed(() => isMobile),
@@ -143,7 +156,8 @@ function getShallowWrapper(
 
   const plugins = defaultPlugins({
     piniaOptions: {
-      resourcesStore: { resources: selected, selectedIds: selected.map(({ id }) => id) }
+      resourcesStore: { resources: selected, selectedIds: selected.map(({ id }) => id) },
+      spacesState: { spaces }
     }
   })
 


### PR DESCRIPTION
## Description

The app bar hid breadcrumbs on the trash route when the personal space was the only available space. This left the trash view without its “Deleted files” breadcrumb.

The special-case suppression is removed, and a regression test covers the single-space trash route.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3269

## How Has This Been Tested?

- test environment: Node 24.20.0, pnpm 11.24.0
- test case 1: AppBar unit test suite (11 passed)
- test case 2: web-pkg unit suite (1,484 passed, 2 skipped; 5 unrelated existing Intl formatting failures)

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
