### PR TITLE
chore(deps): update docker images

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2,12 +2,16 @@ repo_slug = "opencloud-eu/web"
 docker_repo_slug = "opencloudeu/web"
 
 ALPINE_GIT = "alpine/git:latest"
-APACHE_TIKA = "apache/tika:2.8.0.0"
+
+# renovate: datasource=docker depName=apache/tika
+APACHE_TIKA = "apache/tika:3.3.1.0"
 
 # renovate: datasource=docker depName=collabora/code
-COLLABORA_CODE = "collabora/code:26.04.2.4.1"
-KEYCLOAK = "quay.io/keycloak/keycloak:26.6.1"
-MINIO_MC = "minio/mc:RELEASE.2021-10-07T04-19-58Z"
+COLLABORA_CODE = "collabora/code:26.04.3.1.1"
+
+# renovate: datasource=docker depName=quay.io/keycloak/keycloak
+KEYCLOAK = "quay.io/keycloak/keycloak:26.7.3"
+MINIO_MC = "minio/mc:RELEASE.2025-08-13T08-35-41Z"
 OC_CI_BAZEL_BUILDIFIER = "quay.io/opencloudeu/bazel-buildifier-ci:latest"
 OC_CI_GOLANG = "quay.io/opencloudeu/golang-ci:1.25"
 OC_CI_NODEJS = "quay.io/opencloudeu/nodejs-ci:24"
@@ -24,7 +28,7 @@ PLUGINS_GIT_ACTION = "quay.io/thegeeklab/wp-git-action:2"
 PLUGINS_S3 = "plugins/s3:1.5"
 PLUGINS_S3_CACHE = "plugins/s3-cache:1"
 PLUGINS_SLACK = "plugins/slack:1"
-POSTGRES_ALPINE = "postgres:alpine3.18"
+POSTGRES_ALPINE = "postgres:alpine3.24"
 OPENLDAP = "bitnamilegacy/openldap:2.6"
 READY_RELEASE_GO = "woodpeckerci/plugin-ready-release-go:latest"
 

--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -824,7 +824,6 @@ def notifyMatrixCheckSteps():
     result = {
         "name": "all-checks-finished",
         "skip_clone": True,
-        "runs_on": ["success", "failure"],
         "steps": [
             {
                 "name": "notify-matrix",
@@ -862,11 +861,12 @@ def notifyMatrixCheckSteps():
             },
         ],
         "when": [
-            event["cron"],
-            event["pull_request"],
+            dict(event["cron"], status = ["success", "failure"]),
+            dict(event["pull_request"], status = ["success", "failure"]),
             {
                 "event": ["push", "manual"],
                 "branch": "${CI_REPO_DEFAULT_BRANCH}",
+                "status": ["success", "failure"],
             },
         ],
     }
@@ -1503,11 +1503,10 @@ def purgeCache(name, flush_path, flush_age):
         "name": name,
         "skip_clone": True,
         "when": [
-            event["cron"],
-            event["pull_request"],
-            event["main_branch"],
+            dict(event["cron"], status = ["success", "failure"]),
+            dict(event["pull_request"], status = ["success", "failure"]),
+            dict(event["main_branch"], status = ["success", "failure"]),
         ],
-        "runs_on": ["success", "failure"],
         "steps": {
             "purge": {
                 "image": MINIO_MC,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - ${OC_WEB_CONFIG:-./dev/docker/opencloud.web-federated.config.json}:/web/config.json:ro
 
   collabora:
-    image: collabora/code:26.04.2.4.1
+    image: collabora/code:26.04.3.1.1
     environment:
       aliasgroup1: ${OC_URL:-https://host.docker.internal:9200}
       extra_params: --o:ssl.enable=false --o:ssl.ssl_verification=false --o:welcome.enable=false --o:home_mode.enable=true --o:ssl.termination=true --o:net.frame_ancestors=${OC_URL:-https://host.docker.internal:9200} --o:net.lok_allow.host[14]=${OC_URL:-https://host.docker.internal:9200}
@@ -338,7 +338,7 @@ services:
     restart: unless-stopped
 
   stalwart:
-    image: ghcr.io/stalwartlabs/stalwart:v0.16.8-alpine
+    image: ghcr.io/stalwartlabs/stalwart:v0.16.20-alpine
     hostname: ${STALWART_DOMAIN:-stalwart.opencloud.test}
     depends_on:
       opencloud:

--- a/tests/e2e/features/app-provider/secureView.feature
+++ b/tests/e2e/features/app-provider/secureView.feature
@@ -41,23 +41,23 @@ Feature: Secure view
 
     # we copy the contents of the file and compare the clipboard with the expected contents.
     # In case the user does not have download permissions and tries to copy file content, the clipboard should be set to “Copying from document disabled”.
-    Then "Brian" should see the content "Copying from the document disabled" in editor "CollaboraOnline"
+    Then "Brian" should see the content "Copying from the document has been disabled by your administrator" in editor "CollaboraOnline"
     And "Brian" closes the file viewer
     When "Brian" opens folder "shared folder"
     And "Brian" opens the following file in Collabora
       | resource   |
       | simple.pdf |
-    Then "Brian" should see the content "Copying from the document disabled" in editor "CollaboraOnline"
+    Then "Brian" should see the content "Copying from the document has been disabled by your administrator" in editor "CollaboraOnline"
     And "Brian" closes the file viewer
     And "Brian" opens the following file in Collabora
       | resource        |
       | testavatar.jpeg |
-    Then "Brian" should see the content "Copying from the document disabled" in editor "CollaboraOnline"
+    Then "Brian" should see the content "Copying from the document has been disabled by your administrator" in editor "CollaboraOnline"
     And "Brian" closes the file viewer
     And "Brian" opens the following file in Collabora
       | resource  |
       | lorem.txt |
-    Then "Brian" should see the content "Copying from the document disabled" in editor "CollaboraOnline"
+    Then "Brian" should see the content "Copying from the document has been disabled by your administrator" in editor "CollaboraOnline"
     And "Brian" logs out
 
 


### PR DESCRIPTION
## Description

Bump the pinned images used by CI and the local dev stack:

- apache/tika 2.8.0.0 -> 3.3.1.0 (aligns CI with docker-compose)
- collabora/code 26.04.2.4.1 -> 26.04.3.1.1
- keycloak 26.6.1 -> 26.7.3
- minio/mc RELEASE.2021-10-07 -> RELEASE.2025-08-13
- postgres alpine3.18 -> alpine3.24
- stalwart v0.16.8 -> v0.16.20

Annotate apache/tika and keycloak with renovate comments so they are picked up by the custom manager for .woodpecker.star from now on.

## Related Issue

- Supersedes some stale PRs

## Types of changes

- [x] Tests (adding or improving tests)
- [x] Maintenance (like dependency updates or tooling adjustments)
