### PR TITLE
Hide duplicate 'Insert from cloud' action in text editor toolbar

### DIFF
--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -715,6 +715,7 @@ export function useEditorActions(state: TextEditorState) {
     icon: 'cloud-line',
     keywords: ['image', 'picture', 'cloud'],
     showInSlashCommands: true,
+    showInToolbar: false,
     toolbarAction: (editor) => openCloudImagePicker(editor),
     slashCommandAction: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).run()


### PR DESCRIPTION
## Description

This pull request removes the duplicate standalone `Insert from cloud` button from the text editor toolbar.

The cloud image action remains available where it belongs:
- in the `Insert image` dropdown
- in slash commands

This is done by setting `showInToolbar: false` on `image-cloud`.

## Related Issue

- Fixes N/A (no dedicated issue was provided)

## How Has This Been Tested?

- test environment: local development environment (macOS)
- test case 1: `pnpm test:unit --run packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts packages/web-pkg/tests/unit/editor/strategies/html.spec.ts packages/web-pkg/tests/unit/editor/strategies/markdown.spec.ts packages/web-pkg/tests/unit/editor/strategies/tiptapJson.spec.ts`
- test case 2: all targeted editor tests pass (4 files, 176 tests)

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
