### PR TITLE
fix: remove pasted text/background colors in Tiptap editor

### DIFF
--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -17,6 +17,7 @@ import type {
 import { DEFAULT_YDOC_FRAGMENT } from '../types'
 import type { EditorAction, EditorActionGroup } from './useEditorActions'
 import { SlashCommands } from '../extensions'
+import { stripColorFormattingFromPastedHtml } from '../helpers'
 import { useContentStrategy } from './useContentStrategy'
 import { useConfigStore } from '../../composables'
 
@@ -177,6 +178,9 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
 
   editorOptions.editorProps = {
     attributes: editorAttributes,
+    transformPastedHTML(html: string) {
+      return stripColorFormattingFromPastedHtml(html)
+    },
     handleDOMEvents: {
       auxclick(view: Editor['view'], event: Event) {
         const target = event.target

--- a/packages/web-pkg/src/editor/helpers/index.ts
+++ b/packages/web-pkg/src/editor/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './link'
+export * from './paste'
 export * from './print'

--- a/packages/web-pkg/src/editor/helpers/paste.ts
+++ b/packages/web-pkg/src/editor/helpers/paste.ts
@@ -1,0 +1,29 @@
+const STYLE_PROPERTIES_TO_REMOVE_ON_PASTE = ['color', 'background-color'] as const
+const HTML_ATTRIBUTES_TO_REMOVE_ON_PASTE = ['color', 'bgcolor'] as const
+
+export function stripColorFormattingFromPastedHtml(html: string): string {
+  if (!html || typeof DOMParser === 'undefined') {
+    return html
+  }
+
+  const parsedHtml = new DOMParser().parseFromString(html, 'text/html')
+  const allElements = parsedHtml.body.querySelectorAll<HTMLElement>('*')
+
+  allElements.forEach((element) => {
+    if (element.hasAttribute('style')) {
+      STYLE_PROPERTIES_TO_REMOVE_ON_PASTE.forEach((propertyName) => {
+        element.style.removeProperty(propertyName)
+      })
+
+      if (!element.style.cssText.trim()) {
+        element.removeAttribute('style')
+      }
+    }
+
+    HTML_ATTRIBUTES_TO_REMOVE_ON_PASTE.forEach((attributeName) => {
+      element.removeAttribute(attributeName)
+    })
+  })
+
+  return parsedHtml.body.innerHTML
+}

--- a/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
@@ -196,6 +196,26 @@ describe('useTextEditor', () => {
     )
   })
 
+  describe('paste formatting', () => {
+    it('removes pasted text and background colors', () => {
+      const { result } = createEditor()
+      const transformPastedHTML = (result.editor.value?.options.editorProps as any)
+        ?.transformPastedHTML as (html: string) => string
+
+      const transformedHtml = transformPastedHTML(
+        '<p><span style="color: #ff0000; background-color: #ffff00; font-weight: 700;">Styled</span><font color="#00ff00">Legacy</font><table><tr><td bgcolor="#0000ff">Cell</td></tr></table></p>'
+      )
+      const parsedHtml = new DOMParser().parseFromString(transformedHtml, 'text/html')
+      const span = parsedHtml.body.querySelector('span')
+
+      expect(span?.getAttribute('style')).toContain('font-weight')
+      expect(span?.style.color).toBe('')
+      expect(span?.style.backgroundColor).toBe('')
+      expect(parsedHtml.body.querySelector('[color]')).toBeNull()
+      expect(parsedHtml.body.querySelector('[bgcolor]')).toBeNull()
+    })
+  })
+
   describe('onUpdate debounce', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts
@@ -196,26 +196,6 @@ describe('useTextEditor', () => {
     )
   })
 
-  describe('paste formatting', () => {
-    it('removes pasted text and background colors', () => {
-      const { result } = createEditor()
-      const transformPastedHTML = (result.editor.value?.options.editorProps as any)
-        ?.transformPastedHTML as (html: string) => string
-
-      const transformedHtml = transformPastedHTML(
-        '<p><span style="color: #ff0000; background-color: #ffff00; font-weight: 700;">Styled</span><font color="#00ff00">Legacy</font><table><tr><td bgcolor="#0000ff">Cell</td></tr></table></p>'
-      )
-      const parsedHtml = new DOMParser().parseFromString(transformedHtml, 'text/html')
-      const span = parsedHtml.body.querySelector('span')
-
-      expect(span?.getAttribute('style')).toContain('font-weight')
-      expect(span?.style.color).toBe('')
-      expect(span?.style.backgroundColor).toBe('')
-      expect(parsedHtml.body.querySelector('[color]')).toBeNull()
-      expect(parsedHtml.body.querySelector('[bgcolor]')).toBeNull()
-    })
-  })
-
   describe('onUpdate debounce', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/packages/web-pkg/tests/unit/editor/helpers/paste.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/helpers/paste.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { stripColorFormattingFromPastedHtml } from '../../../../src/editor/helpers/paste'
+
+describe('stripColorFormattingFromPastedHtml', () => {
+  it('removes color and background-color styles but keeps other styles', () => {
+    const transformedHtml = stripColorFormattingFromPastedHtml(
+      '<p><span style="color: #ff0000; background-color: #ffff00; font-weight: 700;">Styled</span></p>'
+    )
+    const parsedHtml = new DOMParser().parseFromString(transformedHtml, 'text/html')
+    const span = parsedHtml.body.querySelector('span')
+
+    expect(span?.getAttribute('style')).toContain('font-weight')
+    expect(span?.style.color).toBe('')
+    expect(span?.style.backgroundColor).toBe('')
+  })
+
+  it('removes style attribute when only color styles were present', () => {
+    const transformedHtml = stripColorFormattingFromPastedHtml(
+      '<p><span style="color: #ff0000; background-color: #ffff00;">Styled</span></p>'
+    )
+    const parsedHtml = new DOMParser().parseFromString(transformedHtml, 'text/html')
+    const span = parsedHtml.body.querySelector('span')
+
+    expect(span?.hasAttribute('style')).toBe(false)
+  })
+
+  it('removes deprecated color and bgcolor attributes', () => {
+    const transformedHtml = stripColorFormattingFromPastedHtml(
+      '<p><font color="#00ff00">Legacy</font><table><tr><td bgcolor="#0000ff">Cell</td></tr></table></p>'
+    )
+    const parsedHtml = new DOMParser().parseFromString(transformedHtml, 'text/html')
+
+    expect(parsedHtml.body.querySelector('[color]')).toBeNull()
+    expect(parsedHtml.body.querySelector('[bgcolor]')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Description

When users paste content from websites or emails into Tiptap, inline `color` / `background-color` styles can make text unreadable in dark theme (for example black text on dark background).

This change strips pasted text and background colors while preserving other inline styles.

Downsides / trade-offs:
- Intentional source colors and highlights are not preserved on paste.
- Legacy HTML color attributes (`color`, `bgcolor`) are removed as well, which can reduce visual fidelity for copied legacy content.

## Related Issue

- Fixes <issue_link>

## How Has This Been Tested?

- test environment: local macOS dev environment, pnpm + vitest
- test case 1: `pnpm --config.confirmModulesPurge=false test:unit --run packages/web-pkg/tests/unit/editor/helpers/paste.spec.ts`
- test case 2: `pnpm --config.confirmModulesPurge=false test:unit --run packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts`
- test case 3: `pnpm --config.confirmModulesPurge=false test:unit --run packages/web-pkg/tests/unit/editor/helpers/paste.spec.ts packages/web-pkg/tests/unit/editor/composables/useTextEditor.spec.ts`
- ...

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
