### PR TITLE
build: prepare yjs server image publish

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -16,6 +16,8 @@ OC_CI_WAIT_FOR = "quay.io/opencloudeu/wait-for-ci:latest"
 
 # renovate: datasource=docker depName=ghcr.io/euro-office/documentserver
 EURO_OFFICE_DOCUMENT_SERVER = "ghcr.io/euro-office/documentserver:v9.3.2"
+PLUGINS_DOCKER_BUILDX = "woodpeckerci/plugin-docker-buildx:latest"
+PLUGINS_DOCKER_PUSHRM = "chko/docker-pushrm:1"
 PLUGINS_GH_PAGES = "plugins/gh-pages:1"
 PLUGINS_GITHUB_RELEASE = "plugins/github-release:1"
 PLUGINS_GIT_ACTION = "quay.io/thegeeklab/wp-git-action:2"
@@ -25,6 +27,13 @@ PLUGINS_SLACK = "plugins/slack:1"
 POSTGRES_ALPINE = "postgres:alpine3.18"
 OPENLDAP = "bitnamilegacy/openldap:2.6"
 READY_RELEASE_GO = "woodpeckerci/plugin-ready-release-go:latest"
+
+YJS_TAG_PREFIX = "yjs-v"
+YJS_DOCKERFILE = "services/yjs/Dockerfile"
+YJS_PACKAGE_JSON = "services/yjs/package.json"
+YJS_DOCKER_REPOS = "opencloudeu/yjs,quay.io/opencloudeu/yjs"
+YJS_DOCKER_PLATFORMS = "linux/amd64,linux/arm64"
+YJS_IMAGE_DESCRIPTION = "Yjs collaboration server for OpenCloud"
 
 WEB_PUBLISH_NPM_PACKAGES = ["design-system", "eslint-config", "extension-sdk", "prettier-config", "tsconfig", "web-client", "web-pkg", "web-test-helpers"]
 WEB_PUBLISH_NPM_ORGANIZATION = "@opencloud-eu"
@@ -277,6 +286,9 @@ event = {
 def main(ctx):
     if ctx.build.event == "cron" and ctx.build.cron == "translation-sync":
         return translation_sync(ctx)
+    if isYjsRelease(ctx):
+        return publishYjsImage(ctx)
+
     is_release_pr = (ctx.build.event == "pull_request" and ctx.build.sender == "openclouders" and "🎉 release" in ctx.build.title.lower())
     if is_release_pr:
         license = licenseCheck()
@@ -492,6 +504,99 @@ def publishRelease(ctx):
     pipelines.append(build_pipeline)
 
     return pipelines
+
+def isYjsRelease(ctx):
+    return ctx.build.event == "tag" and ctx.build.ref.startswith("refs/tags/%s" % YJS_TAG_PREFIX)
+
+def determineYjsReleaseVersion(ctx):
+    return ctx.build.ref.replace("refs/tags/%s" % YJS_TAG_PREFIX, "")
+
+# The yjs image has its own version, independent of the web app version. It is released by
+# pushing a `yjs-vX.Y.Z` tag (see dev/scripts/create_and_push_yjs_tag.sh).
+def publishYjsImage(ctx):
+    version = determineYjsReleaseVersion(ctx)
+
+    # only stable releases move the rolling `latest` tag
+    tags = ["v%s" % version]
+    if len(version.split("-")) == 1:
+        tags.append("latest")
+
+    return [{
+        "name": "publish-yjs-image",
+        "steps": [
+            {
+                "name": "verify-version",
+                "image": OC_CI_NODEJS,
+                "commands": [
+                    "package_version=$(jq -r '.version' < %s)" % YJS_PACKAGE_JSON,
+                    "echo \"tag version: %s, %s: $package_version\"" % (version, YJS_PACKAGE_JSON),
+                    "[ \"$package_version\" = \"%s\" ] || (echo \"git tag does not match version in %s\"; exit 1)" % (version, YJS_PACKAGE_JSON),
+                ],
+            },
+            {
+                "name": "build-and-push",
+                "image": PLUGINS_DOCKER_BUILDX,
+                "depends_on": ["verify-version"],
+                "settings": {
+                    "repo": YJS_DOCKER_REPOS,
+                    "dockerfile": YJS_DOCKERFILE,
+                    "platforms": YJS_DOCKER_PLATFORMS,
+                    "tags": tags,
+                    "pull_image": False,
+                    "logins": [
+                        {
+                            "registry": "https://index.docker.io/v1/",
+                            "username": {
+                                "from_secret": "docker_username",
+                            },
+                            "password": {
+                                "from_secret": "docker_password",
+                            },
+                        },
+                        {
+                            "registry": "https://quay.io",
+                            "username": {
+                                "from_secret": "quay_username",
+                            },
+                            "password": {
+                                "from_secret": "quay_password",
+                            },
+                        },
+                    ],
+                },
+            },
+            {
+                "name": "push-readme-dockerhub",
+                "image": PLUGINS_DOCKER_PUSHRM,
+                "environment": {
+                    "DOCKER_USER": {
+                        "from_secret": "docker_username",
+                    },
+                    "DOCKER_PASS": {
+                        "from_secret": "docker_password",
+                    },
+                    "PUSHRM_TARGET": "opencloudeu/yjs",
+                    "PUSHRM_SHORT": YJS_IMAGE_DESCRIPTION,
+                    "PUSHRM_FILE": "services/yjs/README.md",
+                },
+                "depends_on": ["build-and-push"],
+            },
+            {
+                "name": "push-readme-quayio",
+                "image": PLUGINS_DOCKER_PUSHRM,
+                "environment": {
+                    "APIKEY__QUAY_IO": {
+                        "from_secret": "quay_apikey",
+                    },
+                    "PUSHRM_TARGET": "quay.io/opencloudeu/yjs",
+                    "PUSHRM_SHORT": YJS_IMAGE_DESCRIPTION,
+                    "PUSHRM_FILE": "services/yjs/README.md",
+                },
+                "depends_on": ["build-and-push"],
+            },
+        ],
+        "when": [event["tag"]],
+    }]
 
 def readyReleaseGo():
     return [

--- a/dev/scripts/create_and_push_yjs_tag.sh
+++ b/dev/scripts/create_and_push_yjs_tag.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script creates and pushes the release tag for the yjs server image.
+# The yjs server has its own version, independent of the web app version.
+# Pushing the tag triggers the CI pipeline that builds and publishes the image.
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+VERSION=$(node -p "require('./services/yjs/package.json').version")
+TAG="yjs-v${VERSION}"
+
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+	echo "$TAG already exists locally"
+	exit 1
+fi
+
+if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+	echo "$TAG already exists on origin"
+	exit 1
+fi
+
+git tag -s -a "$TAG" -m "$TAG"
+git push origin "$TAG"
+
+echo "$TAG has been created and pushed"

--- a/services/yjs/package.json
+++ b/services/yjs/package.json
@@ -1,7 +1,6 @@
 {
   "name": "opencloud-yjs-server",
-  "version": "0.0.0",
-  "private": true,
+  "version": "1.0.0-rc.1",
   "description": "Yjs collaboration server (Hocuspocus) for OpenCloud Web",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bump the yjs server package to `v1.0.0-rc.1` and remove the private flag. Add a CI step running on tags like `yjs-v1.0.0` that builds the image and publishes it to the OpenCloud docker and quay.io registries.

Also add a script to create and publish the tag, since there currently is no automated trigger for this.

closes https://github.com/opencloud-eu/web/issues/3106