### PR TITLE
fix: safari file list performance

### DIFF
--- a/packages/web-app-admin-settings/src/components/AppTemplate.vue
+++ b/packages/web-app-admin-settings/src/components/AppTemplate.vue
@@ -41,7 +41,8 @@
                 </div>
                 <div
                   v-if="showBatchActions"
-                  class="flex flex-1 has-[_ul:first-child>*]:flex justify-between items-center px-3 h-9 rounded-xl has-[_ul:first-child>*]:bg-role-surface-container peer-[:not(:empty)]:absolute peer-[:not(:empty)]:inset-x-0 peer-[:not(:empty)]:top-1/2 peer-[:not(:empty)]:-translate-y-1/2"
+                  class="flex flex-1 justify-between items-center px-3 h-9 rounded-xl peer-[:not(:empty)]:absolute peer-[:not(:empty)]:inset-x-0 peer-[:not(:empty)]:top-1/2 peer-[:not(:empty)]:-translate-y-1/2"
+                  :class="{ 'bg-role-surface-container': batchActionItems.length }"
                 >
                   <batch-actions
                     v-if="showBatchActions"

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -53,7 +53,8 @@
         </div>
         <div
           v-if="showBatchActions"
-          class="flex flex-1 has-[_ul:first-child>*]:flex justify-between items-center px-3 h-9 rounded-xl has-[_ul:first-child>*]:bg-role-surface-container peer-[:not(:empty)]:absolute peer-[:not(:empty)]:inset-x-0 peer-[:not(:empty)]:top-1/2 peer-[:not(:empty)]:-translate-y-1/2"
+          class="flex flex-1 justify-between items-center px-3 h-9 rounded-xl peer-[:not(:empty)]:absolute peer-[:not(:empty)]:inset-x-0 peer-[:not(:empty)]:top-1/2 peer-[:not(:empty)]:-translate-y-1/2"
+          :class="{ 'bg-role-surface-container': batchActions.length }"
         >
           <BatchActions
             v-if="!batchActionsLoading"


### PR DESCRIPTION
Fix the bad file list performance in Safari be removing the complicated `has:` tailwind css classes in the wrapper for the batch actions. Apparently, Safari really struggles with them.

This also was the main issue for https://github.com/opencloud-eu/web/issues/3159 all along. Still, all the other performance improvements that resulted because of it were a good thing.

fixes https://github.com/opencloud-eu/web/issues/3159