### PR TITLE
fix: new button flickering during navigation

### DIFF
--- a/packages/web-app-files/src/components/CreateOrUploadMenu.vue
+++ b/packages/web-app-files/src/components/CreateOrUploadMenu.vue
@@ -13,7 +13,10 @@
       :class="areFileExtensionsShown ? 'sm:min-w-xs' : null"
       class="py-2 sm:first:pt-0 sm:last:pb-0"
     >
-      <li>
+      <li v-if="!currentFolder" class="flex justify-center items-center my-2">
+        <oc-spinner :aria-label="$gettext('Loading actions')" />
+      </li>
+      <li v-else>
         <oc-button
           id="new-folder-btn"
           class="w-full"

--- a/packages/web-app-files/src/extensions.ts
+++ b/packages/web-app-files/src/extensions.ts
@@ -10,6 +10,7 @@ import {
   useRouter,
   useSearch,
   useSpaceActionsCreate,
+  useSpacesStore,
   useUserStore
 } from '@opencloud-eu/web-pkg'
 import { computed, markRaw, unref } from 'vue'
@@ -20,7 +21,7 @@ import { useVaultIndicator } from './composables/extensions/useVaultIndicator'
 import { useFileActions } from './composables/extensions/useFileActions'
 import { useSpaceActions } from './composables/extensions/useSpaceActions'
 import { useUploadActions } from './composables/extensions/useUploadActions'
-import { urlJoin } from '@opencloud-eu/web-client'
+import { isPublicSpaceResource, SharePermissionBit, urlJoin } from '@opencloud-eu/web-client'
 import { useGettext } from 'vue3-gettext'
 import { storeToRefs } from 'pinia'
 import CreateOrUploadMenu from './components/CreateOrUploadMenu.vue'
@@ -30,8 +31,8 @@ export const extensions = (appInfo: ApplicationInformation) => {
   const capabilityStore = useCapabilityStore()
   const configStore = useConfigStore()
   const userStore = useUserStore()
-  const resourcesStore = useResourcesStore()
-  const { currentFolder } = storeToRefs(resourcesStore)
+  const { currentFolder } = storeToRefs(useResourcesStore())
+  const { currentSpace } = storeToRefs(useSpacesStore())
   const router = useRouter()
   const { search: searchFunction } = useSearch()
   const { $gettext } = useGettext()
@@ -76,6 +77,19 @@ export const extensions = (appInfo: ApplicationInformation) => {
           unref(createSpaceAction).isVisible()
         ) {
           return false
+        }
+
+        // permission checks on the space are preferred over the current folder,
+        // as the current folder resets on every navigation, causing a button flicker.
+        const space = unref(currentSpace)
+        if (space) {
+          if (!isPublicSpaceResource(space)) {
+            return space.canUpload({ user: userStore.user }) !== true
+          }
+          // public spaces have no graph permissions, check link permission
+          if (space.publicLinkPermission !== undefined) {
+            return !(space.publicLinkPermission & SharePermissionBit.Create)
+          }
         }
 
         return !unref(currentFolder)?.canUpload({ user: userStore.user })

--- a/packages/web-app-files/src/extensions.ts
+++ b/packages/web-app-files/src/extensions.ts
@@ -4,6 +4,7 @@ import {
   FloatingActionButtonExtension,
   isLocationPublicActive,
   isLocationSpacesActive,
+  isLocationTrashActive,
   useCapabilityStore,
   useConfigStore,
   useResourcesStore,
@@ -77,6 +78,10 @@ export const extensions = (appInfo: ApplicationInformation) => {
           unref(createSpaceAction).isVisible()
         ) {
           return false
+        }
+
+        if (isLocationTrashActive(router, 'files-trash-generic')) {
+          return true
         }
 
         // permission checks on the space are preferred over the current folder,

--- a/packages/web-app-files/src/views/spaces/DriveResolver.vue
+++ b/packages/web-app-files/src/views/spaces/DriveResolver.vue
@@ -23,7 +23,8 @@ import {
   isLocationTrashActive,
   useLinkTargetRoute,
   locationPublicUpload,
-  AppLoadingSpinner
+  AppLoadingSpinner,
+  useSpacesStore
 } from '@opencloud-eu/web-pkg'
 import {
   isPublicSpaceResource,
@@ -41,6 +42,7 @@ const isTrashRoute = useActiveLocation(isLocationTrashActive, 'files-trash-gener
 const { item, itemId, space } = useDriveResolver({ driveAliasAndItem })
 const { getInternalSpace } = useGetMatchingSpace()
 const { getLinkTargetRoute } = useLinkTargetRoute()
+const { updateSpaceField } = useSpacesStore()
 
 const loading = ref(true)
 
@@ -121,6 +123,11 @@ onMounted(async () => {
      **/
     if (unref(space).fileId === unref(space).id) {
       const publicSpace = (await getSpaceResource()) as PublicSpaceResource
+      updateSpaceField<PublicSpaceResource>({
+        id: unref(space).id,
+        field: 'publicLinkPermission',
+        value: publicSpace.publicLinkPermission
+      })
 
       // FIXME: check for type when server sends public-link-permission dav property
       if (publicSpace.publicLinkPermission === SharePermissionBit.Create) {

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -82,8 +82,8 @@ export function buildPublicSpaceResource(
   const publicLinkShareOwner = data.props?.[DavProperty.PublicLinkShareOwner]
   const publicLinkType = data.publicLinkType
 
-  let driveAlias
-  let webDavPath
+  let driveAlias: string
+  let webDavPath: string
   if (publicLinkType === 'ocm') {
     driveAlias = `ocm/${data.id}`
     webDavPath = buildWebDavOcmPath(data.id)

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -704,6 +704,7 @@ const isAppProviderServiceForOfficeSuitesReadyInWebUI = async (page: Page, type:
   let retry = 1
   let isCreateNewOfficeDocumentFileButtonVisible
   while (retry <= 5) {
+    await page.locator(createNewFolderButton).waitFor()
     isCreateNewOfficeDocumentFileButtonVisible = await page
       .locator(util.format(createNewOfficeDocumentFileBUtton, type))
       .isVisible()


### PR DESCRIPTION
Do the permission checks of the FAB on the space instead of the current folder. A space stays stable while navigating its folders, so this makes the FAB not flicker during navigation.

fixes https://github.com/opencloud-eu/web/issues/3289