### PR TITLE
Editor: Add Default font-size reset and simplify zoom styling

### DIFF
--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -1,5 +1,6 @@
 import { computed, markRaw, ref, unref } from 'vue'
 import type { Component } from 'vue'
+import { getMarksBetween } from '@tiptap/core'
 import type { Editor, Range } from '@tiptap/core'
 import { useGettext } from 'vue3-gettext'
 import { storeToRefs } from 'pinia'
@@ -188,14 +189,24 @@ export function useEditorActions(state: TextEditorState) {
         title: $gettext('Default'),
         icon: 'font-size-2',
         toolbarAction: (editor) => editor.chain().focus().unsetFontSize().run(),
-        isActive: (editor) => !editor.getAttributes('textStyle').fontSize
+        isActive: (editor) => {
+          const { from, to, empty } = editor.state.selection
+          if (empty || from === to) {
+            return !editor.getAttributes('textStyle').fontSize
+          }
+
+          // For mixed font sizes in a range selection, no option should be active, including "Default".
+          return !getMarksBetween(from, to, editor.state.doc).some(
+            ({ mark }) => mark.type.name === 'textStyle' && !!mark.attrs.fontSize
+          )
+        }
       },
       ...['12px', '14px', '16px', '18px', '20px', '24px', '28px', '32px'].map((size) => ({
         id: `font-size-${size}`,
         title: size,
         icon: 'font-size-2',
         toolbarAction: (editor: Editor) => editor.chain().focus().setFontSize(size).run(),
-        isActive: (editor: Editor) => editor.getAttributes('textStyle').fontSize === size
+        isActive: (editor: Editor) => editor.isActive('textStyle', { fontSize: size })
       }))
     ]
   })

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -182,13 +182,22 @@ export function useEditorActions(state: TextEditorState) {
     title: $gettext('Font size'),
     icon: 'font-size-2',
     showInSlashCommands: false,
-    childActions: ['12px', '14px', '16px', '18px', '20px', '24px', '28px', '32px'].map((size) => ({
-      id: `font-size-${size}`,
-      title: size,
-      icon: 'font-size-2',
-      toolbarAction: (editor) => editor.chain().focus().setFontSize(size).run(),
-      isActive: (editor) => editor.getAttributes('textStyle').fontSize === size
-    }))
+    childActions: [
+      {
+        id: 'font-size-default',
+        title: $gettext('Default'),
+        icon: 'font-size-2',
+        toolbarAction: (editor) => editor.chain().focus().unsetFontSize().run(),
+        isActive: (editor) => !editor.getAttributes('textStyle').fontSize
+      },
+      ...['12px', '14px', '16px', '18px', '20px', '24px', '28px', '32px'].map((size) => ({
+        id: `font-size-${size}`,
+        title: size,
+        icon: 'font-size-2',
+        toolbarAction: (editor) => editor.chain().focus().setFontSize(size).run(),
+        isActive: (editor) => editor.getAttributes('textStyle').fontSize === size
+      }))
+    ]
   })
 
   const alignLeft = (): EditorAction => ({

--- a/packages/web-pkg/src/editor/composables/useEditorActions.ts
+++ b/packages/web-pkg/src/editor/composables/useEditorActions.ts
@@ -194,8 +194,8 @@ export function useEditorActions(state: TextEditorState) {
         id: `font-size-${size}`,
         title: size,
         icon: 'font-size-2',
-        toolbarAction: (editor) => editor.chain().focus().setFontSize(size).run(),
-        isActive: (editor) => editor.getAttributes('textStyle').fontSize === size
+        toolbarAction: (editor: Editor) => editor.chain().focus().setFontSize(size).run(),
+        isActive: (editor: Editor) => editor.getAttributes('textStyle').fontSize === size
       }))
     ]
   })

--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -23,8 +23,9 @@
   border: none;
   margin: 0 auto;
   padding: 0;
-  font-size: calc(15px * var(--text-editor-zoom-factor));
+  font-size: 15px;
   line-height: 1.6;
+  zoom: var(--text-editor-zoom-factor);
 }
 
 .text-editor-content .ProseMirror:focus,
@@ -76,19 +77,19 @@
 }
 
 .text-editor-content .ProseMirror h1 {
-  font-size: calc(30px * var(--text-editor-zoom-factor));
+  font-size: 30px;
 }
 
 .text-editor-content .ProseMirror h2 {
-  font-size: calc(24px * var(--text-editor-zoom-factor));
+  font-size: 24px;
 }
 
 .text-editor-content .ProseMirror h3 {
-  font-size: calc(20px * var(--text-editor-zoom-factor));
+  font-size: 20px;
 }
 
 .text-editor-content .ProseMirror h4 {
-  font-size: calc(17px * var(--text-editor-zoom-factor));
+  font-size: 17px;
 }
 
 .text-editor-content .ProseMirror a {
@@ -134,13 +135,14 @@
 }
 
 .text-editor-content textarea {
-  font-size: calc(15px * var(--text-editor-zoom-factor));
+  font-size: 15px;
   line-height: 1.6;
+  zoom: var(--text-editor-zoom-factor);
 }
 
 /* Codeblock styles */
 .text-editor-content .ProseMirror pre {
-  font-size: calc(14px * var(--text-editor-zoom-factor));
+  font-size: 14px;
   background: var(--oc-role-surface-container-high);
   padding: 8px 12px;
   border-radius: 6px;
@@ -150,7 +152,7 @@
 
 /* Inline code styles */
 .text-editor-content .ProseMirror :not(pre) > code {
-  font-size: calc(13px * var(--text-editor-zoom-factor));
+  font-size: 13px;
   padding: 2px 4px;
   border-radius: 6px;
   background: var(--oc-role-surface-container-high);
@@ -169,7 +171,7 @@
   border-radius: 6px;
   background: var(--oc-role-surface-container-high);
   color: var(--oc-role-on-surface-variant);
-  font-size: calc(13px * var(--text-editor-zoom-factor));
+  font-size: 13px;
 }
 
 .text-editor-content .ProseMirror .text-editor-frontmatter pre {

--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -76,22 +76,6 @@
   font-weight: 600;
 }
 
-.text-editor-content .ProseMirror h1 {
-  font-size: 30px;
-}
-
-.text-editor-content .ProseMirror h2 {
-  font-size: 24px;
-}
-
-.text-editor-content .ProseMirror h3 {
-  font-size: 20px;
-}
-
-.text-editor-content .ProseMirror h4 {
-  font-size: 17px;
-}
-
 .text-editor-content .ProseMirror a {
   color: var(--oc-role-primary);
   text-decoration: underline;

--- a/packages/web-pkg/src/editor/styles/text-editor.css
+++ b/packages/web-pkg/src/editor/styles/text-editor.css
@@ -67,15 +67,6 @@
   margin: 0 0 8px;
 }
 
-.text-editor-content .ProseMirror h1,
-.text-editor-content .ProseMirror h2,
-.text-editor-content .ProseMirror h3,
-.text-editor-content .ProseMirror h4 {
-  margin: 0 0 8px;
-  line-height: 1.25;
-  font-weight: 600;
-}
-
 .text-editor-content .ProseMirror a {
   color: var(--oc-role-primary);
   text-decoration: underline;
@@ -120,7 +111,6 @@
 
 .text-editor-content textarea {
   font-size: 15px;
-  line-height: 1.6;
   zoom: var(--text-editor-zoom-factor);
 }
 

--- a/packages/web-pkg/tests/unit/editor/composables/helpers.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/helpers.ts
@@ -72,6 +72,7 @@ export function createMockEditor(options: MockEditorOptions = {}) {
       'insertTable',
       'setFontFamily',
       'setFontSize',
+      'unsetFontSize',
       'setLineHeight',
       'setColor',
       'unsetColor',

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -250,7 +250,7 @@ describe('useEditorActions', () => {
                   )!
                 : name === 'fontSize'
                   ? actions[name]().childActions!.find(({ id }) => id !== 'font-size-default')!
-                : actions[name]().childActions![0]
+                  : actions[name]().childActions![0]
           childAction.toolbarAction!(editor)
           expect(editor._chain[setMethod]).toHaveBeenCalled()
         })

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -228,7 +228,10 @@ describe('useEditorActions', () => {
 
         if (valueIsTitle) {
           it('child isActive reads from editor.getAttributes("textStyle")', () => {
-            const child = actions[name]().childActions![0]
+            const child =
+              name === 'fontSize'
+                ? actions[name]().childActions!.find(({ id }) => id === 'font-size-16px')!
+                : actions[name]().childActions![0]
             const editor = createMockEditor({
               attributes: { textStyle: { [attrKey]: child.title } }
             })
@@ -245,6 +248,8 @@ describe('useEditorActions', () => {
                 ? actions[name]().childActions!.find(
                     ({ id }) => id !== 'background-color-transparent'
                   )!
+                : name === 'fontSize'
+                  ? actions[name]().childActions!.find(({ id }) => id !== 'font-size-default')!
                 : actions[name]().childActions![0]
           childAction.toolbarAction!(editor)
           expect(editor._chain[setMethod]).toHaveBeenCalled()
@@ -287,6 +292,24 @@ describe('useEditorActions', () => {
       expect(
         noneAction!.isActive!(
           createMockEditor({ attributes: { textStyle: { backgroundColor: '#e60000' } } })
+        )
+      ).toBe(false)
+    })
+
+    it('fontSize has a default entry that resets font size', () => {
+      const editor = createMockEditor()
+      const action = actions.fontSize()
+      const defaultAction = action.childActions!.find(({ id }) => id === 'font-size-default')
+
+      expect(defaultAction).toBeDefined()
+      defaultAction!.toolbarAction!(editor)
+      expect(editor._chain.unsetFontSize).toHaveBeenCalled()
+      expect(defaultAction!.isActive!(createMockEditor({ attributes: { textStyle: {} } }))).toBe(
+        true
+      )
+      expect(
+        defaultAction!.isActive!(
+          createMockEditor({ attributes: { textStyle: { fontSize: '16px' } } })
         )
       ).toBe(false)
     })

--- a/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts
@@ -2,6 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ref } from 'vue'
 import type { Range } from '@tiptap/core'
 import { Editor } from '@tiptap/vue-3'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import StarterKit from '@tiptap/starter-kit'
 import { mock } from 'vitest-mock-extended'
 import { createMockEditor } from './helpers'
@@ -208,7 +209,7 @@ describe('useEditorActions', () => {
     }
 
     const dropdownActions = [
-      { name: 'fontSize', setMethod: 'setFontSize', attrKey: 'fontSize', valueIsTitle: true },
+      { name: 'fontSize', setMethod: 'setFontSize', attrKey: 'fontSize', valueIsTitle: false },
       { name: 'lineHeight', setMethod: 'setLineHeight', attrKey: 'lineHeight', valueIsTitle: true },
       { name: 'textColor', setMethod: 'setColor', attrKey: 'color', valueIsTitle: false },
       {
@@ -228,10 +229,7 @@ describe('useEditorActions', () => {
 
         if (valueIsTitle) {
           it('child isActive reads from editor.getAttributes("textStyle")', () => {
-            const child =
-              name === 'fontSize'
-                ? actions[name]().childActions!.find(({ id }) => id === 'font-size-16px')!
-                : actions[name]().childActions![0]
+            const child = actions[name]().childActions![0]
             const editor = createMockEditor({
               attributes: { textStyle: { [attrKey]: child.title } }
             })
@@ -312,6 +310,39 @@ describe('useEditorActions', () => {
           createMockEditor({ attributes: { textStyle: { fontSize: '16px' } } })
         )
       ).toBe(false)
+    })
+
+    it('fontSize option isActive delegates to editor.isActive', () => {
+      const option = actions.fontSize().childActions!.find(({ id }) => id === 'font-size-16px')
+      const editor = createMockEditor({
+        isActive: (type, attrs) => type === 'textStyle' && attrs?.fontSize === '16px'
+      })
+
+      expect(option).toBeDefined()
+      expect(option!.isActive!(editor)).toBe(true)
+      expect(editor.isActive).toHaveBeenCalledWith('textStyle', { fontSize: '16px' })
+    })
+
+    it('fontSize has no active option for mixed selection', () => {
+      const editor = createMockEditor({ attributes: { textStyle: {} }, isActive: () => false })
+      const action = actions.fontSize()
+
+      Object.assign(editor.state.selection, { from: 1, to: 6, empty: false })
+      Object.assign(editor.state.doc, {
+        nodesBetween: (_from: number, _to: number, callback: (node: ProseMirrorNode) => void) => {
+          callback({ isText: true, nodeSize: 1, marks: [] } as unknown as ProseMirrorNode)
+          callback({
+            isText: true,
+            nodeSize: 1,
+            marks: [{ type: { name: 'textStyle' }, attrs: { fontSize: '16px' } }]
+          } as unknown as ProseMirrorNode)
+        }
+      })
+
+      const activeStates = action.childActions!.map(
+        (childAction) => childAction.isActive?.(editor) ?? false
+      )
+      expect(activeStates).toEqual(Array(action.childActions!.length).fill(false))
     })
   })
 


### PR DESCRIPTION
## Description

This bugfix improves text-size handling and simplifies zoom behavior in the text editor:

### Font-size management
- Adds a `Default` option to the font size dropdown so users can remove explicit font-size formatting and return to inherited sizing.
- Fixes incorrect active-state handling for mixed font-size selections: previously one size could appear active even when multiple sizes were selected. Now no size is shown as active (including `Default`) in that case, which should be self-explanatory.

### Zooming
- Fixes zoom not working when font size is set manually.
- Simplifies zoom styling by applying zoom centrally instead of maintaining per-element or special-case font-size scaling logic.
- Reduces CSS complexity and lowers the risk of regressions from case-by-case font-size overrides.

_Trade-off: because editor zoom is not a standard text-editing feature, the editor container can grow or shrink dynamically with zoom levels.
Let's accept this trade-off because the centralized approach is simpler and more robust overall, and the benefits outweigh this downside._

## Related Issue

- Fixes N/A

## How Has This Been Tested?

- test environment: local development environment (Vitest)
- test case 1: `node_modules/.bin/vitest run --config tests/unit/config/vitest.config.ts packages/web-pkg/tests/unit/editor/composables/useEditorActions.spec.ts`
- test case 2: verified updated unit coverage for new `font-size-default` action behavior
- test case 3: verified mixed font-size selection shows no active font-size option
- test case 4: reviewed CSS zoom simplification diff for removal of per-rule scaling complexity

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [x] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
