### PR TITLE
fix: prevent browser login dialog on upload

### DIFF
--- a/packages/web-pkg/src/composables/upload/useUpload.ts
+++ b/packages/web-pkg/src/composables/upload/useUpload.ts
@@ -38,6 +38,8 @@ export function useUpload(options: UploadOptions) {
     headers['X-Request-ID'] = uuidV4()
     headers['Accept-Language'] = language.current
     headers['Initiator-ID'] = clientService.initiatorId
+    // tells the server to not send a `Www-Authenticate` header, which would trigger the browser's native login dialog
+    headers['X-Requested-With'] = 'XMLHttpRequest'
     return headers
   }
 
@@ -50,6 +52,7 @@ export function useUpload(options: UploadOptions) {
           req.setHeader('X-Request-ID', headers['X-Request-ID'])
           req.setHeader('Accept-Language', headers['Accept-Language'])
           req.setHeader('Initiator-ID', headers['Initiator-ID'])
+          req.setHeader('X-Requested-With', headers['X-Requested-With'])
           if (file?.isRemote) {
             req.setHeader('x-oc-mtime', ((file?.data as File)?.lastModified / 1000).toFixed(0))
           }


### PR DESCRIPTION
Uploads via tus/XHR did not send `X-Requested-With: XMLHttpRequest`, so the server answered an expired token with a `Www-Authenticate` header. That triggers the browser's native login dialog.

This surfaced during research for https://github.com/opencloud-eu/web/issues/3282