### PR TITLE
fix: defer sidebar actions until resource loads

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
@@ -41,6 +41,10 @@ const { actions: deleteActions } = useFileActionsDelete()
 const { actions: restoreActions } = useFileActionsRestore()
 
 const actions = computed(() => {
+  if (!unref(resource)) {
+    return []
+  }
+
   const options = {
     space: unref(space),
     resources: unref(resources),

--- a/packages/web-app-files/tests/unit/components/SideBar/Actions/FileActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Actions/FileActions.spec.ts
@@ -93,11 +93,25 @@ describe('FileActions', () => {
           expect(wrapper.find(fileActions[action].selector).exists()).toBeTruthy()
         }
       })
+
+      it('skips action resolution while the resource is loading', () => {
+        const getAllOpenWithActions = vi.fn(() => [])
+        vi.mocked(useFileActions).mockImplementation(() =>
+          mock<ReturnType<typeof useFileActions>>({ getAllOpenWithActions })
+        )
+        vi.mocked(useExtensionRegistry).mockImplementation(() =>
+          mock<ReturnType<typeof useExtensionRegistry>>({ requestExtensions: () => [] })
+        )
+
+        getWrapper(null)
+
+        expect(getAllOpenWithActions).not.toHaveBeenCalled()
+      })
     })
   })
 })
 
-function getWrapper() {
+function getWrapper(resource: Resource = mock<Resource>({ extension: 'md' })) {
   const mocks = defaultComponentMocks({
     currentRoute: mock<RouteLocation>({
       name: 'files-spaces-generic',
@@ -113,9 +127,7 @@ function getWrapper() {
         stubs: { ...defaultStubs, OcButton: false },
         provide: {
           space: mock<SpaceResource>(),
-          resource: mock<Resource>({
-            extension: 'md'
-          }),
+          resource,
           ...mocks
         }
       }


### PR DESCRIPTION
## Description

The Actions panel can stay mounted while the sidebar switches resources. During that gap it resolves actions with a null resource and can throw before the shares selection finishes loading.

Return no actions until the resource is available. A regression test covers the loading state.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3297

## How Has This Been Tested?

- test environment: Node 24.20.0, pnpm 11.25.0
- test case 1: FileActions unit suite (3 passed)
- test case 2: full unit suite (3,916 passed, 6 skipped, 11 todo)
- test case 3: type checks, lint, formatting, and production build

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
