### PR TITLE
fix: load indirect shares in editors

### DIFF
--- a/packages/web-pkg/src/composables/shares/useLoadShares.ts
+++ b/packages/web-pkg/src/composables/shares/useLoadShares.ts
@@ -163,7 +163,11 @@ export const useLoadShares = () => {
       })
     }
 
-    if (includeInheritedShares || isLocationCommonActive(router, 'files-common-search')) {
+    if (
+      includeInheritedShares ||
+      isLocationCommonActive(router, 'files-common-search') ||
+      !resourcesStore.currentFolder
+    ) {
       yield resourcesStore.loadAncestorMetaData({
         folder: unref(resource),
         space,

--- a/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
@@ -164,9 +164,15 @@ describe('FileSideBar', () => {
       ).toHaveBeenCalledTimes(2)
     })
 
-    it('should load ancestor meta data to get indirect shares when on search page', async () => {
+    it.each([
+      [
+        'on the search page',
+        { currentRouteName: 'files-common-search', currentFolder: mock<Resource>() }
+      ],
+      ['when the current folder is not loaded', { currentFolder: null }]
+    ])('loads ancestor meta data for indirect shares %s', async (_, options) => {
       const resource = mock<Resource>()
-      const { wrapper, mocks } = createWrapper({ currentRouteName: 'files-common-search' })
+      const { wrapper, mocks } = createWrapper(options)
       const { loadAncestorMetaData } = useResourcesStore()
 
       mocks.$clientService.graphAuthenticated.permissions.listPermissions.mockResolvedValue({
@@ -177,6 +183,20 @@ describe('FileSideBar', () => {
 
       await (wrapper.vm as any).loadSharesTask.perform({ resource })
       expect(loadAncestorMetaData).toHaveBeenCalled()
+    })
+    it('does not load ancestor meta data when the current folder is loaded', async () => {
+      const resource = mock<Resource>()
+      const { wrapper, mocks } = createWrapper({ currentFolder: mock<Resource>() })
+      const { loadAncestorMetaData } = useResourcesStore()
+
+      mocks.$clientService.graphAuthenticated.permissions.listPermissions.mockResolvedValue({
+        shares: [],
+        allowedActions: [],
+        allowedRoles: []
+      })
+
+      await (wrapper.vm as any).loadSharesTask.perform({ resource })
+      expect(loadAncestorMetaData).not.toHaveBeenCalled()
     })
 
     it('loads inherited shares and project space members when explicitly requested', async () => {
@@ -303,9 +323,19 @@ function createWrapper({
   item = undefined,
   isOpen = true,
   currentRouteName = 'files-spaces-generic',
+  currentFolder = undefined,
   space = undefined
-}: { item?: Resource; isOpen?: boolean; currentRouteName?: string; space?: SpaceResource } = {}) {
+}: {
+  item?: Resource
+  isOpen?: boolean
+  currentRouteName?: string
+  currentFolder?: Resource
+  space?: SpaceResource
+} = {}) {
   const plugins = defaultPlugins()
+
+  const resourcesStore = useResourcesStore()
+  resourcesStore.currentFolder = currentFolder
 
   const { requestExtensions } = useExtensionRegistry()
   vi.mocked(requestExtensions).mockReturnValue([])


### PR DESCRIPTION
## Description

Editor routes load files without the folder loader, so ancestor metadata stays empty. The sharing sidebar then has no ancestor IDs from which to load indirect shares.

Load ancestor metadata when the share loader runs inside an editor. The regression test covers both search and editor routes.

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/3298

## How Has This Been Tested?

- test environment: Node 24.20.0, pnpm 11.25.0
- test case 1: FileSideBar unit suite (19 passed)
- test case 2: full unit suite (3,916 passed, 6 skipped, 11 todo)
- test case 3: type checks, lint, formatting, and production build

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
