### PR TITLE
fix(tests): authenticate basic auth requests with the username

### DIFF
--- a/tests/e2e/support/api/http.ts
+++ b/tests/e2e/support/api/http.ts
@@ -7,7 +7,7 @@ import { TokenEnvironmentFactory } from '../environment'
 export const getAuthHeader = (user: User, isKeycloakRequest: boolean = false) => {
   const tokenEnvironment = TokenEnvironmentFactory(isKeycloakRequest ? 'keycloak' : null)
   const authHeader = {
-    Authorization: 'Basic ' + Buffer.from(user.id + ':' + user.password).toString('base64')
+    Authorization: 'Basic ' + Buffer.from(user.username + ':' + user.password).toString('base64')
   }
 
   if (!appConfig.basicAuth) {


### PR DESCRIPTION
Running the e2e suite with `BASIC_AUTH=true` fails for every created user: the API setup steps get a 401 and the server logs `could not authenticate with username and password user: Alice, got code: 6`.

`getAuthHeader` builds the basic credential from `user.id`, but that is only the key the steps address a user by. The create-user step builds `{ id: 'Alice', username: 'Alice-<run prefix>' }` and creates the account under `username`, which becomes `onPremisesSamAccountName` and ends up as the LDAP `uid`, the attribute basic auth logs in with (`AUTH_BASIC_LDAP_LOGIN_ATTRIBUTES` defaults to `uid`).

`username` is required on the `User` type and set everywhere users are built, so admin and the other dummy users are unaffected: their `id` and `username` are identical.

Draft because it has only been exercised against a local backend so far.