### PR TITLE
fix: send mtime metadata for public link uploads

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -145,6 +145,8 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
         file[this.getUploadPluginName()] = { endpoint }
         file.meta = {
           ...file.meta,
+          name: file.name,
+          mtime: (file.data as File).lastModified / 1000,
           tusEndpoint: endpoint,
           uploadId: uuidV4(),
           isFolder: file.type === 'directory'

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -92,6 +92,24 @@ describe('HandleUpload', () => {
 
       expect(processedFiles[0].meta.relativeFolder).toEqual(`/${fileToUpload.name}`)
     })
+    it('sets name and mtime meta for public file drop uploads', () => {
+      const { instance, mocks } = getWrapper()
+      mocks.uppy.getPlugin.mockReturnValue(mock<UppyPlugin>())
+      mocks.opts.resourcesStore.currentFolder = null
+      unref(mocks.opts.route).params.token = 'public-token'
+      mocks.opts.clientService.webdav.getPublicFileUrl.mockReturnValue('https://public/')
+
+      const lastModified = 1_700_000_000_000
+      const fileToUpload = mock<OcUppyFile>({
+        name: 'name',
+        data: { lastModified } as File
+      })
+      const uploadFolder = mock<Resource>({ id: '1', path: '/' })
+      const processedFiles = instance.prepareFiles([fileToUpload], uploadFolder)
+
+      expect(processedFiles[0].meta.name).toEqual(fileToUpload.name)
+      expect(processedFiles[0].meta.mtime).toEqual(lastModified / 1000)
+    })
   })
   describe('method createDirectoryTree', () => {
     it('creates a directory for a single file with a relative folder given', async () => {


### PR DESCRIPTION
fixes https://github.com/opencloud-eu/opencloud/issues/3410

before: 

<img width="1448" height="836" alt="Screenshot 2026-09-07 at 11 01 45" src="https://github.com/user-attachments/assets/85bd88da-130b-48e4-b0da-cd76d98d5795" />


after fix: 
<img width="1003" height="433" alt="Screenshot 2026-09-07 at 11 09 51" src="https://github.com/user-attachments/assets/ae634c29-ab4d-4c57-b9bb-779b1b2de2da" />
