### PR TITLE
[stable-7.1] fix: send mtime metadata for public link uploads (#3322)

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -137,6 +137,8 @@ export class HandleUpload extends BasePlugin<PluginOpts, OcUppyMeta, OcUppyBody>
         file[this.getUploadPluginName()] = { endpoint }
         file.meta = {
           ...file.meta,
+          name: file.name,
+          mtime: (file.data as File).lastModified / 1000,
           tusEndpoint: endpoint,
           uploadId: uuidV4(),
           isFolder: file.type === 'directory'

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -84,6 +84,24 @@ describe('HandleUpload', () => {
 
       expect(processedFiles[0].meta.relativeFolder).toEqual(`/${fileToUpload.name}`)
     })
+    it('sets name and mtime meta for public file drop uploads', () => {
+      const { instance, mocks } = getWrapper()
+      mocks.uppy.getPlugin.mockReturnValue(mock<UppyPlugin>())
+      mocks.opts.resourcesStore.currentFolder = null
+      unref(mocks.opts.route).params.token = 'public-token'
+      mocks.opts.clientService.webdav.getPublicFileUrl.mockReturnValue('https://public/')
+
+      const lastModified = 1_700_000_000_000
+      const fileToUpload = mock<OcUppyFile>({
+        name: 'name',
+        data: { lastModified } as File
+      })
+      const uploadFolder = mock<Resource>({ id: '1', path: '/' })
+      const processedFiles = instance.prepareFiles([fileToUpload], uploadFolder)
+
+      expect(processedFiles[0].meta.name).toEqual(fileToUpload.name)
+      expect(processedFiles[0].meta.mtime).toEqual(lastModified / 1000)
+    })
   })
   describe('method createDirectoryTree', () => {
     it('creates a directory for a single file with a relative folder given', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-7.1`:
 - [fix: send mtime metadata for public link uploads (#3322)](https://github.com/opencloud-eu/web/pull/3322)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)