### PR TITLE
fix: stop re-fetching resources in AppWrapper on every context change

### DIFF
--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -457,7 +457,10 @@ const loadFileTask = useTask(function* (signal) {
 }).restartable()
 
 watch(
-  currentFileContext,
+  () => {
+    const ctx = unref(currentFileContext)
+    return `${ctx.path}::${ctx.itemId ?? ''}`
+  },
   async () => {
     if (!unref(noResourceLoading)) {
       // Reset for the new file: `resource` swaps well before the matching


### PR DESCRIPTION
Previously, the `AppWrapper` component re-fetched the current resource every time `currentFileContext` changed, which also included route changes. Bind the watcher on `path::fileId` to ensure this only happens when a file actually changes.

The issue surfaced with the presentation viewer app, also see https://github.com/JankariTech/web-app-presentation-viewer/pull/149