### PR TITLE
🎉 Release 7.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [7.1.6](https://github.com/opencloud-eu/web/releases/tag/v7.1.6) - 2026-09-08
+
+### ❤️ Thanks to all contributors! ❤️
+
+@v-scharf
+
+### 🐛 Bug Fixes
+
+- [stable-7.1] fix: send mtime metadata for public link uploads (#3322) [[#3323](https://github.com/opencloud-eu/web/pull/3323)]
+
 ## [7.1.5](https://github.com/opencloud-eu/web/releases/tag/v7.1.5) - 2026-08-20
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `7.1.6` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-7.1` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [7.1.6](https://github.com/opencloud-eu/web/releases/tag/v7.1.6) - 2026-09-08

### 🐛 Bug Fixes

- [stable-7.1] fix: send mtime metadata for public link uploads (#3322) [[#3323](https://github.com/opencloud-eu/web/pull/3323)]