### PR TITLE
test(e2e): repeat the global search while waiting for an indexed result

### DIFF
--- a/tests/e2e/environment/world.ts
+++ b/tests/e2e/environment/world.ts
@@ -1,6 +1,13 @@
 import { appConfig } from '../playwright.config'
 import { environment } from '../support'
 import { state } from './shared'
+import { searchFilter } from '../support/objects/app-files/resource/actions'
+
+export interface GlobalSearch {
+  keyword: string
+  filter: searchFilter
+  pressEnter: boolean
+}
 
 export class World {
   actorsEnvironment: environment.ActorsEnvironment
@@ -11,6 +18,7 @@ export class World {
   uniquePrefix: string
   a11yEnabled: boolean = false
   tags: string[] = []
+  lastGlobalSearch: Record<string, GlobalSearch> = {}
 
   constructor() {
     this.usersEnvironment = new environment.UsersEnvironment()

--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -386,6 +386,8 @@ Then(
   }
 )
 
+const searchIndexTimeout = 40 * 1000
+
 When(
   /^"([^"]*)" searches "([^"]*)" using the global search(?: and the "([^"]*)" filter)?( and presses enter)?$/,
   async (
@@ -399,6 +401,7 @@ When(
     const pressEnter = !!command && command.endsWith('presses enter')
     const { page } = world.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })
+    world.lastGlobalSearch[stepUser] = { keyword, filter: filter as searchFilter, pressEnter }
     await resourceObject.searchResource({
       keyword,
       filter: filter as searchFilter,
@@ -502,9 +505,16 @@ Then(
     const resourceObject = new objects.applicationFiles.Resource({ page })
     for (const info of stepTable.hashes()) {
       if (actionType === 'should') {
-        await expect(resourceObject.getResourceSearchItemLocator(info.resource)).toBeVisible({
-          timeout: appConfig.timeout * 1000
-        })
+        const lastSearch = world.lastGlobalSearch[stepUser]
+        let attempt = 0
+        await expect(async () => {
+          if (attempt++ > 0 && lastSearch) {
+            await resourceObject.searchResource(lastSearch)
+          }
+          await expect(resourceObject.getResourceSearchItemLocator(info.resource)).toBeVisible({
+            timeout: appConfig.minTimeout * 1000
+          })
+        }).toPass({ timeout: searchIndexTimeout })
       } else {
         await expect(resourceObject.getResourceSearchItemLocator(info.resource)).not.toBeVisible()
       }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1919,7 +1919,6 @@ export const searchResourceGlobalSearch = async (
   const { page, keyword, filter, pressEnter, keyboardShortcut } = args
   const searchInputLocator = page.locator(globalSearchInput)
 
-  // .reload() waits nicely for search indexing to be finished
   await page.reload()
 
   // select the filter if provided
@@ -1943,8 +1942,6 @@ export const searchResourceGlobalSearch = async (
     return
   }
 
-  // wait for tika indexing
-  await new Promise((resolve) => setTimeout(resolve, 500))
   const waitResponse = page.waitForResponse(
     (resp) => resp.status() === 207 && resp.request().method() === 'REPORT'
   )

--- a/tests/e2e/support/objects/app-files/search/actions.ts
+++ b/tests/e2e/support/objects/app-files/search/actions.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import util from 'util'
 
 const searchResultMessageSelector = '//p[@class="text-role-on-surface-variant"]'
@@ -28,7 +28,16 @@ export const selectTagFilter = async ({
   tag: string
   page: Page
 }): Promise<void> => {
-  await page.locator(selectTagDropdownSelector).click()
+  const dropdown = page.locator(selectTagDropdownSelector)
+  let attempt = 0
+  await expect(async () => {
+    if (attempt++ > 0) {
+      await page.reload()
+    }
+    await expect(dropdown).toBeVisible({ timeout: 5000 })
+  }).toPass({ timeout: 30000 })
+
+  await dropdown.click()
   await page.locator(util.format(tagFilterChipSelector, tag)).click()
 }
 

--- a/tests/e2e/support/utils/closeNotifications.ts
+++ b/tests/e2e/support/utils/closeNotifications.ts
@@ -3,8 +3,7 @@ import { Page } from '@playwright/test'
 // checks if there are any notifications and closes them
 export const closeNotifications = async ({ page }: { page: Page }) => {
   const closeButton = page.locator('.oc-notification-message button')
-  const count = await closeButton.count()
-  for (let i = 0; i < count; i++) {
-    await closeButton.nth(i).click()
+  while ((await closeButton.count()) > 0) {
+    await closeButton.first().click()
   }
 }


### PR DESCRIPTION
## Description

as the title says, it retires the search instead of waiting for it, oc has a debouncer and in some cases the search request is send before oc is done indexing.

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [X] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
