### PR TITLE
feat(editor): show users in active yjs session

### DIFF
--- a/dev/docs/yjs.md
+++ b/dev/docs/yjs.md
@@ -107,7 +107,10 @@ id. The prefix still exists so two editors with incompatible Y.Doc layouts (Tipt
 `Y.XmlFragment` vs CodeMirror's `Y.Text`) never share a room for the same file.
 
 Awareness is anti-spoofed: `beforeHandleAwareness` overwrites the `user` field on every inbound awareness state with the
-identity from the authenticated connection, so a client cannot present itself as someone else.
+identity from the authenticated connection, so a client cannot present itself as someone else. Yjs never echoes a
+client's own awareness back, so the `connected` hook sends each client its stamped identity over a stateless message.
+The client puts it into its own `user` awareness field, which is how it shows up in the collaborator list next to its
+peers.
 
 ## Inside `web`
 

--- a/packages/design-system/src/components/OcAvatars/OcAvatars.vue
+++ b/packages/design-system/src/components/OcAvatars/OcAvatars.vue
@@ -35,7 +35,7 @@
           :icon-size="iconSize"
         />
       </template>
-      <oc-avatar-count v-if="isOverlapping" :count="items.length - maxDisplayed" />
+      <oc-avatar-count v-if="isOverlapping" :count="items.length - maxDisplayed" :size="width" />
     </span>
     <span v-if="accessibleDescription" class="sr-only" v-text="accessibleDescription" />
   </span>

--- a/packages/web-pkg/src/components/Avatars/UserAvatar.vue
+++ b/packages/web-pkg/src/components/Avatars/UserAvatar.vue
@@ -1,5 +1,10 @@
 <template>
-  <oc-avatar :user-name="userName" :src="avatarSrc" :width="width" />
+  <oc-avatar
+    :user-name="userName"
+    :src="avatarSrc"
+    :width="width"
+    :background-color="backgroundColor"
+  />
 </template>
 
 <script setup lang="ts">
@@ -10,11 +15,13 @@ import { storeToRefs } from 'pinia'
 const {
   userId,
   userName,
-  width = 36
+  width = 36,
+  backgroundColor = undefined
 } = defineProps<{
   userId: string
   userName: string
   width?: number
+  backgroundColor?: string
 }>()
 
 const avatarsStore = useAvatarsStore()

--- a/packages/web-pkg/src/composables/yjs/index.ts
+++ b/packages/web-pkg/src/composables/yjs/index.ts
@@ -1,2 +1,3 @@
 export * from './useYjsSession'
 export * from './types'
+export * from './useYjsCollaborators'

--- a/packages/web-pkg/src/composables/yjs/useYjsCollaborators.ts
+++ b/packages/web-pkg/src/composables/yjs/useYjsCollaborators.ts
@@ -1,0 +1,103 @@
+import { onScopeDispose, shallowRef } from 'vue'
+import type { Ref } from 'vue'
+import type { Awareness } from 'y-protocols/awareness'
+
+/** The `user` awareness field. The Yjs server stamps it on every peer state. */
+export interface YjsAwarenessUser {
+  id: string
+  name: string
+  /** Hex color, shared by the remote cursor and the avatar in the toolbar. */
+  color: string
+}
+
+export interface YjsCollaborator extends YjsAwarenessUser {
+  isSelf: boolean
+}
+
+/**
+ * Prefix of the stateless message the Yjs server sends a connection with its
+ * own identity. Mirrors `IDENTITY_MESSAGE_PREFIX` in
+ * `services/yjs/src/lib/identity.ts`, keep the two in sync.
+ */
+export const IDENTITY_MESSAGE_PREFIX = '_oc_identity:'
+
+/** Fallback when a state carries no color. Same as the remote cursor default. */
+const DEFAULT_COLOR = '#ffa500'
+
+/** Parses a server identity message. Null for any other stateless payload. */
+export function decodeIdentityMessage(payload: string): YjsAwarenessUser | null {
+  if (!payload.startsWith(IDENTITY_MESSAGE_PREFIX)) return null
+  try {
+    const user: unknown = JSON.parse(payload.slice(IDENTITY_MESSAGE_PREFIX.length))
+    if (!isAwarenessUser(user)) return null
+    return normalizeUser(user)
+  } catch {
+    return null
+  }
+}
+
+function isAwarenessUser(value: unknown): value is YjsAwarenessUser {
+  if (!value || typeof value !== 'object') return false
+  const user = value as Partial<YjsAwarenessUser>
+  return typeof user.id === 'string' && user.id !== ''
+}
+
+function normalizeUser(user: YjsAwarenessUser): YjsAwarenessUser {
+  return {
+    id: user.id,
+    name: typeof user.name === 'string' ? user.name : '',
+    color: typeof user.color === 'string' ? user.color : DEFAULT_COLOR
+  }
+}
+
+/** One entry per user, so a user with several tabs open appears once. */
+function readCollaborators(awareness: Awareness): YjsCollaborator[] {
+  const byId = new Map<string, YjsCollaborator>()
+  for (const [clientId, state] of awareness.getStates() as Map<number, Record<string, unknown>>) {
+    const user = state?.user
+    if (!isAwarenessUser(user)) continue
+    const isSelf = clientId === awareness.clientID
+    const existing = byId.get(user.id)
+    if (existing) {
+      if (isSelf) existing.isSelf = true
+      continue
+    }
+    byId.set(user.id, { ...normalizeUser(user), isSelf })
+  }
+  return Array.from(byId.values()).sort((a, b) => {
+    if (a.isSelf !== b.isSelf) return a.isSelf ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+}
+
+function signatureOf(collaborators: YjsCollaborator[]): string {
+  return collaborators.map((u) => `${u.id}|${u.name}|${u.color}|${u.isSelf}`).join('\n')
+}
+
+/**
+ * The people in the room, derived from the awareness states. The own user
+ * comes first, peers follow sorted by name. Bound to the awareness passed at
+ * setup time, like the cursor extension, and detached when the scope ends.
+ */
+export function useYjsCollaborators(awareness?: Awareness | null): Ref<YjsCollaborator[]> {
+  const collaborators = shallowRef<YjsCollaborator[]>([])
+  if (!awareness) return collaborators
+
+  const aw = awareness
+  let signature = ''
+
+  function update() {
+    const next = readCollaborators(aw)
+    const nextSignature = signatureOf(next)
+    // Awareness fires on every cursor move. Only publish when the people change.
+    if (nextSignature === signature) return
+    signature = nextSignature
+    collaborators.value = next
+  }
+
+  aw.on('change', update)
+  update()
+  onScopeDispose(() => aw.off('change', update), true)
+
+  return collaborators
+}

--- a/packages/web-pkg/src/composables/yjs/useYjsSession.ts
+++ b/packages/web-pkg/src/composables/yjs/useYjsSession.ts
@@ -7,6 +7,7 @@ import type { Resource } from '@opencloud-eu/web-client'
 import { useGettext } from 'vue3-gettext'
 import { useAuthStore, useConfigStore } from '../piniaStores'
 import type { YjsAdapter } from './types'
+import { decodeIdentityMessage } from './useYjsCollaborators'
 
 export const YjsStatus = {
   Connecting: 'connecting',
@@ -854,6 +855,13 @@ export function useYjsSession(options: YjsSessionOptions): YjsSession {
         void onProviderSynced(doc, null)
       },
       onStateless({ payload }) {
+        const identity = decodeIdentityMessage(payload)
+        if (identity) {
+          // The server never echoes our own awareness back to us, so we receive
+          // it via a stateless identity message instead.
+          prov.setAwarenessField('user', identity)
+          return
+        }
         onSeedMessage(doc, prov, payload)
       },
       onSynced() {

--- a/packages/web-pkg/src/editor/components/TextEditorCollaborators.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorCollaborators.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="text-editor-toolbar-collaborators inline-flex items-center">
+    <oc-button
+      id="toolbar-collaborators-trigger"
+      v-oc-tooltip="label"
+      type="button"
+      appearance="raw"
+      gap-size="none"
+      class="text-editor-toolbar-collaborators-trigger rounded-full p-0.5"
+      :aria-label="label"
+      @mousedown.prevent
+    >
+      <oc-avatars
+        :items="avatarItems"
+        :width="24"
+        :max-displayed="3"
+        stacked
+        class="text-editor-collaborators-stack inline-flex"
+      >
+        <template #userAvatars="{ avatars }">
+          <span
+            v-for="(item, index) in avatars"
+            :key="item.userId"
+            class="text-editor-collaborator-avatar relative inline-flex rounded-full border-2"
+            :style="{ borderColor: colorById[item.userId], zIndex: avatars.length - index }"
+            :data-test-user-id="item.userId"
+          >
+            <user-avatar
+              :user-id="item.userId"
+              :user-name="item.displayName"
+              :width="20"
+              :background-color="colorById[item.userId]"
+            />
+          </span>
+        </template>
+      </oc-avatars>
+    </oc-button>
+    <oc-drop
+      drop-id="toolbar-collaborators"
+      toggle="#toolbar-collaborators-trigger"
+      :teleport="teleport"
+      mode="click"
+      position="bottom-end"
+      padding-size="small"
+      enforce-drop-on-mobile
+      class="text-editor-toolbar-collaborators-drop"
+    >
+      <oc-list class="text-editor-collaborators-list">
+        <li
+          v-for="user in users"
+          :key="user.id"
+          class="text-editor-collaborators-item flex items-center gap-2 py-1"
+          :data-test-user-id="user.id"
+        >
+          <span
+            class="inline-flex shrink-0 rounded-full border-2"
+            :style="{ borderColor: user.color }"
+          >
+            <user-avatar
+              :user-id="user.id"
+              :user-name="user.name"
+              :width="28"
+              :background-color="user.color"
+            />
+          </span>
+          <span class="truncate" v-text="user.name" />
+          <span
+            v-if="user.isSelf"
+            class="shrink-0 text-sm text-role-on-surface-variant"
+            v-text="$gettext('(you)')"
+          />
+        </li>
+      </oc-list>
+    </oc-drop>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import type { YjsCollaborator } from '../../composables/yjs'
+import UserAvatar from '../../components/Avatars/UserAvatar.vue'
+
+const { users, teleport = 'body' } = defineProps<{
+  users: YjsCollaborator[]
+  teleport?: string
+}>()
+
+const { $gettext, $ngettext } = useGettext()
+
+const avatarItems = computed(() =>
+  users.map((user) => ({ avatarType: 'user', userId: user.id, displayName: user.name }))
+)
+const colorById = computed(() => Object.fromEntries(users.map((user) => [user.id, user.color])))
+
+const label = computed(() =>
+  $ngettext(
+    '%{count} person in this editing session',
+    '%{count} people in this editing session',
+    users.length,
+    { count: users.length.toString() }
+  )
+)
+</script>

--- a/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
+++ b/packages/web-pkg/src/editor/components/TextEditorToolbar.vue
@@ -91,10 +91,16 @@
       </oc-drop>
     </div>
     <div
-      v-if="showCollaborationStatusIndicator"
-      class="text-editor-toolbar-status flex shrink-0 items-center gap-1 px-4 ml-4"
+      v-if="showCollaborationStatusIndicator || collaborators.length"
+      class="text-editor-toolbar-status flex shrink-0 items-center gap-2 px-4 ml-4"
     >
+      <text-editor-collaborators
+        v-if="collaborators.length"
+        :users="collaborators"
+        :teleport="dropTeleport"
+      />
       <div
+        v-if="showCollaborationStatusIndicator"
         v-oc-tooltip="collaborationStatusLabel"
         class="text-editor-toolbar-collaboration-status inline-flex items-center"
         :aria-label="collaborationStatusLabel"
@@ -130,6 +136,7 @@ import type { TextEditorInstance } from '../types'
 import type { EditorAction, EditorActionGroup } from '../composables'
 import { OcBubbleMenu, OcDrop } from '@opencloud-eu/design-system/components'
 import TextEditorToolbarItem from './TextEditorToolbarItem.vue'
+import TextEditorCollaborators from './TextEditorCollaborators.vue'
 import { isEditorActionEnabled } from '../helpers'
 import { Key, Modifier, useKeyboardActions } from '../../composables/keyboardActions'
 import { YjsStatus } from '../../composables/yjs'
@@ -383,6 +390,7 @@ const visible = computed(() => {
 })
 
 const yjsStatus = computed(() => unref(textEditor.yjsStatus))
+const collaborators = computed(() => unref(textEditor.collaborators) ?? [])
 
 const showCollaborationStatusIndicator = computed(() => {
   const status = unref(textEditor.yjsStatus)

--- a/packages/web-pkg/src/editor/composables/useTextEditor.ts
+++ b/packages/web-pkg/src/editor/composables/useTextEditor.ts
@@ -20,6 +20,7 @@ import { Mentions, SlashCommands } from '../extensions'
 import { stripColorFormattingFromPastedHtml } from '../helpers'
 import { useContentStrategy } from './useContentStrategy'
 import { useConfigStore } from '../../composables'
+import { useYjsCollaborators } from '../../composables/yjs'
 
 // Custom Tiptap extension that wires y-tiptap's yCursorPlugin to a given
 // Awareness. We bypass `@tiptap/extension-collaboration-cursor` because
@@ -69,6 +70,7 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
   const contentType = ref(options.contentType)
   const readonly = computed(() => toValue(options.readonly) ?? false)
   const yjsStatus = computed(() => toValue(options.yjsStatus) ?? null)
+  const collaborators = useYjsCollaborators(options.awareness)
   const strategy = resolveStrategy(options.contentType, state)
   const yjsFragment = options.ydocFragment ?? DEFAULT_YDOC_FRAGMENT
 
@@ -292,6 +294,7 @@ export function useTextEditor(options: TextEditorOptions): TextEditorInstance {
     contentType,
     readonly,
     yjsStatus,
+    collaborators,
     actionGroups: editorActionGroups,
     getContent,
     setContent,

--- a/packages/web-pkg/src/editor/types.ts
+++ b/packages/web-pkg/src/editor/types.ts
@@ -4,7 +4,7 @@ import type { Resource } from '@opencloud-eu/web-client'
 import type { Editor } from '@tiptap/vue-3'
 import type * as Y from 'yjs'
 import type { Awareness } from 'y-protocols/awareness'
-import type { YjsStatus } from '../composables/yjs'
+import type { YjsCollaborator, YjsStatus } from '../composables/yjs'
 import type { EditorActionGroup } from './composables'
 
 export type ContentType = 'plain-text' | 'markdown' | 'html' | 'tiptap-json'
@@ -90,6 +90,8 @@ export interface TextEditorInstance {
   readonly: Ref<boolean>
   /** Current transport status of the hosting Yjs session, if any. */
   yjsStatus: Ref<YjsStatus | null>
+  /** Users in the Yjs room, own user first. Empty without an awareness. */
+  collaborators: Ref<YjsCollaborator[]>
   actionGroups(): EditorActionGroup[]
   getContent(): string
   setContent(value: string): void

--- a/packages/web-pkg/tests/unit/composables/yjs/useYjsCollaborators.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/yjs/useYjsCollaborators.spec.ts
@@ -1,0 +1,138 @@
+import { defineComponent, h, unref } from 'vue'
+import { mount } from '@vue/test-utils'
+import * as Y from 'yjs'
+import { Awareness } from 'y-protocols/awareness'
+import {
+  decodeIdentityMessage,
+  useYjsCollaborators
+} from '../../../../src/composables/yjs/useYjsCollaborators'
+
+/** Two awareness instances that see each other's states, like peers in a room. */
+function createRoom() {
+  const a = new Awareness(new Y.Doc())
+  const b = new Awareness(new Y.Doc())
+  return { a, b }
+}
+
+function setRemoteUser(aw: Awareness, clientId: number, user: Record<string, unknown> | null) {
+  // Awareness has no public API to set foreign states, so mirror the
+  // internal bookkeeping and emit the same change event a network update does.
+  const meta = aw.meta.get(clientId)
+  aw.meta.set(clientId, { clock: (meta?.clock ?? 0) + 1, lastUpdated: Date.now() })
+  if (user === null) {
+    aw.states.delete(clientId)
+    aw.emit('change', [{ added: [], updated: [], removed: [clientId] }, 'test'])
+    return
+  }
+  const isNew = !aw.states.has(clientId)
+  aw.states.set(clientId, { user })
+  aw.emit('change', [
+    { added: isNew ? [clientId] : [], updated: isNew ? [] : [clientId], removed: [] },
+    'test'
+  ])
+}
+
+function mountCollaborators(awareness: Awareness | null) {
+  let collaborators: ReturnType<typeof useYjsCollaborators>
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        collaborators = useYjsCollaborators(awareness)
+        return () => h('div')
+      }
+    })
+  )
+  return { wrapper, collaborators: () => unref(collaborators!) }
+}
+
+describe('decodeIdentityMessage', () => {
+  it('parses the server identity message', () => {
+    expect(
+      decodeIdentityMessage('_oc_identity:{"id":"u1","name":"Alice","color":"#123456"}')
+    ).toEqual({ id: 'u1', name: 'Alice', color: '#123456' })
+  })
+
+  it('returns null for other payloads', () => {
+    expect(decodeIdentityMessage('_oc_seed_granted')).toBeNull()
+    expect(decodeIdentityMessage('_oc_identity:{broken')).toBeNull()
+    expect(decodeIdentityMessage('_oc_identity:{"name":"no id"}')).toBeNull()
+    expect(decodeIdentityMessage('_oc_identity:"string"')).toBeNull()
+  })
+})
+
+describe('useYjsCollaborators', () => {
+  it('is empty without an awareness', () => {
+    const { collaborators } = mountCollaborators(null)
+    expect(collaborators()).toEqual([])
+  })
+
+  it('ignores states without a stamped user', () => {
+    const { a } = createRoom()
+    a.setLocalStateField('user', {})
+    const { collaborators } = mountCollaborators(a)
+    expect(collaborators()).toEqual([])
+  })
+
+  it('lists the own user first and peers sorted by name', () => {
+    const { a } = createRoom()
+    a.setLocalStateField('user', { id: 'me', name: 'Zoe', color: '#000000' })
+    setRemoteUser(a, 200, { id: 'p2', name: 'Bob', color: '#00ff00' })
+    setRemoteUser(a, 300, { id: 'p1', name: 'Alice', color: '#ff0000' })
+    const { collaborators } = mountCollaborators(a)
+
+    expect(collaborators().map((u) => u.name)).toEqual(['Zoe', 'Alice', 'Bob'])
+    expect(collaborators()[0]).toMatchObject({ id: 'me', isSelf: true, color: '#000000' })
+    expect(collaborators()[1].isSelf).toBe(false)
+  })
+
+  it('shows a user with several clients once', () => {
+    const { a } = createRoom()
+    a.setLocalStateField('user', { id: 'me', name: 'Zoe', color: '#000000' })
+    setRemoteUser(a, 200, { id: 'me', name: 'Zoe', color: '#000000' })
+    setRemoteUser(a, 300, { id: 'p1', name: 'Alice', color: '#ff0000' })
+    const { collaborators } = mountCollaborators(a)
+
+    expect(collaborators()).toHaveLength(2)
+    expect(collaborators()[0]).toMatchObject({ id: 'me', isSelf: true })
+  })
+
+  it('updates when peers join and leave', () => {
+    const { a } = createRoom()
+    a.setLocalStateField('user', { id: 'me', name: 'Zoe', color: '#000000' })
+    const { collaborators } = mountCollaborators(a)
+    expect(collaborators()).toHaveLength(1)
+
+    setRemoteUser(a, 200, { id: 'p1', name: 'Alice', color: '#ff0000' })
+    expect(collaborators()).toHaveLength(2)
+
+    setRemoteUser(a, 200, null)
+    expect(collaborators()).toHaveLength(1)
+  })
+
+  it('falls back to a default color when the state carries none', () => {
+    const { a } = createRoom()
+    setRemoteUser(a, 200, { id: 'p1', name: 'Alice' })
+    const { collaborators } = mountCollaborators(a)
+    expect(collaborators()[0].color).toBe('#ffa500')
+  })
+
+  it('keeps the same list when only a cursor moves', () => {
+    const { a } = createRoom()
+    a.setLocalStateField('user', { id: 'me', name: 'Zoe', color: '#000000' })
+    const { collaborators } = mountCollaborators(a)
+    const before = collaborators()
+
+    a.setLocalStateField('cursor', { anchor: 1, head: 2 })
+    expect(collaborators()).toBe(before)
+  })
+
+  it('detaches from the awareness on unmount', () => {
+    const { a } = createRoom()
+    a.setLocalStateField('user', { id: 'me', name: 'Zoe', color: '#000000' })
+    const { wrapper, collaborators } = mountCollaborators(a)
+    wrapper.unmount()
+
+    setRemoteUser(a, 200, { id: 'p1', name: 'Alice', color: '#ff0000' })
+    expect(collaborators()).toHaveLength(1)
+  })
+})

--- a/packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/yjs/useYjsSession.spec.ts
@@ -506,6 +506,32 @@ describe('useYjsSession — remote mode (yjsServerUrl set)', () => {
     expect(providerInstances[0].setAwarenessField).toHaveBeenCalledWith('user', {})
   })
 
+  it('takes its own identity from the server', async () => {
+    setupSession({ yjsServerUrl: 'wss://example.test/yjs' })
+    await flushPromises()
+
+    providerInstances[0].triggerStateless(
+      '_oc_identity:{"id":"u1","name":"Alice","color":"#123456"}'
+    )
+
+    expect(providerInstances[0].setAwarenessField).toHaveBeenCalledWith('user', {
+      id: 'u1',
+      name: 'Alice',
+      color: '#123456'
+    })
+  })
+
+  it('ignores a malformed identity message', async () => {
+    setupSession({ yjsServerUrl: 'wss://example.test/yjs' })
+    await flushPromises()
+    providerInstances[0].setAwarenessField.mockClear()
+
+    providerInstances[0].triggerStateless('_oc_identity:{not json')
+    providerInstances[0].triggerStateless('_oc_identity:{"name":"no id"}')
+
+    expect(providerInstances[0].setAwarenessField).not.toHaveBeenCalled()
+  })
+
   // Regression: hydration used to be decided by an awareness election that
   // counted every peer, but a read-only client never seeds - the server
   // rejects its writes, it only hydrates a private copy. Whenever a viewer

--- a/packages/web-pkg/tests/unit/editor/components/TextEditorCollaborators.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/components/TextEditorCollaborators.spec.ts
@@ -1,0 +1,66 @@
+import { defaultPlugins, mount } from '@opencloud-eu/web-test-helpers'
+import TextEditorCollaborators from '../../../../src/editor/components/TextEditorCollaborators.vue'
+import type { YjsCollaborator } from '../../../../src/composables/yjs'
+
+const users: YjsCollaborator[] = [
+  { id: 'me', name: 'Zoe', color: '#111111', isSelf: true },
+  { id: 'p1', name: 'Alice', color: '#222222', isSelf: false },
+  { id: 'p2', name: 'Bob', color: '#333333', isSelf: false },
+  { id: 'p3', name: 'Carol', color: '#444444', isSelf: false },
+  { id: 'p4', name: 'Dan', color: '#555555', isSelf: false }
+]
+
+function getWrapper(props: Partial<{ users: YjsCollaborator[]; maxDisplayed: number }> = {}) {
+  const wrapper = mount(TextEditorCollaborators, {
+    props: { users, ...props },
+    global: {
+      plugins: [...defaultPlugins()],
+      stubs: {
+        UserAvatar: {
+          props: ['userId', 'userName', 'width', 'backgroundColor'],
+          template: '<span class="user-avatar-stub" :data-bg="backgroundColor" />'
+        },
+        OcDrop: { template: '<div class="oc-drop-stub"><slot /></div>' }
+      }
+    }
+  })
+  return { wrapper }
+}
+
+describe('TextEditorCollaborators', () => {
+  it('stacks at most three avatars and counts the rest', () => {
+    const { wrapper } = getWrapper()
+    const trigger = wrapper.find('.text-editor-toolbar-collaborators-trigger')
+    expect(trigger.findAll('.text-editor-collaborator-avatar')).toHaveLength(3)
+    expect(trigger.find('.oc-avatar-count').text()).toBe('+2')
+  })
+
+  it('shows no counter when everyone fits', () => {
+    const { wrapper } = getWrapper({ users: users.slice(0, 2) })
+    expect(wrapper.findAll('.text-editor-collaborator-avatar')).toHaveLength(2)
+    expect(wrapper.find('.oc-avatar-count').exists()).toBe(false)
+  })
+
+  it('colors the avatar border and background with the user color', () => {
+    const { wrapper } = getWrapper()
+    const avatar = wrapper.find('.text-editor-collaborator-avatar[data-test-user-id="p1"]')
+    expect(avatar.attributes('style')).toContain('border-color: #222222')
+    expect(avatar.find('.user-avatar-stub').attributes('data-bg')).toBe('#222222')
+  })
+
+  it('lists every user in the dropdown and marks the own user', () => {
+    const { wrapper } = getWrapper()
+    const items = wrapper.findAll('.text-editor-collaborators-item')
+    expect(items).toHaveLength(5)
+    expect(items[0].text()).toContain('Zoe')
+    expect(items[0].text()).toContain('(you)')
+    expect(items[1].text()).not.toContain('(you)')
+  })
+
+  it('labels the trigger with the user count', () => {
+    const { wrapper } = getWrapper()
+    expect(
+      wrapper.find('.text-editor-toolbar-collaborators-trigger').attributes('aria-label')
+    ).toBe('5 people in this editing session')
+  })
+})

--- a/packages/web-pkg/tests/unit/editor/components/TextEditorToolbar.spec.ts
+++ b/packages/web-pkg/tests/unit/editor/components/TextEditorToolbar.spec.ts
@@ -4,6 +4,7 @@ import { vi } from 'vitest'
 import TextEditorToolbar from '../../../../src/editor/components/TextEditorToolbar.vue'
 import type { TextEditorInstance } from '../../../../src/editor/types'
 import type { EditorAction } from '../../../../src/editor/composables'
+import type { YjsCollaborator } from '../../../../src/composables/yjs'
 
 vi.mock('vue3-gettext', () => ({
   useGettext: () => ({ $gettext: (value: string) => value })
@@ -13,10 +14,12 @@ function mountToolbar(
   sourceMode = false,
   contentType: 'markdown' | 'html' = 'markdown',
   includeSearchAction = false,
-  collaborationStatus: 'connecting' | 'connected' | 'disconnected' | 'local' | null = null
+  collaborationStatus: 'connecting' | 'connected' | 'disconnected' | 'local' | null = null,
+  collaborators: YjsCollaborator[] = []
 ) {
   const showSpy = vi.fn()
   const collaborationStatusRef = ref(collaborationStatus)
+  const collaboratorsRef = ref(collaborators)
 
   const actions: EditorAction[] = [
     {
@@ -48,6 +51,7 @@ function mountToolbar(
     contentType: ref<'markdown' | 'html'>(contentType),
     readonly: ref(false),
     yjsStatus: collaborationStatusRef,
+    collaborators: collaboratorsRef,
     state: { sourceMode: ref(sourceMode), editorZoom: ref(100) },
     isFocused: computed(() => isFocusedRef.value),
     actionGroups: () => [
@@ -81,12 +85,16 @@ function mountToolbar(
           inheritAttrs: false,
           template: '<button v-bind="$attrs"><slot /></button>'
         }),
-        'oc-icon': true
+        'oc-icon': true,
+        'text-editor-collaborators': defineComponent({
+          props: { users: { type: Array, required: true } },
+          template: '<div class="collaborators-stub" :data-count="users.length" />'
+        })
       }
     }
   })
 
-  return { wrapper, textEditor, isFocusedRef, showSpy, collaborationStatusRef }
+  return { wrapper, textEditor, isFocusedRef, showSpy, collaborationStatusRef, collaboratorsRef }
 }
 
 /**
@@ -301,6 +309,23 @@ describe('TextEditorToolbar', () => {
     collaborationStatusRef.value = 'local'
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.text-editor-toolbar-collaboration-status').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('hides the collaborator stack when nobody is in the room', () => {
+    const { wrapper } = mountToolbar(false, 'markdown', false, 'connected')
+    expect(wrapper.find('.collaborators-stub').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows the collaborator stack and follows peers joining', async () => {
+    const me: YjsCollaborator = { id: 'me', name: 'Zoe', color: '#111111', isSelf: true }
+    const { wrapper, collaboratorsRef } = mountToolbar(false, 'markdown', false, 'connected', [me])
+    expect(wrapper.find('.collaborators-stub').attributes('data-count')).toBe('1')
+
+    collaboratorsRef.value = [me, { id: 'p1', name: 'Alice', color: '#222222', isSelf: false }]
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.collaborators-stub').attributes('data-count')).toBe('2')
     wrapper.unmount()
   })
 })

--- a/services/yjs/README.md
+++ b/services/yjs/README.md
@@ -14,6 +14,8 @@ Every connection is authenticated and authorized against OpenCloud:
 - the bearer token is validated against `/graph/v1.0/me`
 - write access is derived from the effective permission actions on the file
 - awareness states are re-stamped with the authenticated identity, so users cannot spoof each other
+- on connect, each client receives its own stamped identity over a stateless message, because Yjs
+  never echoes a client's own awareness back to it
 
 ## Seeding an empty room
 

--- a/services/yjs/src/lib/hooks.ts
+++ b/services/yjs/src/lib/hooks.ts
@@ -1,5 +1,6 @@
 import type {
   afterUnloadDocumentPayload,
+  connectedPayload,
   Document,
   Extension,
   onDisconnectPayload,
@@ -7,6 +8,7 @@ import type {
 } from '@hocuspocus/server'
 import { deterministicColor } from './color.ts'
 import { DeniedReason, isRefusal, refuse } from './errors.ts'
+import { encodeIdentityMessage } from './identity.ts'
 import {
   MAX_DOCUMENT_NAME_LENGTH,
   probeFileAccess,
@@ -168,6 +170,18 @@ export function createHooks({ opencloudUrl, lifecycle }: HookOptions) {
     }): Promise<void> {
       const origin = requestHeaders.get('origin') ?? '-'
       console.log(`[onConnect] document=${JSON.stringify(documentName)} origin=${origin}`)
+    },
+
+    /**
+     * Hand the connection its own identity, see `identity.ts`. Runs after
+     * authentication, so the context is populated.
+     */
+    async connected({ connection, context }: connectedPayload<YjsContext>): Promise<void> {
+      const user = context?.user ?? connection.context?.user
+      if (!user) {
+        return
+      }
+      connection.sendStateless(encodeIdentityMessage(user))
     },
 
     async onDisconnect({

--- a/services/yjs/src/lib/identity.ts
+++ b/services/yjs/src/lib/identity.ts
@@ -1,0 +1,23 @@
+/**
+ * Stateless message that tells a connection who the server thinks it is.
+ * Peers get this identity stamped into every awareness update, but Yjs never
+ * echoes a client's own awareness back, so without this message a client
+ * would never learn its own name and color.
+ *
+ * The prefix has to match `IDENTITY_MESSAGE_PREFIX` in the client.
+ */
+export const IDENTITY_MESSAGE_PREFIX = '_oc_identity:'
+
+export type IdentityUser = {
+  id: string
+  displayName: string
+  color: string
+}
+
+/** Same shape as the `user` awareness field `beforeHandleAwareness` stamps. */
+export function encodeIdentityMessage(user: IdentityUser): string {
+  return (
+    IDENTITY_MESSAGE_PREFIX +
+    JSON.stringify({ id: user.id, name: user.displayName, color: user.color })
+  )
+}

--- a/services/yjs/tests/unit/lib/hooks.spec.ts
+++ b/services/yjs/tests/unit/lib/hooks.spec.ts
@@ -355,6 +355,36 @@ describe('beforeHandleAwareness', () => {
   })
 })
 
+describe('connected', () => {
+  it('sends the connection its own identity', async () => {
+    const conn = connection('a')
+    const user = { id: 'u1', displayName: 'Alice', color: '#123456' }
+
+    await getHooks().connected({ connection: conn, context: { readOnly: false, user } } as any)
+
+    expect(conn.sendStateless).toHaveBeenCalledWith(
+      '_oc_identity:{"id":"u1","name":"Alice","color":"#123456"}'
+    )
+  })
+
+  it('falls back to the connection context', async () => {
+    const user = { id: 'u1', displayName: 'Alice', color: '#123456' }
+    const conn = { ...connection('a'), context: { readOnly: false, user } }
+
+    await getHooks().connected({ connection: conn, context: undefined } as any)
+
+    expect(conn.sendStateless).toHaveBeenCalledOnce()
+  })
+
+  it('sends nothing when no user is known', async () => {
+    const conn = connection('a')
+
+    await getHooks().connected({ connection: conn, context: {} } as any)
+
+    expect(conn.sendStateless).not.toHaveBeenCalled()
+  })
+})
+
 describe('logging hooks', () => {
   it('logs the origin on connect', async () => {
     await getHooks().onConnect({


### PR DESCRIPTION
Show all the users of a yjs room in the editor toolbar on the right.

For this to work, the yjs server now reports back the awareness (user id, name, color) of the current user back to it via a stateless message. Without this, a user would never get its own awareness from the server.

Known limitations for now: the users list is not visible for read-only peers and editors not in the room (e.g. public link).

closes https://github.com/opencloud-eu/web/issues/3110

<img width="1115" height="140" alt="image" src="https://github.com/user-attachments/assets/7f2bef0f-ab83-4ef3-9a65-bc54d1b8cab8" />
